### PR TITLE
ci+hooks+test+docs: project integrity safeguards from retrospective (#202)

### DIFF
--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -1,0 +1,157 @@
+name: Integrity
+
+# Enforces release hygiene and drift checks that catch mismatches between
+# Cargo.toml / git tags / CHANGELOG / README / workflow files. Introduced
+# as part of issue #202 after an April 2026 retrospective found six classes
+# of silent drift that had shipped multiple releases undetected.
+#
+# Security: any input sourced from PR metadata (title, body, etc.) is passed
+# via env vars rather than ${{ }} expansion directly in run blocks. See
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integrity:
+    name: Integrity checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Cargo.toml version matches a git tag
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "✓ v$VERSION tag exists"
+          else
+            if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && echo "${PR_TITLE:-}" | grep -qi '^chore.*release'; then
+              echo "⚠ v$VERSION has no tag (release PR in flight — OK)"
+            else
+              echo "✗ Cargo.toml version $VERSION has no matching git tag"
+              exit 1
+            fi
+          fi
+
+      - name: README MCP tool count matches src/server.rs
+        run: |
+          set -euo pipefail
+          README_COUNT=$(grep -oE '[0-9]+ MCP tools?' README.md | head -1 | grep -oE '[0-9]+' || echo 0)
+          # The README uses words like "Four MCP tools" — fall back to word-to-digit mapping.
+          if [ "$README_COUNT" = "0" ]; then
+            README_WORD=$(grep -oE '(One|Two|Three|Four|Five|Six|Seven|Eight|Nine|Ten) MCP tools?' README.md | head -1 | awk '{print $1}' || true)
+            case "$README_WORD" in
+              One) README_COUNT=1 ;;
+              Two) README_COUNT=2 ;;
+              Three) README_COUNT=3 ;;
+              Four) README_COUNT=4 ;;
+              Five) README_COUNT=5 ;;
+              Six) README_COUNT=6 ;;
+              Seven) README_COUNT=7 ;;
+              Eight) README_COUNT=8 ;;
+              Nine) README_COUNT=9 ;;
+              Ten) README_COUNT=10 ;;
+              *) README_COUNT=0 ;;
+            esac
+          fi
+          CODE_COUNT=$(grep -c '#\[tool(' src/server.rs || echo 0)
+          if [ "$README_COUNT" = "$CODE_COUNT" ]; then
+            echo "✓ README claims $README_COUNT MCP tools, src/server.rs has $CODE_COUNT"
+          else
+            echo "✗ README claims $README_COUNT MCP tools but src/server.rs has $CODE_COUNT"
+            exit 1
+          fi
+
+      - name: No '|| true' in workflow files
+        run: |
+          set -euo pipefail
+          HITS=$(grep -rn '|| true' .github/workflows/ | grep -v 'integrity.yml:' || true)
+          if [ -z "$HITS" ]; then
+            echo "✓ no || true masking in workflow files"
+          else
+            echo "✗ || true found in workflow files (silently masks errors):"
+            echo "$HITS"
+            exit 1
+          fi
+
+      - name: cargo clippy invocations include --all-targets
+        run: |
+          set -euo pipefail
+          FILES_TO_CHECK=".github/workflows/ci.yml lefthook.yml CLAUDE.md"
+          BAD=""
+          for f in $FILES_TO_CHECK; do
+            BAD_LINES=$(grep -n 'cargo clippy' "$f" | grep -v -- '--all-targets' || true)
+            if [ -n "$BAD_LINES" ]; then
+              BAD="$BAD\n$f:\n$BAD_LINES"
+            fi
+          done
+          if [ -z "$BAD" ]; then
+            echo "✓ all cargo clippy invocations use --all-targets"
+          else
+            printf "✗ cargo clippy without --all-targets:%s\n" "$BAD"
+            exit 1
+          fi
+
+      - name: '@not_implemented scenarios for closed issues'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]; then
+            echo "⚠ not a PR event, skipping @not_implemented audit"
+            exit 0
+          fi
+          PR_NUM="${GITHUB_EVENT_PATH:+$(jq -r '.pull_request.number // empty' < "$GITHUB_EVENT_PATH")}"
+          if [ -z "$PR_NUM" ]; then
+            echo "⚠ no PR number, skipping"
+            exit 0
+          fi
+          BODY=$(gh pr view "$PR_NUM" --json body --jq .body)
+          ISSUES=$(echo "$BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' || true)
+          if [ -z "$ISSUES" ]; then
+            echo "⚠ no Closes/Fixes/Resolves references, skipping"
+            exit 0
+          fi
+          BAD=""
+          for ISSUE in $ISSUES; do
+            HITS=$(grep -rn "@ISSUE-$ISSUE" bdd/features/ 2>/dev/null | grep '@not_implemented' || true)
+            if [ -n "$HITS" ]; then
+              BAD="$BAD\n$HITS"
+            fi
+          done
+          if [ -z "$BAD" ]; then
+            echo "✓ no @not_implemented scenarios for closed issues"
+          else
+            printf "✗ PR closes issues but their scenarios are still @not_implemented:%s\n" "$BAD"
+            exit 1
+          fi
+
+      - name: CHANGELOG sections have matching git tags
+        run: |
+          set -euo pipefail
+          git fetch --tags 2>/dev/null || true
+          MISSING=""
+          while IFS= read -r VER; do
+            if [ "$VER" = "Unreleased" ]; then continue; fi
+            if ! git rev-parse "v$VER" >/dev/null 2>&1; then
+              MISSING="$MISSING $VER"
+            fi
+          done < <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | sed 's/^## \[\(.*\)\]$/\1/')
+          if [ -z "$MISSING" ]; then
+            echo "✓ all CHANGELOG versions have matching tags"
+          else
+            echo "✗ CHANGELOG sections without matching git tags:$MISSING"
+            exit 1
+          fi

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -31,13 +31,17 @@ jobs:
           fetch-tags: true
 
       - name: Cargo.toml version matches a git tag
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "✓ v$VERSION tag exists"
           else
-            if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && echo "${PR_TITLE:-}" | grep -qi '^chore.*release'; then
+            # Narrow allowlist: `chore: release vX.Y.Z` or `chore(release): X.Y.Z`
+            # with an actual version number after `release`. Prevents "chore: release the hounds"
+            # from bypassing the check.
+            if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && echo "${PR_TITLE:-}" | grep -qiE '^chore(\([^)]*\))?:[[:space:]]+release[[:space:]]+v?[0-9]+\.[0-9]+\.[0-9]+'; then
               echo "⚠ v$VERSION has no tag (release PR in flight — OK)"
             else
               echo "✗ Cargo.toml version $VERSION has no matching git tag"
@@ -46,6 +50,7 @@ jobs:
           fi
 
       - name: README MCP tool count matches src/server.rs
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           README_COUNT=$(grep -oE '[0-9]+ MCP tools?' README.md | head -1 | grep -oE '[0-9]+' || echo 0)
@@ -74,27 +79,32 @@ jobs:
             exit 1
           fi
 
-      - name: No '|| true' in workflow files
+      - name: Workflow files do not mask errors
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          HITS=$(grep -rn '|| true' .github/workflows/ | grep -v 'integrity.yml:' || true)
-          if [ -z "$HITS" ]; then
-            echo "✓ no || true masking in workflow files"
-          else
-            echo "✗ || true found in workflow files (silently masks errors):"
-            echo "$HITS"
+          # Comment-aware: the pattern matches only lines whose prefix contains no '#',
+          # so YAML and shell comments (including backticked references in explanatory
+          # text) do not trip the check. integrity.yml is excluded to avoid self-matching
+          # on its own pattern literal — this file is hand-audited.
+          if grep -rnE '^[^#]*\|\| true' .github/workflows/ --exclude=integrity.yml; then
+            echo ""
+            echo "forbidden masking pattern found in workflow files"
+            echo "Use 'continue-on-error: true' on the step, or an explicit 'if !' check."
             exit 1
           fi
+          echo "no masking pattern in workflow files"
 
       - name: cargo clippy invocations include --all-targets
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           FILES_TO_CHECK=".github/workflows/ci.yml lefthook.yml CLAUDE.md"
           BAD=""
           for f in $FILES_TO_CHECK; do
-            BAD_LINES=$(grep -n 'cargo clippy' "$f" | grep -v -- '--all-targets' || true)
-            if [ -n "$BAD_LINES" ]; then
-              BAD="$BAD\n$f:\n$BAD_LINES"
+            # `if` context suppresses pipefail so no-match exits do not abort the script.
+            if BAD_LINES=$(grep -n 'cargo clippy' "$f" | grep -v -- '--all-targets'); then
+              BAD+=$'\n'"${f}:"$'\n'"${BAD_LINES}"
             fi
           done
           if [ -z "$BAD" ]; then
@@ -105,6 +115,7 @@ jobs:
           fi
 
       - name: '@not_implemented scenarios for closed issues'
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -119,16 +130,19 @@ jobs:
             exit 0
           fi
           BODY=$(gh pr view "$PR_NUM" --json body --jq .body)
-          ISSUES=$(echo "$BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' || true)
+          # Case-insensitive, handles `Closes/closes/close/closed`, `Fix/fixes/fixed`, `Resolves/resolved`.
+          ISSUES=""
+          if MATCHES=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+'); then
+            ISSUES=$(echo "$MATCHES" | grep -oE '[0-9]+')
+          fi
           if [ -z "$ISSUES" ]; then
             echo "⚠ no Closes/Fixes/Resolves references, skipping"
             exit 0
           fi
           BAD=""
           for ISSUE in $ISSUES; do
-            HITS=$(grep -rn "@ISSUE-$ISSUE" bdd/features/ 2>/dev/null | grep '@not_implemented' || true)
-            if [ -n "$HITS" ]; then
-              BAD="$BAD\n$HITS"
+            if HITS=$(grep -rn "@ISSUE-$ISSUE" bdd/features/ 2>/dev/null | grep '@not_implemented'); then
+              BAD+=$'\n'"${HITS}"
             fi
           done
           if [ -z "$BAD" ]; then
@@ -139,16 +153,18 @@ jobs:
           fi
 
       - name: CHANGELOG sections have matching git tags
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           git fetch --tags 2>/dev/null || true
           MISSING=""
+          # Pattern allows pre-release and build suffixes: `0.7.0`, `0.7.0-rc.1`, `0.7.0+build.5`.
           while IFS= read -r VER; do
             if [ "$VER" = "Unreleased" ]; then continue; fi
             if ! git rev-parse "v$VER" >/dev/null 2>&1; then
               MISSING="$MISSING $VER"
             fi
-          done < <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | sed 's/^## \[\(.*\)\]$/\1/')
+          done < <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+[^]]*\]' CHANGELOG.md | sed 's/^## \[\(.*\)\]$/\1/')
           if [ -z "$MISSING" ]; then
             echo "✓ all CHANGELOG versions have matching tags"
           else

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -68,7 +68,14 @@ jobs:
         run: git diff "origin/${{ github.base_ref }}"...HEAD > pr.diff
 
       - name: Run cargo-mutants on changed files
-        run: cargo mutants --timeout 300 --jobs 4 --copy-target true --test-tool nextest --in-diff pr.diff || true
+        # Incremental mutation testing is informational on PRs: a failing mutant should
+        # surface in the "Report mutation score" step, not block the PR. We use
+        # continue-on-error rather than `|| true` so the failure is visible in the GitHub
+        # UI (yellow warning icon) rather than silently masked. The integrity workflow
+        # bans `|| true` in workflow files because of incidents where it hid real bugs
+        # for multiple releases.
+        continue-on-error: true
+        run: cargo mutants --timeout 300 --jobs 4 --copy-target true --test-tool nextest --in-diff pr.diff
 
       - name: Report mutation score
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,13 @@ jobs:
             export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
             brew update
             # We avoid reformatting user-provided data such as the app description and homepage.
-            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+            # brew style failures here are advisory (the generated formula may have style nits
+            # that don't affect functionality). We surface them as GitHub annotations rather
+            # than masking with `|| true` — the integrity workflow bans `|| true` in workflow
+            # files because silent masking hid the mutation-testing shard bug for months.
+            if ! brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}"; then
+              echo "::warning::brew style returned non-zero for Formula/${filename} (advisory, not blocking)"
+            fi
 
             git add "Formula/${filename}"
             git commit -m "${name} ${version}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,19 @@ gh api repos/OWNER/REPO/issues/XX/dependencies/blocked_by \
 
 Don't trust memory or issue titles. Check the API.
 
+## Release Hygiene
+
+Release integrity — tag, GH Release, crates.io publish, homebrew tap — is enforced by `.github/workflows/integrity.yml` and by the global `releasing-to-production` skill. See `~/.claude/skills/releasing-to-production/SKILL.md` for the full release checklist.
+
+Non-negotiable rules:
+
+- **Release PRs are incomplete until the tag is pushed and the release workflow succeeds.** Bumping `Cargo.toml` without tagging leaves main in a broken state. The `integrity.yml` workflow's `cargo-tag-sync` check will fail on any main commit where `Cargo.toml` version has no matching git tag.
+- **`|| true` is banned in workflow files.** It masks errors silently and caused the mutation-testing shard bug (A5 finding from 2026-04-10 gauntlet). The `integrity.yml` workflow greps for this pattern and fails the build.
+- **Clippy always uses `--all-targets`.** Any `cargo clippy` command in `ci.yml`, `lefthook.yml`, `CLAUDE.md`, or ad-hoc session commands must include `--all-targets`. The `integrity.yml` workflow enforces this.
+- **CHANGELOG sections must match git tags.** Every `## [X.Y.Z]` heading must have a corresponding tag (except `## [Unreleased]`). Enforced by `integrity.yml`.
+- **MCP tool drift is a test failure, not a doc failure.** `src/server.rs::tests::it_matches_expected_tools` is the single source of truth for which tools are registered. If you add, remove, or rename a tool, update the `EXPECTED_TOOLS` constant AND update README/CHANGELOG/CLAUDE.md — or the test will fail.
+- **Commit messages must reference real PR/issue numbers.** Phantom `(#N)` references are rejected by the lefthook `commit-msg` hook (`scripts/validate-pr-refs.sh`). This prevents the PR #125 squash-merge situation where commits referenced PRs #114-#123 that never existed.
+
 ## Git Hooks (lefthook)
 
 A pre-push hook runs `fmt --check`, `clippy`, and `test` before every push. Managed by [lefthook](https://github.com/evilmartians/lefthook) via `lefthook.yml`. After cloning:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,3 +21,8 @@ install-updater = false
 tap = "mikelane/homebrew-tap"
 # Publish Homebrew formula to the tap on release
 publish-jobs = ["homebrew"]
+# Manual edits to .github/workflows/release.yml are intentional (the integrity
+# workflow bans `|| true` masking patterns, so the brew style invocation was
+# rewritten to use an `if !` conditional with a GitHub warning annotation).
+# Tells cargo-dist not to flag these edits as "out of date" in the plan step.
+allow-dirty = ["ci"]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,3 +7,8 @@ pre-push:
       run: cargo clippy --all-targets -- -D warnings
     test:
       run: env -u GIT_DIR -u GIT_WORK_TREE cargo test
+
+commit-msg:
+  commands:
+    validate-pr-refs:
+      run: scripts/validate-pr-refs.sh {1}

--- a/scripts/validate-pr-refs.sh
+++ b/scripts/validate-pr-refs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Reject commit messages that reference (#N) where N does not resolve to a real PR or issue.
+#
+# History: PR #125 was squash-merged with commit messages referencing PRs
+# #114-#123 that never existed, creating a phantom audit trail. This hook
+# was introduced as part of issue #202 to make that class of phantom
+# impossible to commit.
+set -euo pipefail
+
+COMMIT_MSG_FILE="${1:-}"
+if [ -z "$COMMIT_MSG_FILE" ] || [ ! -f "$COMMIT_MSG_FILE" ]; then
+  echo "usage: $0 <commit-msg-file>" >&2
+  exit 2
+fi
+
+# Extract all (#N) references from the commit message.
+REFS=$(grep -oE '\(#[0-9]+\)' "$COMMIT_MSG_FILE" | grep -oE '[0-9]+' | sort -u || true)
+if [ -z "$REFS" ]; then
+  exit 0
+fi
+
+FAILED=""
+for N in $REFS; do
+  # A real PR or issue must exist. Try PR first, then issue.
+  # NB: use `--json state` rather than `--json number` — gh returns the
+  # echoed number for any numeric input without actually resolving it,
+  # so checking a server-side field like `state` forces real validation.
+  if gh pr view "$N" --json state --jq .state >/dev/null 2>&1; then
+    continue
+  fi
+  if gh issue view "$N" --json state --jq .state >/dev/null 2>&1; then
+    continue
+  fi
+  FAILED="$FAILED #$N"
+done
+
+if [ -n "$FAILED" ]; then
+  echo "error: commit message references PR/issue numbers that do not exist:$FAILED" >&2
+  echo "" >&2
+  echo "This check exists because PR #125 was once merged with commit messages" >&2
+  echo "referencing PRs #114-#123 that never existed, creating a phantom audit trail." >&2
+  echo "" >&2
+  echo "If you meant to use placeholder numbers, use a different format (e.g. TBD-114)." >&2
+  exit 1
+fi
+
+exit 0

--- a/src/server.rs
+++ b/src/server.rs
@@ -591,6 +591,25 @@ pub async fn run_server() -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
+    /// The canonical list of MCP tools exposed by this server.
+    ///
+    /// This constant is a compile-time contract. If you add, remove, or rename
+    /// a tool, you MUST update this constant and the corresponding docs
+    /// (README.md "N MCP tools" claim, CHANGELOG entry, CLAUDE.md tool list).
+    /// The `it_matches_expected_tools` test enforces that the list here is
+    /// identical to the tools actually registered via the `#[tool]` macro.
+    ///
+    /// History: git-prism shipped multiple releases with `get_function_context`
+    /// claimed as a new MCP tool in CHANGELOG/README/CLAUDE.md while the tool
+    /// itself was never registered in src/server.rs. This constant was
+    /// introduced as part of issue #202 to make that class of drift impossible.
+    const EXPECTED_TOOLS: &[&str] = &[
+        "get_change_manifest",
+        "get_commit_history",
+        "get_file_snapshots",
+        "get_function_context",
+    ];
+
     #[test]
     fn it_registers_get_change_manifest_tool() {
         let router = GitPrismServer::tool_router();
@@ -702,6 +721,25 @@ mod tests {
             "expected exactly four MCP tools, found {}: {:?}",
             tools.len(),
             names
+        );
+    }
+
+    #[test]
+    fn it_matches_expected_tools() {
+        let router = GitPrismServer::tool_router();
+        let mut actual: Vec<String> = router
+            .list_all()
+            .iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        actual.sort();
+        let mut expected: Vec<String> = EXPECTED_TOOLS.iter().map(|s| s.to_string()).collect();
+        expected.sort();
+        assert_eq!(
+            actual, expected,
+            "MCP tool set drifted from EXPECTED_TOOLS. \
+             If you added, removed, or renamed a tool, update the EXPECTED_TOOLS constant \
+             in src/server.rs AND update README.md 'N MCP tools' count, CHANGELOG, and CLAUDE.md."
         );
     }
 }


### PR DESCRIPTION
## Summary

Implements the integrity safeguards identified in the post-remediation retrospective. Four components landing atomically as one PR: a CI integrity workflow, a commit-msg hook validating `(#N)` references, an `EXPECTED_TOOLS` test enforcing MCP tool drift detection, and a new `Release Hygiene` section in `CLAUDE.md`.

These safeguards would have prevented (or at least caught) every major incident from the April 2026 remediation session:

- **PR #125 mis-labeled squash merge** with fictional PR refs `#114-#123` → Component B's commit-msg hook rejects phantom `(#N)` references at commit time.
- **v0.5.0 / v0.6.0 never tagged but Cargo.toml bumped** → Component A's Check 1 fails any main commit where `Cargo.toml` version has no matching git tag.
- **`get_function_context` claimed as MCP tool for multiple releases without registration** → Component C's `EXPECTED_TOOLS` test makes the MCP tool set a compile-time contract.
- **Mutation shard `|| true` masked a broken shard for multiple releases** → Component A's Check 3 greps workflow files for `|| true` and fails.
- **Pre-existing clippy `--all-targets` failure hidden by CI config** → Component A's Check 4 enforces `--all-targets` in all clippy invocations.
- **9 telemetry BDD scenarios permanently tagged `@not_implemented` in closed issues' PRs** → Component A's Check 5 audits `@not_implemented @ISSUE-N` against `Closes #N` in PR body.
- **CHANGELOG drift where `## [0.6.0]` existed with no tag** → Component A's Check 6 validates every CHANGELOG heading has a matching tag.

See issue #202 for the full retrospective.

## Component breakdown

| Component | Commit | Files |
|---|---|---|
| A — CI integrity workflow | `91ff274` | `.github/workflows/integrity.yml` (new, 158 lines, 6 independent check steps) |
| B — commit-msg phantom-ref validator | `3efeb81` | `scripts/validate-pr-refs.sh` (new, executable), `lefthook.yml` (new `commit-msg` section) |
| C — `EXPECTED_TOOLS` compile-time contract | `6275dd1` | `src/server.rs` (new constant + test) |
| D — CLAUDE.md Release Hygiene section | `f3869bb` | `CLAUDE.md` (new section just before `## Git Hooks`) |

## TDD audit trail

**Component B** — agent tested the script with three cases: `(#999999)` rejected, `(#145)` accepted (real merged PR), `(#202)` accepted (real issue). During testing the agent caught a real bug: `gh pr view N --json number` echoes the input number regardless of whether the PR exists. Fixed to use `--json state` which forces gh to resolve against the API.

**Component C** — strict RED → GREEN → TRIANGULATE → GREEN:
- RED: test added before the constant → compile error `cannot find value EXPECTED_TOOLS in this scope`
- GREEN: constant added → test passes
- TRIANGULATE: remove `"get_function_context"` from constant → test fails with clear drift message referencing README/CHANGELOG/CLAUDE.md
- GREEN: restored → passing

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 572 passed, 0 failed (was 502 before; +70 from the various Tier 1-5 work merged this week)
- [x] lefthook pre-push (clippy + fmt + test) passed on every push
- [x] lefthook commit-msg `validate-pr-refs` hook validated every commit message on this branch
- [x] Component A's Check 4 corner case verified: the new Release Hygiene section in CLAUDE.md mentions `cargo clippy` in prose, but the same line also has `--all-targets`, so the grep filter correctly doesn't flag it

## Security note

Component A uses `env:` to pass `PR_TITLE` into the integrity workflow rather than `${{ }}` interpolation inside `run:` blocks — this avoids the common GitHub Actions workflow injection attack vector.

## Corner cases documented

- **Check 5** (`@not_implemented` audit) will print "no Closes/Fixes/Resolves references, skipping" if this PR body doesn't reference `#202`. The PR body above includes `Closes #202` so it will fire and validate that `bdd/features/` has no `@not_implemented @ISSUE-202` (there are no BDD scenarios for this PR, so it passes).
- **Check 1** (Cargo.toml tag sync) currently passes because `Cargo.toml` version `0.6.0` matches the `v0.6.0` tag that we pushed yesterday.

Closes #202

🤖 Generated with [Claude Code](https://claude.ai/claude-code)