### PR TITLE
chore: .cargo/mutants.toml config + baseline ADR (#52)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,31 @@
+# cargo-mutants configuration for git-prism
+# See: https://mutants.rs/config.html
+
+# Only examine production source code, not test helpers or build scripts.
+examine_globs = ["src/**/*.rs"]
+
+# Exclude files that are genuinely untestable in isolation:
+#
+# - main.rs: Entry point shim — main() and CLI dispatch cannot be
+#   mutation-tested without end-to-end process invocation. parse_range()
+#   and validate_commit_range() have direct unit tests already.
+#
+# - server.rs: MCP server lifecycle and tool handler wiring — requires
+#   a running rmcp transport and async runtime. The business logic it
+#   calls (build_manifest, build_snapshots, build_history) is tested
+#   directly. Metrics/span recording is observability plumbing.
+#
+# - telemetry.rs: OTel provider initialization — tested via BDD scenarios
+#   with a mock OTLP collector. Mutating init() or Drop requires an OTLP
+#   endpoint to detect, which unit tests can't provide.
+#
+# - metrics.rs: OTel instrument creation and recording helpers — all
+#   methods delegate to the global meter provider. When no endpoint is
+#   configured (test default), every call is a no-op, so mutants in
+#   recording logic are undetectable without a live exporter.
+exclude_globs = [
+    "src/main.rs",
+    "src/server.rs",
+    "src/telemetry.rs",
+    "src/metrics.rs",
+]

--- a/docs/decisions/0002-mutation-testing-baseline.md
+++ b/docs/decisions/0002-mutation-testing-baseline.md
@@ -1,0 +1,67 @@
+# ADR 0002: Mutation Testing Baseline
+
+- **Status**: Accepted
+- **Date**: 2026-04-06
+- **Epic**: #44 (Mutation testing with 90% gate)
+
+## Context
+
+We want to quantify how effectively git-prism's test suite catches regressions, not just whether tests pass. [cargo-mutants](https://mutants.rs/) systematically modifies production code and checks whether the test suite detects each change. A high mutation score means the tests actually verify behavior, not just exercise code paths.
+
+## Decision
+
+Adopt cargo-mutants with a 90% mutation score gate on non-excluded code.
+
+### Configuration
+
+Config lives at `.cargo/mutants.toml`.
+
+**Scope**: `src/**/*.rs` (production code only).
+
+**Excluded files** (48 mutants, ~9% of total):
+
+| File | Mutants | Reason |
+|------|---------|--------|
+| `src/main.rs` | 3 | CLI entry point — requires process-level E2E testing |
+| `src/server.rs` | 25 | MCP transport wiring + observability plumbing — business logic tested via `tools/` |
+| `src/telemetry.rs` | 5 | OTel initialization — tested via BDD with mock OTLP collector |
+| `src/metrics.rs` | 15 | OTel instrument helpers — no-op without live exporter |
+
+**In scope**: 460 mutants across git operations, tree-sitter analyzers, tool logic, dependency parsing, privacy helpers, and type utilities.
+
+### Baseline Score
+
+**To be filled after first CI run.**
+
+| Metric | Value |
+|--------|-------|
+| Total mutants generated | 460 |
+| Mutants killed (caught) | TBD |
+| Mutants survived (missed) | TBD |
+| Timeouts | TBD |
+| Unviable | TBD |
+| **Mutation score** | **TBD%** |
+
+### Top Unkilled-Mutant Categories (TBD)
+
+Will be populated after the first full run. Expected high-survivor areas based on code analysis:
+
+1. **Tree-sitter analyzers** (~193 mutants) — string matching on AST node types; tests use known snippets but may not cover all edge mutations
+2. **Dependency file parsing** (72 mutants) — TOML/JSON parsing with many branch points
+3. **Privacy helpers** (25 mutants) — simple heuristic functions with edge cases
+
+### Plan to Reach 90%
+
+1. Run baseline in CI (#54)
+2. Categorize surviving mutants into:
+   - **Real gaps** — write tests to kill them
+   - **Genuinely untestable** — add `#[mutants::skip]` with a justifying comment
+   - **Low-value cosmetic** — exclude in config with justification
+3. Iterate until score ≥ 90% (#53)
+
+## Consequences
+
+- Every PR must maintain ≥90% mutation score on changed files (incremental mode)
+- Full suite runs on main merges and weekly
+- `#[mutants::skip]` annotations require a comment explaining why
+- Developers should run `cargo mutants --in-diff HEAD~1` locally before pushing


### PR DESCRIPTION
## Summary

- New `.cargo/mutants.toml` — cargo-mutants config with documented exclusions
- New `docs/decisions/0002-mutation-testing-baseline.md` — ADR recording the baseline setup and plan

## Details

First issue in the mutation testing epic (#44). Sets up cargo-mutants configuration and documents the approach.

### Config
- **In scope**: 460 mutants across `src/git/`, `src/treesitter/`, `src/tools/`, `src/privacy.rs`
- **Excluded** (48 mutants): `main.rs` (CLI shim), `server.rs` (MCP wiring), `telemetry.rs` (OTel init), `metrics.rs` (no-op instruments)
- Each exclusion documented with rationale

### ADR
- Documents the 90% target, exclusion rationale, and plan to reach the target
- Baseline scores marked TBD — will be filled after first CI run (#54)
- Identifies expected high-survivor areas (tree-sitter analyzers, dep parsing, privacy helpers)

### Note on issue #52
This PR delivers the config and ADR structure but leaves baseline scores as TBD since `cargo mutants` requires a clean test suite (the sandbox has git signing failures that prevent running it locally). Issue #52 should remain open until the CI workflow (#54) produces the actual baseline numbers and the ADR is updated.

Part of #52

## Test plan

- [x] `cargo mutants --list` correctly shows 460 mutants (exclusions applied)
- [x] `cargo clippy -- -D warnings` passes
- [x] No code changes — config and docs only

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y