### PR TITLE
chore: gitignore Claude Code worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .worktrees/
+.claude/worktrees/
 .DS_Store
 CLAUDE.local.md
 mutants.out*


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore`

## Context

Claude Code's Agent tool creates temporary git worktrees under `.claude/worktrees/` when running isolated sub-tasks (e.g., parallel implementation of epic child issues). These directories are transient build artifacts that should never be committed.

The existing `.worktrees/` entry covers the project's own worktree convention but not the `.claude/`-prefixed path that Claude Code uses.

Discovered while kicking off parallel worktree agents for the observability epic (#43) — issues #46, #49, and #50 are being developed concurrently in isolated worktrees, and the parent directories were showing up as untracked files.

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y