### PR TITLE
security: recursion depth guards for python/ts/rust/cpp/c analyzers

### DIFF
--- a/src/treesitter/c_lang.rs
+++ b/src/treesitter/c_lang.rs
@@ -371,22 +371,22 @@ void guarded(int x) {
     /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
     /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
     #[test]
-    fn deeply_nested_preproc_blocks_do_not_stack_overflow() {
-        const NESTING_DEPTH: usize = 5000;
-        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+    fn it_completes_without_overflow_on_deeply_nested_preproc_blocks() {
+        const GENERATED_NESTING_LEVELS: usize = 5000;
+        const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             source.push_str(&format!("#ifdef MACRO_{i}\n"));
         }
         // Function is past the cap — it should not be extracted.
         source.push_str("void deep_fn(void) {}\n");
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("#endif\n");
         }
 
         let handle = std::thread::Builder::new()
-            .stack_size(TEST_STACK_SIZE)
+            .stack_size(CONSTRAINED_THREAD_STACK_BYTES)
             .spawn(move || {
                 let analyzer = CAnalyzer;
                 analyzer.extract_functions(source.as_bytes())
@@ -404,15 +404,15 @@ void guarded(int x) {
     /// Triangulation: 255 nested `#ifdef` blocks with a function at the innermost level.
     /// The guard fires at depth 256, so depth 255 must still allow extraction.
     #[test]
-    fn nested_preproc_blocks_at_boundary_depth_still_extract_functions() {
-        const NESTING_DEPTH: usize = 255;
+    fn it_extracts_functions_at_boundary_nesting_depth() {
+        const GENERATED_NESTING_LEVELS: usize = 255;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             source.push_str(&format!("#ifdef MACRO_{i}\n"));
         }
         source.push_str("void leaf_fn(void) {}\n");
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("#endif\n");
         }
 

--- a/src/treesitter/c_lang.rs
+++ b/src/treesitter/c_lang.rs
@@ -1,4 +1,6 @@
-use super::{CallSite, Function, LanguageAnalyzer, body_hash_for_node, sha256_hex};
+use super::{
+    CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node, sha256_hex,
+};
 use tree_sitter::Parser;
 
 pub struct CAnalyzer;
@@ -28,7 +30,15 @@ fn is_preprocessor_container(kind: &str) -> bool {
     )
 }
 
-fn collect_functions(node: &tree_sitter::Node, source: &[u8], functions: &mut Vec<Function>) {
+fn collect_functions(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    functions: &mut Vec<Function>,
+    depth: usize,
+) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -70,14 +80,22 @@ fn collect_functions(node: &tree_sitter::Node, source: &[u8], functions: &mut Ve
                 }
             }
             kind if is_preprocessor_container(kind) => {
-                collect_functions(&child, source, functions);
+                collect_functions(&child, source, functions, depth + 1);
             }
             _ => {}
         }
     }
 }
 
-fn collect_imports(node: &tree_sitter::Node, source: &[u8], imports: &mut Vec<String>) {
+fn collect_imports(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    imports: &mut Vec<String>,
+    depth: usize,
+) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -86,7 +104,7 @@ fn collect_imports(node: &tree_sitter::Node, source: &[u8], imports: &mut Vec<St
                 imports.push(text);
             }
             kind if is_preprocessor_container(kind) => {
-                collect_imports(&child, source, imports);
+                collect_imports(&child, source, imports, depth + 1);
             }
             _ => {}
         }
@@ -100,7 +118,7 @@ impl LanguageAnalyzer for CAnalyzer {
             .parse(source, None)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse C source"))?;
         let mut functions = Vec::new();
-        collect_functions(&tree.root_node(), source, &mut functions);
+        collect_functions(&tree.root_node(), source, &mut functions, 0);
         Ok(functions)
     }
 
@@ -140,7 +158,7 @@ impl LanguageAnalyzer for CAnalyzer {
             .parse(source, None)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse C source"))?;
         let mut imports = Vec::new();
-        collect_imports(&tree.root_node(), source, &mut imports);
+        collect_imports(&tree.root_node(), source, &mut imports, 0);
         Ok(imports)
     }
 }
@@ -343,6 +361,69 @@ void guarded(int x) {
         let imports = analyzer.extract_imports(source).unwrap();
         assert_eq!(imports.len(), 1);
         assert_eq!(imports[0], "#include <special.h>");
+    }
+
+    /// Security regression: deeply-nested preprocessor blocks used to stack-overflow
+    /// `collect_functions` because it recursed without a depth limit. An attacker committing
+    /// a C file with thousands of nested `#ifdef` blocks could crash git-prism during
+    /// `get_change_manifest`. The analyzer must now complete without crashing.
+    ///
+    /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
+    /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
+    #[test]
+    fn deeply_nested_preproc_blocks_do_not_stack_overflow() {
+        const NESTING_DEPTH: usize = 5000;
+        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("#ifdef MACRO_{i}\n"));
+        }
+        // Function is past the cap — it should not be extracted.
+        source.push_str("void deep_fn(void) {}\n");
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("#endif\n");
+        }
+
+        let handle = std::thread::Builder::new()
+            .stack_size(TEST_STACK_SIZE)
+            .spawn(move || {
+                let analyzer = CAnalyzer;
+                analyzer.extract_functions(source.as_bytes())
+            })
+            .expect("spawn analyzer thread");
+
+        let result = handle
+            .join()
+            .expect("analyzer thread must not stack-overflow on deeply-nested input");
+        let functions = result.expect("analyzer must return Ok on deeply-nested input");
+        // Guard fires at depth 256 — the function at depth 5000 is not extracted.
+        assert!(functions.is_empty());
+    }
+
+    /// Triangulation: 255 nested `#ifdef` blocks with a function at the innermost level.
+    /// The guard fires at depth 256, so depth 255 must still allow extraction.
+    #[test]
+    fn nested_preproc_blocks_at_boundary_depth_still_extract_functions() {
+        const NESTING_DEPTH: usize = 255;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("#ifdef MACRO_{i}\n"));
+        }
+        source.push_str("void leaf_fn(void) {}\n");
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("#endif\n");
+        }
+
+        let analyzer = CAnalyzer;
+        let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
+        assert_eq!(
+            functions.len(),
+            1,
+            "function at depth 255 must be extracted"
+        );
+        assert_eq!(functions[0].name, "leaf_fn");
     }
 
     #[test]

--- a/src/treesitter/cpp.rs
+++ b/src/treesitter/cpp.rs
@@ -538,20 +538,20 @@ void unix_init() { return; }
     /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
     /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
     #[test]
-    fn deeply_nested_namespaces_do_not_stack_overflow() {
-        const NESTING_DEPTH: usize = 5000;
-        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+    fn it_completes_without_overflow_on_deeply_nested_namespaces() {
+        const GENERATED_NESTING_LEVELS: usize = 5000;
+        const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             source.push_str(&format!("namespace N{i} {{\n"));
         }
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("}\n");
         }
 
         let handle = std::thread::Builder::new()
-            .stack_size(TEST_STACK_SIZE)
+            .stack_size(CONSTRAINED_THREAD_STACK_BYTES)
             .spawn(move || {
                 let analyzer = CppAnalyzer;
                 analyzer.extract_functions(source.as_bytes())
@@ -569,15 +569,15 @@ void unix_init() { return; }
     /// Triangulation: 255 nested namespaces with a function at the innermost level.
     /// The guard fires at depth 256, so depth 255 must still allow extraction.
     #[test]
-    fn nested_namespaces_at_boundary_depth_still_extract_functions() {
-        const NESTING_DEPTH: usize = 255;
+    fn it_extracts_functions_at_boundary_nesting_depth() {
+        const GENERATED_NESTING_LEVELS: usize = 255;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             source.push_str(&format!("namespace N{i} {{\n"));
         }
         source.push_str("void leaf_fn() {}\n");
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("}\n");
         }
 

--- a/src/treesitter/cpp.rs
+++ b/src/treesitter/cpp.rs
@@ -1,4 +1,6 @@
-use super::{CallSite, Function, LanguageAnalyzer, body_hash_for_node, sha256_hex};
+use super::{
+    CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node, sha256_hex,
+};
 use tree_sitter::Parser;
 
 pub struct CppAnalyzer;
@@ -41,7 +43,11 @@ fn collect_functions(
     source: &[u8],
     scope: &[String],
     functions: &mut Vec<Function>,
+    depth: usize,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -57,7 +63,7 @@ fn collect_functions(
                     new_scope.push(ns_name);
                 }
                 if let Some(body) = child.child_by_field_name("body") {
-                    collect_functions(&body, source, &new_scope, functions);
+                    collect_functions(&body, source, &new_scope, functions, depth + 1);
                 }
             }
             "class_specifier" | "struct_specifier" => {
@@ -72,7 +78,7 @@ fn collect_functions(
                     new_scope.push(class_name);
                 }
                 if let Some(body) = child.child_by_field_name("body") {
-                    collect_functions(&body, source, &new_scope, functions);
+                    collect_functions(&body, source, &new_scope, functions, depth + 1);
                 }
             }
             "function_definition" => {
@@ -123,20 +129,28 @@ fn collect_functions(
             // linkage_specification itself walks its direct children; the
             // declaration_list arm below handles the braced case.
             "linkage_specification" => {
-                collect_functions(&child, source, scope, functions);
+                collect_functions(&child, source, scope, functions, depth + 1);
             }
             "declaration_list" => {
-                collect_functions(&child, source, scope, functions);
+                collect_functions(&child, source, scope, functions, depth + 1);
             }
             kind if is_preprocessor_container(kind) => {
-                collect_functions(&child, source, scope, functions);
+                collect_functions(&child, source, scope, functions, depth + 1);
             }
             _ => {}
         }
     }
 }
 
-fn collect_imports(node: &tree_sitter::Node, source: &[u8], imports: &mut Vec<String>) {
+fn collect_imports(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    imports: &mut Vec<String>,
+    depth: usize,
+) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -145,7 +159,7 @@ fn collect_imports(node: &tree_sitter::Node, source: &[u8], imports: &mut Vec<St
                 imports.push(text);
             }
             kind if is_preprocessor_container(kind) => {
-                collect_imports(&child, source, imports);
+                collect_imports(&child, source, imports, depth + 1);
             }
             _ => {}
         }
@@ -159,7 +173,7 @@ impl LanguageAnalyzer for CppAnalyzer {
             .parse(source, None)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse C++ source"))?;
         let mut functions = Vec::new();
-        collect_functions(&tree.root_node(), source, &[], &mut functions);
+        collect_functions(&tree.root_node(), source, &[], &mut functions, 0);
         Ok(functions)
     }
 
@@ -209,7 +223,7 @@ impl LanguageAnalyzer for CppAnalyzer {
             .parse(source, None)
             .ok_or_else(|| anyhow::anyhow!("Failed to parse C++ source"))?;
         let mut imports = Vec::new();
-        collect_imports(&tree.root_node(), source, &mut imports);
+        collect_imports(&tree.root_node(), source, &mut imports, 0);
         Ok(imports)
     }
 }
@@ -514,6 +528,67 @@ void unix_init() { return; }
         let analyzer = CppAnalyzer;
         let calls = analyzer.extract_calls(source).unwrap();
         assert!(calls.is_empty());
+    }
+
+    /// Security regression: deeply-nested namespace declarations used to stack-overflow
+    /// `collect_functions` because it recursed without a depth limit. An attacker committing
+    /// a C++ file with thousands of nested namespaces could crash git-prism during
+    /// `get_change_manifest`. The analyzer must now complete without crashing.
+    ///
+    /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
+    /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
+    #[test]
+    fn deeply_nested_namespaces_do_not_stack_overflow() {
+        const NESTING_DEPTH: usize = 5000;
+        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("namespace N{i} {{\n"));
+        }
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("}\n");
+        }
+
+        let handle = std::thread::Builder::new()
+            .stack_size(TEST_STACK_SIZE)
+            .spawn(move || {
+                let analyzer = CppAnalyzer;
+                analyzer.extract_functions(source.as_bytes())
+            })
+            .expect("spawn analyzer thread");
+
+        let result = handle
+            .join()
+            .expect("analyzer thread must not stack-overflow on deeply-nested input");
+        let functions = result.expect("analyzer must return Ok on deeply-nested input");
+        // Namespaces contain no functions themselves — everything past the cap is guarded out.
+        assert!(functions.is_empty());
+    }
+
+    /// Triangulation: 255 nested namespaces with a function at the innermost level.
+    /// The guard fires at depth 256, so depth 255 must still allow extraction.
+    #[test]
+    fn nested_namespaces_at_boundary_depth_still_extract_functions() {
+        const NESTING_DEPTH: usize = 255;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("namespace N{i} {{\n"));
+        }
+        source.push_str("void leaf_fn() {}\n");
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("}\n");
+        }
+
+        let analyzer = CppAnalyzer;
+        let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
+        assert_eq!(
+            functions.len(),
+            1,
+            "function at depth 255 must be extracted"
+        );
+        assert!(functions[0].name.ends_with("leaf_fn"));
     }
 
     #[test]

--- a/src/treesitter/python.rs
+++ b/src/treesitter/python.rs
@@ -1,4 +1,4 @@
-use super::{CallSite, Function, LanguageAnalyzer, body_hash_for_node};
+use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
 use tree_sitter::Parser;
 
 pub struct PythonAnalyzer;
@@ -25,7 +25,11 @@ fn extract_functions_from_node(
     node: &tree_sitter::Node,
     class_name: Option<&str>,
     functions: &mut Vec<Function>,
+    depth: usize,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -62,11 +66,17 @@ fn extract_functions_from_node(
                     body_hash,
                 });
                 if let Some(body) = child.child_by_field_name("body") {
-                    extract_functions_from_node(source, &body, Some(cls_name), functions);
+                    extract_functions_from_node(
+                        source,
+                        &body,
+                        Some(cls_name),
+                        functions,
+                        depth + 1,
+                    );
                 }
             }
             "decorated_definition" => {
-                extract_functions_from_node(source, &child, class_name, functions);
+                extract_functions_from_node(source, &child, class_name, functions, depth + 1);
             }
             _ => {}
         }
@@ -81,7 +91,7 @@ impl LanguageAnalyzer for PythonAnalyzer {
             .ok_or_else(|| anyhow::anyhow!("Failed to parse Python source"))?;
         let root = tree.root_node();
         let mut functions = Vec::new();
-        extract_functions_from_node(source, &root, None, &mut functions);
+        extract_functions_from_node(source, &root, None, &mut functions, 0);
         Ok(functions)
     }
 
@@ -324,6 +334,82 @@ class MyClass:
         let analyzer = PythonAnalyzer;
         let calls = analyzer.extract_calls(source).unwrap();
         assert!(calls.is_empty());
+    }
+
+    /// Defense-in-depth: deeply-nested Python class declarations are guarded by
+    /// `MAX_RECURSION_DEPTH`. Investigation showed that Python's indented class nesting
+    /// (which requires valid indentation) produces small per-frame sizes that don't
+    /// naturally SIGABRT on a 2 MB bounded-stack thread at 5000 levels — tree-sitter
+    /// processes them without overflowing. The guard is added for consistency with the
+    /// other five analyzers and to protect against future grammar changes or alternative
+    /// attack shapes that could produce deeper actual recursion.
+    ///
+    /// This test verifies the guard does not corrupt extraction at 5000 depth: the
+    /// outermost ~256 classes must still be extracted even on a constrained stack.
+    #[test]
+    fn deeply_nested_classes_do_not_stack_overflow() {
+        // 1024 = MAX_RECURSION_DEPTH * 4: enough headroom past the cap without
+        // the extreme runtime of 5000-level indented Python (which is O(n²) in
+        // string construction due to the indent repetition).
+        const NESTING_DEPTH: usize = 1024;
+        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            let indent = "    ".repeat(i);
+            source.push_str(&format!("{indent}class C{i}:\n"));
+        }
+        // Innermost class needs a body — use `pass` at the deepest indent.
+        let deepest_indent = "    ".repeat(NESTING_DEPTH);
+        source.push_str(&format!("{deepest_indent}pass\n"));
+
+        let handle = std::thread::Builder::new()
+            .stack_size(TEST_STACK_SIZE)
+            .spawn(move || {
+                let analyzer = PythonAnalyzer;
+                analyzer.extract_functions(source.as_bytes())
+            })
+            .expect("spawn analyzer thread");
+
+        let result = handle
+            .join()
+            .expect("analyzer thread must not stack-overflow on deeply-nested input");
+        let functions = result.expect("analyzer must return Ok on deeply-nested input");
+        // At least the outermost classes (up to MAX_RECURSION_DEPTH) must be
+        // returned — the depth guard truncates deeper nesting but preserves
+        // whatever extraction completed successfully.
+        assert!(
+            !functions.is_empty(),
+            "expected partial extraction to include outer classes"
+        );
+    }
+
+    /// Triangulation: 255 nested classes with a method at the innermost level.
+    /// The guard fires at depth 256, so depth 255 must still allow extraction.
+    #[test]
+    fn nested_classes_at_boundary_depth_still_extract_methods() {
+        const NESTING_DEPTH: usize = 255;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            let indent = "    ".repeat(i);
+            source.push_str(&format!("{indent}class C{i}:\n"));
+        }
+        // Add a method at the innermost class body (depth 255).
+        let method_indent = "    ".repeat(NESTING_DEPTH);
+        source.push_str(&format!("{method_indent}def leaf_method(self):\n"));
+        let body_indent = "    ".repeat(NESTING_DEPTH + 1);
+        source.push_str(&format!("{body_indent}pass\n"));
+
+        let analyzer = PythonAnalyzer;
+        let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
+        // All 255 classes plus the leaf method must be extracted.
+        let leaf = functions.iter().find(|f| f.name.ends_with("leaf_method"));
+        assert!(
+            leaf.is_some(),
+            "method at depth 255 must be extracted; got {} functions",
+            functions.len()
+        );
     }
 
     #[test]

--- a/src/treesitter/python.rs
+++ b/src/treesitter/python.rs
@@ -347,24 +347,24 @@ class MyClass:
     /// This test verifies the guard does not corrupt extraction at 5000 depth: the
     /// outermost ~256 classes must still be extracted even on a constrained stack.
     #[test]
-    fn deeply_nested_classes_do_not_stack_overflow() {
+    fn it_completes_without_overflow_on_deeply_nested_classes() {
         // 1024 = MAX_RECURSION_DEPTH * 4: enough headroom past the cap without
         // the extreme runtime of 5000-level indented Python (which is O(n²) in
         // string construction due to the indent repetition).
-        const NESTING_DEPTH: usize = 1024;
-        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+        const GENERATED_NESTING_LEVELS: usize = 1024;
+        const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             let indent = "    ".repeat(i);
             source.push_str(&format!("{indent}class C{i}:\n"));
         }
         // Innermost class needs a body — use `pass` at the deepest indent.
-        let deepest_indent = "    ".repeat(NESTING_DEPTH);
+        let deepest_indent = "    ".repeat(GENERATED_NESTING_LEVELS);
         source.push_str(&format!("{deepest_indent}pass\n"));
 
         let handle = std::thread::Builder::new()
-            .stack_size(TEST_STACK_SIZE)
+            .stack_size(CONSTRAINED_THREAD_STACK_BYTES)
             .spawn(move || {
                 let analyzer = PythonAnalyzer;
                 analyzer.extract_functions(source.as_bytes())
@@ -375,30 +375,32 @@ class MyClass:
             .join()
             .expect("analyzer thread must not stack-overflow on deeply-nested input");
         let functions = result.expect("analyzer must return Ok on deeply-nested input");
-        // At least the outermost classes (up to MAX_RECURSION_DEPTH) must be
-        // returned — the depth guard truncates deeper nesting but preserves
-        // whatever extraction completed successfully.
+        // The outermost MAX_RECURSION_DEPTH (256) classes must all be extracted
+        // before the guard fires. Asserting >= MAX_RECURSION_DEPTH catches
+        // regressions where the guard fires too early (e.g., at depth 10).
         assert!(
-            !functions.is_empty(),
-            "expected partial extraction to include outer classes"
+            functions.len() >= MAX_RECURSION_DEPTH,
+            "expected at least {} classes to be extracted before depth guard fires, got {}",
+            MAX_RECURSION_DEPTH,
+            functions.len()
         );
     }
 
     /// Triangulation: 255 nested classes with a method at the innermost level.
     /// The guard fires at depth 256, so depth 255 must still allow extraction.
     #[test]
-    fn nested_classes_at_boundary_depth_still_extract_methods() {
-        const NESTING_DEPTH: usize = 255;
+    fn it_extracts_methods_at_boundary_nesting_depth() {
+        const GENERATED_NESTING_LEVELS: usize = 255;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             let indent = "    ".repeat(i);
             source.push_str(&format!("{indent}class C{i}:\n"));
         }
         // Add a method at the innermost class body (depth 255).
-        let method_indent = "    ".repeat(NESTING_DEPTH);
+        let method_indent = "    ".repeat(GENERATED_NESTING_LEVELS);
         source.push_str(&format!("{method_indent}def leaf_method(self):\n"));
-        let body_indent = "    ".repeat(NESTING_DEPTH + 1);
+        let body_indent = "    ".repeat(GENERATED_NESTING_LEVELS + 1);
         source.push_str(&format!("{body_indent}pass\n"));
 
         let analyzer = PythonAnalyzer;

--- a/src/treesitter/rust_lang.rs
+++ b/src/treesitter/rust_lang.rs
@@ -1,4 +1,4 @@
-use super::{body_hash_for_node, CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH};
+use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
 use tree_sitter::Parser;
 
 pub struct RustAnalyzer;

--- a/src/treesitter/rust_lang.rs
+++ b/src/treesitter/rust_lang.rs
@@ -1,4 +1,4 @@
-use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
+use super::{body_hash_for_node, CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH};
 use tree_sitter::Parser;
 
 pub struct RustAnalyzer;
@@ -340,21 +340,21 @@ use anyhow::Result;
     /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
     /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
     #[test]
-    fn deeply_nested_impls_do_not_stack_overflow() {
-        const NESTING_DEPTH: usize = 5000;
-        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+    fn it_completes_without_overflow_on_deeply_nested_impls() {
+        const GENERATED_NESTING_LEVELS: usize = 5000;
+        const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..GENERATED_NESTING_LEVELS {
             source.push_str(&format!("impl T{i} {{\n"));
         }
         source.push_str("fn leaf() {}\n");
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("}\n");
         }
 
         let handle = std::thread::Builder::new()
-            .stack_size(TEST_STACK_SIZE)
+            .stack_size(CONSTRAINED_THREAD_STACK_BYTES)
             .spawn(move || {
                 let analyzer = RustAnalyzer;
                 analyzer.extract_functions(source.as_bytes())
@@ -371,9 +371,13 @@ use anyhow::Result;
     }
 
     /// Triangulation: 255 sequential impl blocks (not nested), each with one method.
-    /// Confirms the guard does not interfere with legitimate impl extraction.
+    /// Confirms the guard does not interfere with legitimate (shallow) impl extraction.
+    /// NOTE: This does NOT exercise the depth-255 boundary — nested Rust impls are a
+    /// parse error and tree-sitter error-recovers them to ERROR nodes, not nested
+    /// impl_item nodes. The deeply_nested_impls_do_not_stack_overflow test covers the
+    /// overflow safety property; this test covers the non-regression property.
     #[test]
-    fn sequential_impls_at_boundary_count_all_extract() {
+    fn sequential_impls_all_extract() {
         const IMPL_COUNT: usize = 255;
 
         let mut source = String::new();

--- a/src/treesitter/rust_lang.rs
+++ b/src/treesitter/rust_lang.rs
@@ -1,4 +1,4 @@
-use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
+use super::{body_hash_for_node, CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH};
 use tree_sitter::Parser;
 
 pub struct RustAnalyzer;
@@ -365,17 +365,19 @@ use anyhow::Result;
             .join()
             .expect("analyzer thread must not stack-overflow on deeply-nested input");
         result.expect("analyzer must return Ok on deeply-nested input");
-        // No assertion on function count — tree-sitter Rust error recovery
-        // produces ERROR nodes for illegal nested impls, not nested impl_item
-        // nodes, so the walker may or may not extract the leaf function.
+        // No assertion on function count — nested impls are a parse error, but
+        // tree-sitter Rust error recovery DOES produce nested impl_item nodes
+        // (confirmed: the unguarded walker SIGABRTs at 5000 levels on a 2MB thread).
+        // The leaf function is past the depth cap and is not extracted.
     }
 
     /// Triangulation: 255 sequential impl blocks (not nested), each with one method.
     /// Confirms the guard does not interfere with legitimate (shallow) impl extraction.
-    /// NOTE: This does NOT exercise the depth-255 boundary — nested Rust impls are a
-    /// parse error and tree-sitter error-recovers them to ERROR nodes, not nested
-    /// impl_item nodes. The deeply_nested_impls_do_not_stack_overflow test covers the
-    /// overflow safety property; this test covers the non-regression property.
+    /// NOTE: This does NOT exercise the depth-255 boundary — valid Rust syntax does not
+    /// allow nested impl blocks. However, tree-sitter Rust error recovery DOES produce
+    /// nested impl_item nodes from syntactically illegal nesting (confirmed: SIGABRT at
+    /// 5000 levels on a 2 MB thread). The it_completes_without_overflow_on_deeply_nested_impls
+    /// test covers the overflow safety property; this test covers the non-regression property.
     #[test]
     fn sequential_impls_all_extract() {
         const IMPL_COUNT: usize = 255;

--- a/src/treesitter/rust_lang.rs
+++ b/src/treesitter/rust_lang.rs
@@ -1,4 +1,4 @@
-use super::{CallSite, Function, LanguageAnalyzer, body_hash_for_node};
+use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
 use tree_sitter::Parser;
 
 pub struct RustAnalyzer;
@@ -24,7 +24,11 @@ fn extract_functions_from_node(
     node: &tree_sitter::Node,
     type_name: Option<&str>,
     functions: &mut Vec<Function>,
+    depth: usize,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -53,7 +57,13 @@ fn extract_functions_from_node(
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("");
                 if let Some(body) = child.child_by_field_name("body") {
-                    extract_functions_from_node(source, &body, Some(impl_type), functions);
+                    extract_functions_from_node(
+                        source,
+                        &body,
+                        Some(impl_type),
+                        functions,
+                        depth + 1,
+                    );
                 }
             }
             _ => {}
@@ -69,7 +79,7 @@ impl LanguageAnalyzer for RustAnalyzer {
             .ok_or_else(|| anyhow::anyhow!("Failed to parse Rust source"))?;
         let root = tree.root_node();
         let mut functions = Vec::new();
-        extract_functions_from_node(source, &root, None, &mut functions);
+        extract_functions_from_node(source, &root, None, &mut functions, 0);
         Ok(functions)
     }
 
@@ -315,5 +325,69 @@ use anyhow::Result;
         let analyzer = RustAnalyzer;
         let calls = analyzer.extract_calls(source).unwrap();
         assert!(calls.is_empty());
+    }
+
+    /// Security regression: deeply-nested `impl` blocks (invalid Rust syntax) used to
+    /// stack-overflow `extract_functions_from_node` because it recursed into each
+    /// `impl_item` body without a depth limit. Although `impl Foo { impl Bar {} }` is
+    /// a parse error, the tree-sitter Rust grammar's error recovery DOES produce nested
+    /// `impl_item` nodes from this input — contrary to the initial plan assumption.
+    /// An attacker committing such a file could crash git-prism during `get_change_manifest`.
+    ///
+    /// RED: 5000 nested `impl` blocks on a 2 MB bounded-stack thread → SIGABRT without guard.
+    /// GREEN: guard returns early at depth 256; thread completes normally.
+    ///
+    /// Runs on a thread with a 2 MB stack: roomy enough for bounded recursion to
+    /// `MAX_RECURSION_DEPTH` but far too small for unbounded recursion to 5000 frames.
+    #[test]
+    fn deeply_nested_impls_do_not_stack_overflow() {
+        const NESTING_DEPTH: usize = 5000;
+        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("impl T{i} {{\n"));
+        }
+        source.push_str("fn leaf() {}\n");
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("}\n");
+        }
+
+        let handle = std::thread::Builder::new()
+            .stack_size(TEST_STACK_SIZE)
+            .spawn(move || {
+                let analyzer = RustAnalyzer;
+                analyzer.extract_functions(source.as_bytes())
+            })
+            .expect("spawn analyzer thread");
+
+        let result = handle
+            .join()
+            .expect("analyzer thread must not stack-overflow on deeply-nested input");
+        result.expect("analyzer must return Ok on deeply-nested input");
+        // No assertion on function count — tree-sitter Rust error recovery
+        // produces ERROR nodes for illegal nested impls, not nested impl_item
+        // nodes, so the walker may or may not extract the leaf function.
+    }
+
+    /// Triangulation: 255 sequential impl blocks (not nested), each with one method.
+    /// Confirms the guard does not interfere with legitimate impl extraction.
+    #[test]
+    fn sequential_impls_at_boundary_count_all_extract() {
+        const IMPL_COUNT: usize = 255;
+
+        let mut source = String::new();
+        for i in 0..IMPL_COUNT {
+            source.push_str(&format!("struct T{i};\n"));
+            source.push_str(&format!("impl T{i} {{ fn method_{i}(&self) {{}} }}\n"));
+        }
+
+        let analyzer = RustAnalyzer;
+        let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
+        assert_eq!(
+            functions.len(),
+            IMPL_COUNT,
+            "all {IMPL_COUNT} impl methods must be extracted"
+        );
     }
 }

--- a/src/treesitter/typescript.rs
+++ b/src/treesitter/typescript.rs
@@ -508,7 +508,7 @@ class Greeter {
     /// walker completes without crashing on a deeply-nested (but grammar-limited)
     /// export chain, and that extraction still works correctly.
     #[test]
-    fn it_completes_without_overflow_on_deeply_nested_export_statements() {
+    fn it_completes_without_overflow_on_deeply_stacked_export_keywords() {
         const GENERATED_NESTING_LEVELS: usize = 5000;
         const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 

--- a/src/treesitter/typescript.rs
+++ b/src/treesitter/typescript.rs
@@ -1,4 +1,4 @@
-use super::{CallSite, Function, LanguageAnalyzer, body_hash_for_node};
+use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash_for_node};
 use tree_sitter::Parser;
 
 #[derive(Debug, Clone, Copy)]
@@ -58,7 +58,11 @@ fn extract_functions_from_node(
     node: &tree_sitter::Node,
     class_name: Option<&str>,
     functions: &mut Vec<Function>,
+    depth: usize,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         match child.kind() {
@@ -103,7 +107,13 @@ fn extract_functions_from_node(
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("");
                 if let Some(body) = child.child_by_field_name("body") {
-                    extract_functions_from_node(source, &body, Some(cls_name), functions);
+                    extract_functions_from_node(
+                        source,
+                        &body,
+                        Some(cls_name),
+                        functions,
+                        depth + 1,
+                    );
                 }
             }
             "lexical_declaration" => {
@@ -133,7 +143,7 @@ fn extract_functions_from_node(
                 }
             }
             "export_statement" => {
-                extract_functions_from_node(source, &child, class_name, functions);
+                extract_functions_from_node(source, &child, class_name, functions, depth + 1);
             }
             _ => {}
         }
@@ -148,7 +158,7 @@ impl LanguageAnalyzer for TypeScriptAnalyzer {
             .ok_or_else(|| anyhow::anyhow!("Failed to parse source"))?;
         let root = tree.root_node();
         let mut functions = Vec::new();
-        extract_functions_from_node(source, &root, None, &mut functions);
+        extract_functions_from_node(source, &root, None, &mut functions, 0);
         Ok(functions)
     }
 
@@ -479,6 +489,73 @@ class Greeter {
         let analyzer = TypeScriptAnalyzer::typescript();
         let calls = analyzer.extract_calls(source).unwrap();
         assert!(calls.is_empty());
+    }
+
+    /// Defense-in-depth: deeply-nested TypeScript export_statement and class_declaration
+    /// bodies are guarded by `MAX_RECURSION_DEPTH`. The two recursion sites in
+    /// `extract_functions_from_node` are `class_declaration` body and `export_statement`.
+    ///
+    /// Investigation per the plan: valid TypeScript syntax does not allow
+    /// `class A { class B {} }` at the declaration level, and the tree-sitter
+    /// TypeScript grammar's error recovery produces ERROR nodes (not nested
+    /// `class_declaration` nodes) for malformed input. Similarly, stacked `export`
+    /// keywords are parse errors and error-recover to a single `export_statement`
+    /// wrapping the inner tokens, not to recursively nested `export_statement` nodes.
+    /// Because the walker's match is explicit (`"export_statement"` and `"class_declaration"`),
+    /// ERROR-kind nodes are invisible to the recursion path.
+    ///
+    /// Guard added for defense-in-depth and consistency. This test verifies the
+    /// walker completes without crashing on a deeply-nested (but grammar-limited)
+    /// export chain, and that extraction still works correctly.
+    #[test]
+    fn deeply_nested_export_statements_do_not_stack_overflow() {
+        const NESTING_DEPTH: usize = 5000;
+        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+
+        // Stacked `export` keywords — tree-sitter error-recovers these, so
+        // they don't produce nested export_statement nodes in practice.
+        // The test still validates the analyzer handles the input safely.
+        let mut source = String::new();
+        for _ in 0..NESTING_DEPTH {
+            source.push_str("export ");
+        }
+        source.push_str("class C {}\n");
+
+        let handle = std::thread::Builder::new()
+            .stack_size(TEST_STACK_SIZE)
+            .spawn(move || {
+                let analyzer = TypeScriptAnalyzer::typescript();
+                analyzer.extract_functions(source.as_bytes())
+            })
+            .expect("spawn analyzer thread");
+
+        let result = handle
+            .join()
+            .expect("analyzer thread must not stack-overflow on deeply-nested input");
+        result.expect("analyzer must return Ok on deeply-nested input");
+        // No assertion on function count — the parse tree shape is grammar-dependent.
+    }
+
+    /// Triangulation: a standard export wrapping a class with a method must still extract.
+    /// This confirms the guard does not fire on legitimate export_statement usage.
+    #[test]
+    fn export_statement_wrapping_class_still_extracts_methods() {
+        const NESTING_DEPTH: usize = 255;
+
+        // Build 255 sequential (not nested) exported classes each with a method,
+        // to confirm the export_statement arm still works at high volume.
+        let mut source = String::new();
+        for i in 0..NESTING_DEPTH {
+            source.push_str(&format!("export class C{i} {{ method{i}(): void {{}} }}\n"));
+        }
+
+        let analyzer = TypeScriptAnalyzer::typescript();
+        let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
+        assert_eq!(
+            functions.len(),
+            NESTING_DEPTH,
+            "all {NESTING_DEPTH} methods must be extracted"
+        );
     }
 
     #[test]

--- a/src/treesitter/typescript.rs
+++ b/src/treesitter/typescript.rs
@@ -2,7 +2,7 @@ use super::{CallSite, Function, LanguageAnalyzer, MAX_RECURSION_DEPTH, body_hash
 use tree_sitter::Parser;
 
 #[derive(Debug, Clone, Copy)]
-pub enum JsDialect {
+enum JsDialect {
     TypeScript,
     Tsx,
     JavaScript,
@@ -508,21 +508,21 @@ class Greeter {
     /// walker completes without crashing on a deeply-nested (but grammar-limited)
     /// export chain, and that extraction still works correctly.
     #[test]
-    fn deeply_nested_export_statements_do_not_stack_overflow() {
-        const NESTING_DEPTH: usize = 5000;
-        const TEST_STACK_SIZE: usize = 2 * 1024 * 1024;
+    fn it_completes_without_overflow_on_deeply_nested_export_statements() {
+        const GENERATED_NESTING_LEVELS: usize = 5000;
+        const CONSTRAINED_THREAD_STACK_BYTES: usize = 2 * 1024 * 1024;
 
         // Stacked `export` keywords — tree-sitter error-recovers these, so
         // they don't produce nested export_statement nodes in practice.
         // The test still validates the analyzer handles the input safely.
         let mut source = String::new();
-        for _ in 0..NESTING_DEPTH {
+        for _ in 0..GENERATED_NESTING_LEVELS {
             source.push_str("export ");
         }
         source.push_str("class C {}\n");
 
         let handle = std::thread::Builder::new()
-            .stack_size(TEST_STACK_SIZE)
+            .stack_size(CONSTRAINED_THREAD_STACK_BYTES)
             .spawn(move || {
                 let analyzer = TypeScriptAnalyzer::typescript();
                 analyzer.extract_functions(source.as_bytes())
@@ -536,16 +536,21 @@ class Greeter {
         // No assertion on function count — the parse tree shape is grammar-dependent.
     }
 
-    /// Triangulation: a standard export wrapping a class with a method must still extract.
+    /// Triangulation: sequential exported classes with methods must all extract.
     /// This confirms the guard does not fire on legitimate export_statement usage.
+    /// NOTE: These are sequential (not nested) exports — each recurses at depth 1,
+    /// not depth 255. This tests non-regression of the export_statement arm, not
+    /// the depth-boundary property (tree-sitter error-recovers stacked `export`
+    /// keywords to a single export_statement, so true depth-255 nesting via exports
+    /// is not achievable with valid or error-recovered TypeScript syntax).
     #[test]
-    fn export_statement_wrapping_class_still_extracts_methods() {
-        const NESTING_DEPTH: usize = 255;
+    fn it_extracts_methods_from_exported_classes() {
+        const CLASS_COUNT: usize = 255;
 
         // Build 255 sequential (not nested) exported classes each with a method,
         // to confirm the export_statement arm still works at high volume.
         let mut source = String::new();
-        for i in 0..NESTING_DEPTH {
+        for i in 0..CLASS_COUNT {
             source.push_str(&format!("export class C{i} {{ method{i}(): void {{}} }}\n"));
         }
 
@@ -553,8 +558,8 @@ class Greeter {
         let functions = analyzer.extract_functions(source.as_bytes()).unwrap();
         assert_eq!(
             functions.len(),
-            NESTING_DEPTH,
-            "all {NESTING_DEPTH} methods must be extracted"
+            CLASS_COUNT,
+            "all {CLASS_COUNT} methods must be extracted"
         );
     }
 


### PR DESCRIPTION
Closes #187.

## Summary

Tier 4 follow-up from the April 2026 B8 security deep-dive. Five tree-sitter
analyzers walked untrusted parse trees with unbounded recursion — a pathological
input (thousands of nested braces/classes/impls) could blow the Rust thread
stack and crash the MCP server for every caller, not just the one sending the
bad blob. This PR ships the same `MAX_RECURSION_DEPTH = 256` defense applied to
`csharp.rs` and `ruby.rs` in PR #181 across the five remaining analyzers.

## Five commits, one per analyzer

| Commit | Analyzer | Recursion sites guarded |
|--------|----------|------------------------|
| `f5ad3db` | `cpp.rs` | 5 in `collect_functions` (namespace, class, linkage_spec, declaration_list, preprocessor), 1 in `collect_imports` |
| `2e6cfdb` | `c_lang.rs` | 1 in `collect_functions` (preprocessor), 1 in `collect_imports` (preprocessor) |
| `ad46971` | `python.rs` | 2 in `extract_functions_from_node` (class body, `decorated_definition`) |
| `61e99a7` | `typescript.rs` | 2 in `extract_functions_from_node` (`class_declaration` body, `export_statement`) |
| `7bef7fe` | `rust_lang.rs` | 1 in `extract_functions_from_node` (`impl_item` body) |

## TDD proof

Each commit has RED→GREEN→TRIANGULATE coverage:

- **RED test** (depth 5000, 2 MB bounded-stack thread): confirms the attack
  actually SIGABRTs the unguarded analyzer. The thread's `.join()` returning
  `Err(...)` is the stack-overflow detector.
- **GREEN**: `if depth >= MAX_RECURSION_DEPTH { return; }` as the first
  statement of each recursive walker; entry points seeded at 0, recursion
  sites pass `depth + 1`.
- **TRIANGULATION test** (depth 255 or 255 sequential constructs): confirms
  legitimate code still extracts correctly at the boundary.

## Escalation clause outcomes

- **`rust_lang.rs`**: Valid Rust doesn't allow nested `impl` blocks, but
  tree-sitter's error recovery DOES produce nested `impl_item` nodes from
  `impl A { impl B { ... } }`. The RED test SIGABRTs as expected — the attack
  vector is real.
- **`typescript.rs`**: TS error recovery produces `ERROR` nodes (not nested
  `export_statement` / `class_declaration`) from stacked `export` keywords.
  No natural SIGABRT. Guard added for defense-in-depth and consistency; commit
  body documents the tree-sitter behavior. One fix covers JS + TSX + TS via
  the shared `JsDialect` walker.
- **`python.rs`**: Python's indented nesting produces small per-frame sizes;
  unguarded recursion doesn't SIGABRT the 2 MB thread at any tested depth.
  Guard added for defense-in-depth; RED test verifies structural safety (partial
  extraction completes, ≥ 256 classes extracted before guard fires).

## What didn't change

- `csharp.rs`, `ruby.rs`, `kotlin.rs` — already fixed or out of scope
- `src/treesitter/mod.rs` — `MAX_RECURSION_DEPTH = 256` already existed there;
  analyzers import it via `use super::{..., MAX_RECURSION_DEPTH}`
- `extract_calls()` — already uses an iterative `Vec<Node>` stack; no guard needed
- Silent truncation behavior — early return without error matches the existing
  csharp/ruby behavior; telemetry hook is tracked separately (see follow-up issue)

## Church purification

Post-implementation cleanup (commits `532d1c6`, `1f7e580`):
- Test functions renamed to `it_verb_noun` convention
- Constants renamed `NESTING_DEPTH` → `GENERATED_NESTING_LEVELS`, `TEST_STACK_SIZE` → `CONSTRAINED_THREAD_STACK_BYTES`
- `python.rs` assertion strengthened: `!functions.is_empty()` → `functions.len() >= MAX_RECURSION_DEPTH`
- `typescript.rs`: `JsDialect` visibility reduced to private (no external importers)
- NOTE comments added to rust_lang.rs and typescript.rs triangulation tests explaining structural constraints

---
Generated with [Claude Code](https://claude.ai/claude-code)