### PR TITLE
chore: configure Homebrew tap for cargo-dist releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,14 +278,61 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          repository: "mikelane/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   announce:
     needs:
       - plan
       - host
+      - publish-homebrew-formula
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Once published to crates.io, `cargo install git-prism` will also work.
 Grab a prebuilt binary from the
 [GitHub Releases](https://github.com/mikelane/git-prism/releases) page.
 
-### Homebrew
+### Homebrew (macOS and Linux)
 
-Not yet available. A Homebrew tap is planned for a future release.
+```bash
+brew tap mikelane/tap
+brew install git-prism
+```
 
 ## MCP Registration
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,3 +17,7 @@ install-path = "CARGO_HOME"
 hosting = "github"
 # Whether to install an updater program
 install-updater = false
+# A GitHub repo to push Homebrew formulas to
+tap = "mikelane/homebrew-tap"
+# Publish Homebrew formula to the tap on release
+publish-jobs = ["homebrew"]


### PR DESCRIPTION
## Summary

- **dist-workspace.toml**: Added Homebrew installer config targeting mikelane/homebrew-tap
- **.github/workflows/release.yml**: Regenerated via `dist generate-ci` to include `publish-homebrew-formula` job
- **README.md**: Updated Homebrew section with actual install commands

## How it works

On `v*` tag push, cargo-dist builds binaries for all platforms, then the `publish-homebrew-formula` job pushes a formula to `mikelane/homebrew-tap`. Users install with:
```bash
brew tap mikelane/tap
brew install git-prism
```

## Manual step required

A `HOMEBREW_TAP_TOKEN` secret must be created in the git-prism repo settings — a fine-grained PAT with `contents: write` on `mikelane/homebrew-tap`. Without this, the publish job will fail on the first release.

## Test plan

- [x] `cargo test` — 147 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `dist generate-ci` regenerated the release workflow with Homebrew job
- [x] `mikelane/homebrew-tap` repo exists and is public

Closes #16

---
Generated with [Claude Code](https://claude.ai/claude-code)