### PR TITLE
fix: use cargo-nextest binary name for version check in CI

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -57,8 +57,8 @@ jobs:
           if ! cargo mutants --version 2>/dev/null | grep -q "$CARGO_MUTANTS_VERSION"; then
             cargo install "cargo-mutants@$CARGO_MUTANTS_VERSION"
           fi
-          if ! cargo nextest --version 2>/dev/null; then
-            cargo install cargo-nextest
+          if ! cargo-nextest --version 2>/dev/null; then
+            cargo install --locked cargo-nextest
           fi
 
       - name: Fetch base branch
@@ -111,8 +111,8 @@ jobs:
           if ! cargo mutants --version 2>/dev/null | grep -q "$CARGO_MUTANTS_VERSION"; then
             cargo install "cargo-mutants@$CARGO_MUTANTS_VERSION"
           fi
-          if ! cargo nextest --version 2>/dev/null; then
-            cargo install cargo-nextest
+          if ! cargo-nextest --version 2>/dev/null; then
+            cargo install --locked cargo-nextest
           fi
 
       - name: Run mutation testing (shard ${{ matrix.shard }})


### PR DESCRIPTION
One-line fix: `cargo nextest --version` → `cargo-nextest --version` in the install step. The subcommand form fails in CI.

https://claude.ai/code/session_01GKARZCb9vETFgboS1rAv1y