### PR TITLE
fix: polish error messages for common failure modes

### DIFF
--- a/src/git/reader.rs
+++ b/src/git/reader.rs
@@ -9,7 +9,7 @@ pub enum GitError {
     OpenRepo(String),
 
     #[error("Could not find ref '{0}'. Check that the branch, tag, or SHA exists.")]
-    ResolveRef(String, String),
+    ResolveRef(String),
 
     #[error("failed to read object: {0}")]
     ReadObject(String),
@@ -28,6 +28,8 @@ pub struct RepoReader {
 
 impl RepoReader {
     pub fn open(path: &std::path::Path) -> Result<Self, GitError> {
+        // Raw gix error omitted from user-facing message — it contains internal
+        // paths and format that aren't actionable for the caller.
         let repo = gix::open(path).map_err(|_| GitError::OpenRepo(path.display().to_string()))?;
         Ok(Self { repo })
     }
@@ -76,7 +78,8 @@ impl RepoReader {
         let rev = self
             .repo
             .rev_parse_single(refspec)
-            .map_err(|e| GitError::ResolveRef(refspec.to_string(), e.to_string()))?;
+            // Raw gix error omitted — see OpenRepo for rationale.
+            .map_err(|_| GitError::ResolveRef(refspec.to_string()))?;
 
         let object = rev
             .object()
@@ -147,6 +150,8 @@ mod tests {
         assert!(reader.is_err());
     }
 
+    // Each OpenRepo error test creates its own TempDir — intentionally not extracted
+    // because the setup is a one-liner and each test asserts a distinct facet.
     #[test]
     fn open_repo_error_message_says_not_a_git_repository() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Improved error messages for the two most common failure modes:

- **Not a git repo:** "Not a git repository at '/path'. Run git-prism from inside a git repo, or use --repo to specify one."
- **Invalid ref:** "Could not find ref 'xyz'. Check that the branch, tag, or SHA exists."

Previously both showed raw gix error text that was hard to act on.

## Changes

- `GitError::OpenRepo` — single field (path only), actionable message with --repo suggestion
- `GitError::ResolveRef` — user-friendly "Could not find ref" message
- 7 new tests validating error message content (paths, ref names, suggestions)

## Test plan

- [x] `cargo test` — 147 tests pass (140 existing + 7 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Lefthook pre-push — all checks pass

Closes #18

---
Generated with [Claude Code](https://claude.ai/claude-code)