### PR TITLE
docs: add README with installation, tools, and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ deeper inspection is needed.
 ### From source (Rust toolchain required)
 
 ```bash
-cargo install git-prism
+cargo install --path .
 ```
+
+Once published to crates.io, `cargo install git-prism` will also work.
 
 ### Binary download
 
 Grab a prebuilt binary from the
 [GitHub Releases](https://github.com/mikelane/git-prism/releases) page.
 
-### Homebrew (coming soon)
+### Homebrew
 
-```bash
-brew tap mikelane/tap && brew install git-prism
-```
+Not yet available. A Homebrew tap is planned for a future release.
 
 ## MCP Registration
 
@@ -204,7 +204,8 @@ git-prism snapshot HEAD~3..HEAD --paths src/main.rs src/lib.rs
 git-prism languages
 ```
 
-All CLI commands output JSON to stdout.
+The `manifest` and `snapshot` commands output JSON to stdout. The `languages`
+command outputs plain text.
 
 ## Agent Workflow
 


### PR DESCRIPTION
## Summary

263-line README covering:
- Installation (cargo install, binary download, Homebrew placeholder)
- MCP registration (`claude mcp add git-prism -- git-prism serve`)
- Both tools with parameter tables and realistic JSON examples
- CLI usage (`manifest`, `snapshot`, `languages`)
- Agent workflow (two-call triage pattern)
- Supported languages table
- Contributing and license

## BDD acceptance criteria

All scenarios from `bdd/features/readme.feature` (@ISSUE-17) will pass:
- README.md exists
- Contains "install", "get_change_manifest", "get_file_snapshots", "claude mcp add"

## Test plan

- [x] `cargo test` — 140 tests pass (no Rust changes)
- [x] Lefthook pre-push — all checks pass

Closes #17

---
Generated with [Claude Code](https://claude.ai/claude-code)