### PR TITLE
feat: metrics instrumentation in MCP handlers (#47)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod git;
+pub(crate) mod metrics;
 #[allow(dead_code)]
 pub(crate) mod privacy;
 mod server;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,276 @@
+use std::sync::OnceLock;
+
+use opentelemetry::metrics::{Counter, Histogram};
+use opentelemetry::{KeyValue, global};
+
+/// Histogram bucket boundaries for duration measurements (milliseconds).
+const DURATION_BUCKETS: &[f64] = &[
+    1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0,
+];
+
+/// Histogram bucket boundaries for token/byte size measurements.
+const SIZE_BUCKETS: &[f64] = &[
+    100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0, 500000.0, 1000000.0,
+];
+
+/// All OpenTelemetry instruments for git-prism metrics.
+///
+/// Created lazily via [`get()`] from the global meter provider installed by
+/// `telemetry::init()`. When no OTLP endpoint is configured, the global
+/// meter is a no-op, so all recording calls are effectively free.
+pub struct Metrics {
+    // Usage counters
+    sessions_started: Counter<u64>,
+    requests_total: Counter<u64>,
+    ref_pattern: Counter<u64>,
+    change_scope_seen: Counter<u64>,
+    languages_analyzed: Counter<u64>,
+    errors_total: Counter<u64>,
+    response_truncated: Counter<u64>,
+
+    // Performance histograms
+    tool_duration_ms: Histogram<f64>,
+
+    // Token-efficiency histograms
+    response_tokens_estimated: Histogram<f64>,
+    response_bytes: Histogram<f64>,
+    manifest_files_returned: Histogram<f64>,
+    manifest_functions_changed: Histogram<f64>,
+}
+
+impl Metrics {
+    /// Create all instruments from the global meter provider.
+    pub fn new() -> Self {
+        let meter = global::meter("git-prism");
+
+        let sessions_started = meter
+            .u64_counter("git_prism.sessions.started")
+            .with_description("Number of MCP server sessions started")
+            .build();
+
+        let requests_total = meter
+            .u64_counter("git_prism.requests.total")
+            .with_description("Total tool requests")
+            .build();
+
+        let ref_pattern = meter
+            .u64_counter("git_prism.manifest.ref_pattern")
+            .with_description("Ref pattern classification counts")
+            .build();
+
+        let change_scope_seen = meter
+            .u64_counter("git_prism.change_scope.seen")
+            .with_description("Change scope counts per file")
+            .build();
+
+        let languages_analyzed = meter
+            .u64_counter("git_prism.languages.analyzed")
+            .with_description("Languages seen in manifest files")
+            .build();
+
+        let errors_total = meter
+            .u64_counter("git_prism.errors.total")
+            .with_description("Error counts by tool and kind")
+            .build();
+
+        let response_truncated = meter
+            .u64_counter("git_prism.response.truncated")
+            .with_description("Truncation events")
+            .build();
+
+        let tool_duration_ms = meter
+            .f64_histogram("git_prism.tool.duration_ms")
+            .with_description("Tool invocation duration in milliseconds")
+            .with_boundaries(DURATION_BUCKETS.to_vec())
+            .build();
+
+        let response_tokens_estimated = meter
+            .f64_histogram("git_prism.response.tokens_estimated")
+            .with_description("Estimated token count of response (bytes / 4)")
+            .with_boundaries(SIZE_BUCKETS.to_vec())
+            .build();
+
+        let response_bytes = meter
+            .f64_histogram("git_prism.response.bytes")
+            .with_description("Response JSON byte size")
+            .with_boundaries(SIZE_BUCKETS.to_vec())
+            .build();
+
+        let manifest_files_returned = meter
+            .f64_histogram("git_prism.manifest.files_returned")
+            .with_description("Number of files in manifest response")
+            .with_boundaries(SIZE_BUCKETS.to_vec())
+            .build();
+
+        let manifest_functions_changed = meter
+            .f64_histogram("git_prism.manifest.functions_changed")
+            .with_description("Per-file function change count")
+            .with_boundaries(SIZE_BUCKETS.to_vec())
+            .build();
+
+        Self {
+            sessions_started,
+            requests_total,
+            ref_pattern,
+            change_scope_seen,
+            languages_analyzed,
+            errors_total,
+            response_truncated,
+            tool_duration_ms,
+            response_tokens_estimated,
+            response_bytes,
+            manifest_files_returned,
+            manifest_functions_changed,
+        }
+    }
+
+    // --- Recording helpers ---
+
+    pub fn record_session_started(&self) {
+        self.sessions_started.add(1, &[]);
+    }
+
+    pub fn record_request(&self, tool: &str, status: &str) {
+        self.requests_total.add(
+            1,
+            &[
+                KeyValue::new("tool", tool.to_string()),
+                KeyValue::new("status", status.to_string()),
+            ],
+        );
+    }
+
+    pub fn record_duration(&self, tool: &str, duration_ms: f64) {
+        self.tool_duration_ms
+            .record(duration_ms, &[KeyValue::new("tool", tool.to_string())]);
+    }
+
+    pub fn record_error(&self, tool: &str, error_kind: &str) {
+        self.errors_total.add(
+            1,
+            &[
+                KeyValue::new("tool", tool.to_string()),
+                KeyValue::new("error_kind", error_kind.to_string()),
+            ],
+        );
+    }
+
+    pub fn record_ref_pattern(&self, pattern: &str) {
+        self.ref_pattern
+            .add(1, &[KeyValue::new("pattern", pattern.to_string())]);
+    }
+
+    pub fn record_change_scope(&self, scope: &str) {
+        self.change_scope_seen
+            .add(1, &[KeyValue::new("scope", scope.to_string())]);
+    }
+
+    pub fn record_language(&self, language: &str) {
+        self.languages_analyzed
+            .add(1, &[KeyValue::new("language", language.to_string())]);
+    }
+
+    pub fn record_response_bytes(&self, tool: &str, bytes: f64) {
+        self.response_bytes
+            .record(bytes, &[KeyValue::new("tool", tool.to_string())]);
+    }
+
+    pub fn record_tokens_estimated(&self, tool: &str, tokens: f64) {
+        self.response_tokens_estimated
+            .record(tokens, &[KeyValue::new("tool", tool.to_string())]);
+    }
+
+    pub fn record_files_returned(&self, count: f64) {
+        self.manifest_files_returned.record(count, &[]);
+    }
+
+    pub fn record_functions_changed(&self, language: &str, count: f64) {
+        self.manifest_functions_changed
+            .record(count, &[KeyValue::new("language", language.to_string())]);
+    }
+
+    pub fn record_truncated(&self, tool: &str, reason: &str) {
+        self.response_truncated.add(
+            1,
+            &[
+                KeyValue::new("tool", tool.to_string()),
+                KeyValue::new("reason", reason.to_string()),
+            ],
+        );
+    }
+}
+
+/// Global singleton accessor for the [`Metrics`] instance.
+///
+/// The instruments are created from the global meter provider, which is either
+/// a real OTLP exporter or a no-op depending on whether `telemetry::init()`
+/// found a configured endpoint.
+pub fn get() -> &'static Metrics {
+    static INSTANCE: OnceLock<Metrics> = OnceLock::new();
+    INSTANCE.get_or_init(Metrics::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_new_does_not_panic() {
+        // With no OTLP endpoint, the global meter is a no-op — but instruments
+        // must still be created without error.
+        let metrics = Metrics::new();
+        // Smoke-test that recording does not panic.
+        metrics.record_session_started();
+        metrics.record_request("test_tool", "success");
+        metrics.record_duration("test_tool", 42.0);
+        metrics.record_error("test_tool", "unknown");
+        metrics.record_ref_pattern("branch");
+        metrics.record_change_scope("committed");
+        metrics.record_language("rust");
+        metrics.record_response_bytes("test_tool", 1024.0);
+        metrics.record_tokens_estimated("test_tool", 256.0);
+        metrics.record_files_returned(5.0);
+        metrics.record_functions_changed("rust", 3.0);
+        metrics.record_truncated("test_tool", "max_files");
+    }
+
+    #[test]
+    fn get_returns_same_instance() {
+        let a = get() as *const Metrics;
+        let b = get() as *const Metrics;
+        assert_eq!(a, b, "get() should return the same singleton");
+    }
+
+    #[test]
+    fn record_request_with_different_statuses() {
+        let metrics = Metrics::new();
+        // Both success and error status should work without panic.
+        metrics.record_request("get_change_manifest", "success");
+        metrics.record_request("get_change_manifest", "error");
+        metrics.record_request("get_commit_history", "success");
+        metrics.record_request("get_file_snapshots", "error");
+    }
+
+    #[test]
+    fn record_all_change_scopes() {
+        let metrics = Metrics::new();
+        metrics.record_change_scope("committed");
+        metrics.record_change_scope("staged");
+        metrics.record_change_scope("unstaged");
+    }
+
+    #[test]
+    fn record_all_error_kinds() {
+        let metrics = Metrics::new();
+        for kind in &[
+            "ref_not_found",
+            "repo_not_found",
+            "diff_failed",
+            "parse_failed",
+            "io_error",
+            "unknown",
+        ] {
+            metrics.record_error("test_tool", kind);
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,11 +4,21 @@ use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router};
 
+use crate::git::diff::ChangeScope;
 use crate::tools::{
     HistoryArgs, HistoryResponse, ManifestArgs, ManifestOptions, ManifestResponse, SnapshotArgs,
     SnapshotOptions, SnapshotResponse, build_history, build_manifest, build_snapshots,
     build_worktree_manifest,
 };
+
+/// Convert a `ChangeScope` variant to a static metric label string.
+fn change_scope_label(scope: ChangeScope) -> &'static str {
+    match scope {
+        ChangeScope::Committed => "committed",
+        ChangeScope::Staged => "staged",
+        ChangeScope::Unstaged => "unstaged",
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct GitPrismServer {
@@ -42,7 +52,14 @@ impl GitPrismServer {
         &self,
         Parameters(args): Parameters<ManifestArgs>,
     ) -> Result<Json<ManifestResponse>, String> {
-        tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let tool_name = "get_change_manifest";
+
+        // Extract ref info before moving args into spawn_blocking.
+        let base_ref_clone = args.base_ref.clone();
+        let head_ref_clone = args.head_ref.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
             let repo_path = match args.repo_path {
                 Some(p) => PathBuf::from(p),
                 None => std::env::current_dir()
@@ -60,7 +77,53 @@ impl GitPrismServer {
             manifest.map(Json).map_err(|e| e.to_string())
         })
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+
+        let metrics = crate::metrics::get();
+        let duration_ms = start.elapsed().as_millis() as f64;
+        metrics.record_duration(tool_name, duration_ms);
+
+        match &result {
+            Ok(Json(response)) => {
+                metrics.record_request(tool_name, "success");
+
+                // Response size metrics
+                let json_bytes = serde_json::to_vec(response).map(|v| v.len()).unwrap_or(0);
+                metrics.record_response_bytes(tool_name, json_bytes as f64);
+                metrics.record_tokens_estimated(tool_name, (json_bytes / 4) as f64);
+
+                // Manifest-specific metrics
+                metrics.record_files_returned(response.files.len() as f64);
+
+                for file in &response.files {
+                    if file.language != "unknown" {
+                        metrics.record_language(&file.language);
+                    }
+                    metrics.record_change_scope(change_scope_label(file.change_scope));
+                    if let Some(fns) = &file.functions_changed {
+                        metrics.record_functions_changed(&file.language, fns.len() as f64);
+                    }
+                }
+
+                if response.truncated {
+                    metrics.record_truncated(tool_name, "max_files");
+                }
+
+                // Ref pattern classification
+                let pattern = if head_ref_clone.is_none() {
+                    crate::privacy::RefPattern::Worktree
+                } else {
+                    crate::privacy::normalize_ref_pattern(&base_ref_clone)
+                };
+                metrics.record_ref_pattern(pattern.as_str());
+            }
+            Err(e) => {
+                metrics.record_request(tool_name, "error");
+                metrics.record_error(tool_name, crate::privacy::classify_error_kind(e));
+            }
+        }
+
+        result
     }
 
     /// Returns one manifest per commit in a range, so agents can see
@@ -73,7 +136,10 @@ impl GitPrismServer {
         &self,
         Parameters(args): Parameters<HistoryArgs>,
     ) -> Result<Json<HistoryResponse>, String> {
-        tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let tool_name = "get_commit_history";
+
+        let result = tokio::task::spawn_blocking(move || {
             let repo_path = match args.repo_path {
                 Some(p) => PathBuf::from(p),
                 None => std::env::current_dir()
@@ -89,7 +155,27 @@ impl GitPrismServer {
                 .map_err(|e| e.to_string())
         })
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+
+        let metrics = crate::metrics::get();
+        let duration_ms = start.elapsed().as_millis() as f64;
+        metrics.record_duration(tool_name, duration_ms);
+
+        match &result {
+            Ok(Json(response)) => {
+                metrics.record_request(tool_name, "success");
+
+                let json_bytes = serde_json::to_vec(response).map(|v| v.len()).unwrap_or(0);
+                metrics.record_response_bytes(tool_name, json_bytes as f64);
+                metrics.record_tokens_estimated(tool_name, (json_bytes / 4) as f64);
+            }
+            Err(e) => {
+                metrics.record_request(tool_name, "error");
+                metrics.record_error(tool_name, crate::privacy::classify_error_kind(e));
+            }
+        }
+
+        result
     }
 
     /// Returns complete before/after file content at two git refs for
@@ -102,7 +188,10 @@ impl GitPrismServer {
         &self,
         Parameters(args): Parameters<SnapshotArgs>,
     ) -> Result<Json<SnapshotResponse>, String> {
-        tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let tool_name = "get_file_snapshots";
+
+        let result = tokio::task::spawn_blocking(move || {
             let repo_path = match args.repo_path {
                 Some(p) => PathBuf::from(p),
                 None => std::env::current_dir()
@@ -120,7 +209,36 @@ impl GitPrismServer {
                 .map_err(|e| e.to_string())
         })
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+
+        let metrics = crate::metrics::get();
+        let duration_ms = start.elapsed().as_millis() as f64;
+        metrics.record_duration(tool_name, duration_ms);
+
+        match &result {
+            Ok(Json(response)) => {
+                metrics.record_request(tool_name, "success");
+
+                let json_bytes = serde_json::to_vec(response).map(|v| v.len()).unwrap_or(0);
+                metrics.record_response_bytes(tool_name, json_bytes as f64);
+                metrics.record_tokens_estimated(tool_name, (json_bytes / 4) as f64);
+
+                // Check for per-file truncation in snapshots
+                for file in &response.files {
+                    let truncated = file.before.as_ref().is_some_and(|c| c.truncated)
+                        || file.after.as_ref().is_some_and(|c| c.truncated);
+                    if truncated {
+                        metrics.record_truncated(tool_name, "max_file_size");
+                    }
+                }
+            }
+            Err(e) => {
+                metrics.record_request(tool_name, "error");
+                metrics.record_error(tool_name, crate::privacy::classify_error_kind(e));
+            }
+        }
+
+        result
     }
 }
 
@@ -129,6 +247,7 @@ impl ServerHandler for GitPrismServer {}
 
 pub async fn run_server() -> anyhow::Result<()> {
     let _telemetry = crate::telemetry::init();
+    crate::metrics::get().record_session_started();
     let server = GitPrismServer::new();
     let transport = tokio::io::join(tokio::io::stdin(), tokio::io::stdout());
     server.serve(transport).await?.waiting().await?;


### PR DESCRIPTION
## Summary

- New `src/metrics.rs` — all 14 OTel instruments as a lazy singleton (`OnceLock`)
- Instrumented all 3 MCP tool handlers in `src/server.rs` with metric recording
- `sessions.started` counter fires at server startup

## Details

Part of the observability epic (#43). Records all 14 metrics defined in the design spec at the correct call sites. Uses the global meter provider installed by `telemetry::init()` — when no OTLP endpoint is configured, all instruments are no-ops with zero overhead.

### Instruments created

**Usage counters (5):** `sessions.started`, `requests.total` (tool+status), `manifest.ref_pattern` (pattern), `change_scope.seen` (scope), `languages.analyzed` (language)

**Performance (2):** `tool.duration_ms` (tool), `errors.total` (tool+error_kind)

**Token-efficiency (5):** `response.tokens_estimated` (tool), `response.bytes` (tool), `manifest.files_returned`, `manifest.functions_changed` (language), `response.truncated` (tool+reason)

Note: `gix.operation_ms` and `treesitter.parse_ms` histograms are deferred to #48 (trace instrumentation) where per-operation timing is more naturally captured via spans.

### Handler instrumentation

Each tool handler now:
1. Records `Instant::now()` before `spawn_blocking`
2. After completion, records duration, request count (success/error), response bytes/tokens
3. On success: per-file language, change_scope, functions_changed metrics; truncation events; ref pattern classification
4. On error: error_kind classification via `privacy::classify_error_kind()`

### Histogram buckets
- Duration: `[1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000]` ms
- Size/tokens: `[100, 500, 1K, 5K, 10K, 50K, 100K, 500K, 1M]`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] 5 metrics unit tests pass (instrument creation, singleton identity, all label variants)
- [x] Existing tests unaffected

Closes #47

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y