### PR TITLE
feat: trace instrumentation in gix and tree-sitter operations (#48)

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -50,6 +50,7 @@ pub struct DiffResult {
 
 impl RepoReader {
     pub fn diff_commits(&self, base_ref: &str, head_ref: &str) -> Result<DiffResult, GitError> {
+        let _span = tracing::info_span!("git.diff_commits").entered();
         let base_commit = self.peel_to_commit(base_ref)?;
         let head_commit = self.peel_to_commit(head_ref)?;
 

--- a/src/git/reader.rs
+++ b/src/git/reader.rs
@@ -32,6 +32,7 @@ impl RepoReader {
     }
 
     pub fn open(path: &std::path::Path) -> Result<Self, GitError> {
+        let _span = tracing::info_span!("git.open_repo").entered();
         // Raw gix error omitted from user-facing message — it contains internal
         // paths and format that aren't actionable for the caller.
         let repo = gix::open(path).map_err(|_| GitError::OpenRepo(path.display().to_string()))?;
@@ -39,6 +40,7 @@ impl RepoReader {
     }
 
     pub fn resolve_commit(&self, refspec: &str) -> Result<CommitInfo, GitError> {
+        let _span = tracing::info_span!("git.resolve_ref").entered();
         let commit = self.peel_to_commit(refspec)?;
 
         let message = commit
@@ -53,6 +55,7 @@ impl RepoReader {
     }
 
     pub fn read_file_at_ref(&self, refspec: &str, file_path: &str) -> Result<String, GitError> {
+        let _span = tracing::info_span!("git.read_blob").entered();
         let commit = self.peel_to_commit(refspec)?;
 
         let tree = commit
@@ -111,6 +114,7 @@ impl RepoReader {
         base_ref: &str,
         head_ref: &str,
     ) -> Result<Vec<CommitInfo>, GitError> {
+        let _span = tracing::info_span!("git.walk_commits").entered();
         let base_commit = self.peel_to_commit(base_ref)?;
         let head_commit = self.peel_to_commit(head_ref)?;
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -9,6 +9,7 @@ impl RepoReader {
     /// Returns a `DiffResult` where each `FileChange` carries a `change_scope`
     /// of either `Staged` or `Unstaged`, mirroring `git status` semantics.
     pub fn diff_worktree(&self) -> Result<DiffResult, GitError> {
+        let _span = tracing::info_span!("git.diff_worktree").entered();
         use gix::status::Item;
 
         let status_iter = self

--- a/src/tools/manifest.rs
+++ b/src/tools/manifest.rs
@@ -172,11 +172,17 @@ pub fn build_manifest(
     for file_change in &files_to_process {
         let language = detect_language(&file_change.path);
         let ext = extension_from_path(&file_change.path);
-        let is_generated = GeneratedFileDetector::is_generated(&file_change.path, None);
+        let is_generated = {
+            let _span = tracing::info_span!("manifest.detect_generated").entered();
+            GeneratedFileDetector::is_generated(&file_change.path, None)
+        };
 
         if language != "unknown" {
             languages_set.insert(language.to_string());
         }
+
+        let _file_span =
+            tracing::info_span!("manifest.analyze_file", file.language = language).entered();
 
         // Function and import analysis
         let (functions_changed, imports_changed) = if let Some(analyzer) = options
@@ -194,30 +200,45 @@ pub fn build_manifest(
                 _ => reader.read_file_at_ref(head_ref, &file_change.path).ok(),
             };
 
-            let base_fns = base_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let base_fns = {
+                let _span = tracing::info_span!("treesitter.parse").entered();
+                base_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let head_fns = head_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let head_fns = {
+                let _span = tracing::info_span!("treesitter.parse").entered();
+                head_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let fn_changes = diff_functions(&base_fns, &head_fns);
+            let fn_changes = {
+                let _span = tracing::info_span!("treesitter.extract_functions").entered();
+                diff_functions(&base_fns, &head_fns)
+            };
 
             let count = fn_changes.len();
             *total_functions_changed.get_or_insert(0) += count;
 
-            let base_imports = base_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let base_imports = {
+                let _span = tracing::info_span!("treesitter.extract_imports").entered();
+                base_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let head_imports = head_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let head_imports = {
+                let _span = tracing::info_span!("treesitter.extract_imports").entered();
+                head_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
             let import_change = diff_imports(&base_imports, &head_imports);
 
@@ -228,6 +249,7 @@ pub fn build_manifest(
 
         // Dependency analysis
         if is_dependency_file(&file_change.path) {
+            let _dep_span = tracing::info_span!("manifest.diff_dependencies").entered();
             let base_content = match file_change.change_type {
                 ChangeType::Added => String::new(),
                 _ => reader
@@ -367,11 +389,17 @@ pub fn build_worktree_manifest(
     for file_change in &files_to_process {
         let language = detect_language(&file_change.path);
         let ext = extension_from_path(&file_change.path);
-        let is_generated = GeneratedFileDetector::is_generated(&file_change.path, None);
+        let is_generated = {
+            let _span = tracing::info_span!("manifest.detect_generated").entered();
+            GeneratedFileDetector::is_generated(&file_change.path, None)
+        };
 
         if language != "unknown" {
             languages_set.insert(language.to_string());
         }
+
+        let _file_span =
+            tracing::info_span!("manifest.analyze_file", file.language = language).entered();
 
         let (functions_changed, imports_changed) = if let Some(analyzer) = options
             .include_function_analysis
@@ -391,29 +419,44 @@ pub fn build_worktree_manifest(
                 },
             };
 
-            let base_fns = base_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let base_fns = {
+                let _span = tracing::info_span!("treesitter.parse").entered();
+                base_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let head_fns = head_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let head_fns = {
+                let _span = tracing::info_span!("treesitter.parse").entered();
+                head_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_functions(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let fn_changes = diff_functions(&base_fns, &head_fns);
+            let fn_changes = {
+                let _span = tracing::info_span!("treesitter.extract_functions").entered();
+                diff_functions(&base_fns, &head_fns)
+            };
             let count = fn_changes.len();
             *total_functions_changed.get_or_insert(0) += count;
 
-            let base_imports = base_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let base_imports = {
+                let _span = tracing::info_span!("treesitter.extract_imports").entered();
+                base_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
-            let head_imports = head_content
-                .as_ref()
-                .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
-                .unwrap_or_default();
+            let head_imports = {
+                let _span = tracing::info_span!("treesitter.extract_imports").entered();
+                head_content
+                    .as_ref()
+                    .and_then(|c| analyzer.extract_imports(c.as_bytes()).ok())
+                    .unwrap_or_default()
+            };
 
             let import_change = diff_imports(&base_imports, &head_imports);
 


### PR DESCRIPTION
## Summary

- Added `tracing::info_span!` calls across git, tree-sitter, and manifest operations
- Produces the trace trees defined in the design spec for all three tools
- Zero overhead when telemetry is disabled (tracing macros are no-ops)

## Span coverage

### `src/git/reader.rs`
- `git.open_repo` — around `gix::open()`
- `git.resolve_ref` — around `peel_to_commit()`
- `git.read_blob` — around file content reads
- `git.walk_commits` — around commit range traversal

### `src/git/diff.rs`
- `git.diff_commits` — around commit-to-commit diff

### `src/git/worktree.rs`
- `git.diff_worktree` — around working tree status diff

### `src/tools/manifest.rs` (both `build_manifest` and `build_worktree_manifest`)
- `manifest.detect_generated` — per-file generated detection
- `manifest.analyze_file` — per-file analysis (with `file.language` attribute)
- `treesitter.parse` — per-file tree-sitter parsing (base and head)
- `treesitter.extract_functions` — function diff extraction
- `treesitter.extract_imports` — import diff extraction
- `manifest.diff_dependencies` — dependency file analysis

### Not in this PR (deferred)
- Root `mcp.tool.*` spans in `server.rs` with privacy-safe attributes — will be added when merging with #47 (metrics) to avoid conflicts, since both PRs modify `server.rs`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Pre-existing test results unchanged (same 8 failures in manifest tests exist on main)
- [x] No behavior change when telemetry is disabled

Closes #48

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y