### PR TITLE
ci: add workflow_dispatch and self-trigger for mutants workflow

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,6 +1,7 @@
 name: Mutation Testing
 
 on:
+  workflow_dispatch: {}
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +16,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".cargo/mutants.toml"
+      - ".github/workflows/mutants.yml"
   schedule:
     # Weekly full run: Sunday at 03:00 UTC
     - cron: "0 3 * * 0"


### PR DESCRIPTION
## Summary

Two-line fix to the mutation testing workflow:

1. Add `workflow_dispatch: {}` trigger so the full suite can be run manually from the Actions tab
2. Add `.github/workflows/mutants.yml` to the push `paths` filter so changes to the workflow itself trigger a run

The workflow never ran after merging #66 because it wasn't in its own paths filter.

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y