### PR TITLE
ci: mutation testing workflow with incremental PR checks (#54)

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_MUTANTS_VERSION: "27.0.0"
 
 jobs:
   # On PRs: incremental mode — only mutants in changed files.
@@ -43,19 +44,26 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin/cargo-mutants
             target
-          key: ${{ runner.os }}-mutants-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-mutants-${{ env.CARGO_MUTANTS_VERSION }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mutants-
+            ${{ runner.os }}-mutants-${{ env.CARGO_MUTANTS_VERSION }}-
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: |
+          if ! cargo mutants --version 2>/dev/null | grep -q "$CARGO_MUTANTS_VERSION"; then
+            cargo install "cargo-mutants@$CARGO_MUTANTS_VERSION"
+          fi
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}"
 
       - name: Generate diff against base
-        run: git diff origin/${{ github.base_ref }}...HEAD > pr.diff
+        run: git diff "origin/${{ github.base_ref }}"...HEAD > pr.diff
 
       - name: Run cargo-mutants on changed files
-        run: cargo mutants --timeout 300 --in-diff pr.diff
+        run: cargo mutants --timeout 300 --jobs 4 --in-diff pr.diff
 
       - name: Upload mutants output
         if: always()
@@ -82,44 +90,58 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin/cargo-mutants
             target
-          key: ${{ runner.os }}-mutants-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-mutants-${{ env.CARGO_MUTANTS_VERSION }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mutants-
+            ${{ runner.os }}-mutants-${{ env.CARGO_MUTANTS_VERSION }}-
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: |
+          if ! cargo mutants --version 2>/dev/null | grep -q "$CARGO_MUTANTS_VERSION"; then
+            cargo install "cargo-mutants@$CARGO_MUTANTS_VERSION"
+          fi
 
       - name: Run full mutation testing
-        run: cargo mutants --timeout 300
+        run: cargo mutants --timeout 300 --jobs 4
 
       - name: Generate summary
         if: always()
         run: |
           if [ -f mutants.out/outcomes.json ]; then
             python3 - <<'SCRIPT'
-          import json, os
+          import json, os, textwrap
 
           with open("mutants.out/outcomes.json") as f:
-              outcomes = json.load(f)
+              data = json.load(f)
 
-          killed = sum(1 for o in outcomes if o.get("outcome") in ("CaughtMutant", "Timeout"))
-          survived = sum(1 for o in outcomes if o.get("outcome") == "MissedMutant")
-          unviable = sum(1 for o in outcomes if o.get("outcome") == "Unviable")
+          outcomes = data.get("outcomes", data) if isinstance(data, dict) else data
+
+          killed = sum(1 for o in outcomes if o.get("summary") in ("CaughtMutant", "Timeout"))
+          survived = sum(1 for o in outcomes if o.get("summary") == "MissedMutant")
+          unviable = sum(1 for o in outcomes if o.get("summary") == "Unviable")
           total_testable = killed + survived
-          score = (killed / total_testable * 100) if total_testable > 0 else 0
 
-          summary = f"""## Mutation Testing Results
+          if total_testable > 0:
+              score = killed / total_testable * 100
+              score_str = f"{score:.1f}%"
+              verdict = "✅ Score meets 90% threshold." if score >= 90 else "⚠️ Score below 90% threshold — see surviving mutants in the artifact."
+          else:
+              score_str = "N/A (no testable mutants)"
+              verdict = "ℹ️ No testable mutants were generated."
+
+          summary = textwrap.dedent(f"""\
+          ## Mutation Testing Results
 
           | Metric | Value |
           |--------|-------|
           | Mutants killed | {killed} |
           | Mutants survived | {survived} |
           | Unviable | {unviable} |
-          | **Mutation score** | **{score:.1f}%** |
+          | **Mutation score** | **{score_str}** |
 
-          {"✅ Score meets 90% threshold." if score >= 90 else "⚠️ Score below 90% threshold — see surviving mutants in the artifact."}
-          """
+          {verdict}
+          """)
 
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
               f.write(summary)


### PR DESCRIPTION
## Summary

New `.github/workflows/mutants.yml` — mutation testing CI workflow for the mutation testing epic (#44).

## How it works

### On pull requests (incremental)
- Runs `cargo mutants --in-diff` on only the files changed in the PR
- Fast feedback — typically <10 minutes
- Fails if any surviving mutant in the diff scope is not in the skip list
- Only triggers when `src/**/*.rs`, `Cargo.toml`, `Cargo.lock`, or `.cargo/mutants.toml` change

### On main push (full suite)
- Runs all in-scope mutants (~460)
- Posts mutation score to GitHub Actions step summary
- Results uploaded as artifacts for analysis
- Does not block the merge (informational)

### Weekly scheduled run
- Sunday 03:00 UTC — catches drift from accumulated small changes
- Same as full suite

### Timeouts
- Per-mutant: 300s (5 min)
- Incremental job: 30 min
- Full suite job: 120 min

## Test plan

- [x] Workflow YAML is valid (linted)
- [x] Incremental mode uses `--in-diff` with correct base ref
- [x] Full mode generates step summary with score calculation
- [x] Artifacts uploaded on success and failure
- [x] Path filters prevent unnecessary runs on docs-only changes

## Acceptance criteria from #54

- [x] PR workflow runs on pull_request with `--in-diff`
- [x] Full-suite workflow runs on main merges
- [x] Mutation score surfaced in GitHub Actions step summary
- [ ] PR workflow runs in <10 minutes (to be verified after first run)
- [ ] A PR with a surviving mutant fails CI (to be verified with #53)

Closes #54

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y