### PR TITLE
fix: advertise tools capability in MCP initialize response

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,16 @@ pre-push:
     test:
       run: env -u GIT_DIR -u GIT_WORK_TREE cargo test
 
+post-merge:
+  commands:
+    rebuild-binary:
+      run: nohup cargo build --release > /tmp/git-prism-build.log 2>&1 &
+
+post-rewrite:
+  commands:
+    rebuild-binary:
+      run: nohup cargo build --release > /tmp/git-prism-build.log 2>&1 &
+
 commit-msg:
   commands:
     validate-pr-refs:

--- a/src/server.rs
+++ b/src/server.rs
@@ -576,7 +576,15 @@ impl GitPrismServer {
 }
 
 #[tool_handler(router = self.tool_router)]
-impl ServerHandler for GitPrismServer {}
+impl ServerHandler for GitPrismServer {
+    fn get_info(&self) -> rmcp::model::ServerInfo {
+        let mut info = rmcp::model::ServerInfo::default();
+        info.capabilities = rmcp::model::ServerCapabilities::builder()
+            .enable_tools()
+            .build();
+        info
+    }
+}
 
 pub async fn run_server() -> anyhow::Result<()> {
     let _telemetry = crate::telemetry::init();
@@ -721,6 +729,16 @@ mod tests {
             "expected exactly four MCP tools, found {}: {:?}",
             tools.len(),
             names
+        );
+    }
+
+    #[test]
+    fn it_advertises_tools_in_server_capabilities() {
+        let server = GitPrismServer::new();
+        let info = server.get_info();
+        assert!(
+            info.capabilities.tools.is_some(),
+            "ServerInfo must advertise tools capability so MCP clients call tools/list"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -578,11 +578,11 @@ impl GitPrismServer {
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for GitPrismServer {
     fn get_info(&self) -> rmcp::model::ServerInfo {
-        let mut info = rmcp::model::ServerInfo::default();
-        info.capabilities = rmcp::model::ServerCapabilities::builder()
+        let mut server_info = rmcp::model::ServerInfo::default();
+        server_info.capabilities = rmcp::model::ServerCapabilities::builder()
             .enable_tools()
             .build();
-        info
+        server_info
     }
 }
 
@@ -651,6 +651,15 @@ mod tests {
         assert!(
             router.has_route("get_function_context"),
             "get_function_context must be registered as an MCP tool"
+        );
+    }
+
+    #[test]
+    fn it_returns_empty_map_when_entries_is_empty() {
+        let counts = functions_per_language_counts(&[]);
+        assert!(
+            counts.is_empty(),
+            "empty input must produce empty map, not panic or insert spurious entries"
         );
     }
 
@@ -735,11 +744,38 @@ mod tests {
     #[test]
     fn it_advertises_tools_in_server_capabilities() {
         let server = GitPrismServer::new();
+        let server_info = server.get_info();
+        // Must be Some — None means MCP clients will never call tools/list.
+        // Must have list_changed == None — this server does not emit change notifications,
+        // so advertising Some(true) would be a lie that breaks conformant clients.
+        assert_eq!(
+            server_info.capabilities.tools,
+            Some(rmcp::model::ToolsCapability { list_changed: None }),
+            "tools capability must be enabled with list_changed=None (static tool set, no notifications)"
+        );
+    }
+
+    #[test]
+    fn it_does_not_advertise_resources_or_prompts_capabilities() {
+        // Advertising unimplemented capabilities causes MCP clients to call endpoints
+        // that do not exist, producing confusing errors.
+        let server = GitPrismServer::new();
         let info = server.get_info();
         assert!(
-            info.capabilities.tools.is_some(),
-            "ServerInfo must advertise tools capability so MCP clients call tools/list"
+            info.capabilities.resources.is_none(),
+            "resources capability must not be advertised — this server does not implement resources"
         );
+        assert!(
+            info.capabilities.prompts.is_none(),
+            "prompts capability must not be advertised — this server does not implement prompts"
+        );
+    }
+
+    #[test]
+    fn it_labels_all_change_scope_variants() {
+        assert_eq!(change_scope_label(ChangeScope::Committed), "committed");
+        assert_eq!(change_scope_label(ChangeScope::Staged), "staged");
+        assert_eq!(change_scope_label(ChangeScope::Unstaged), "unstaged");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ServerHandler::get_info()` was returning `ServerCapabilities::default()` — an empty object with no `tools` key. Strict MCP clients (including Claude Code) check for `tools` in the capabilities before calling `tools/list`, so they connected but never loaded any tools.
- Fix: override `get_info()` to return `ServerCapabilities::builder().enable_tools().build()`, producing `{"capabilities": {"tools": {}}}`.
- Also adds `post-merge` and `post-rewrite` lefthook hooks to rebuild the release binary in the background after `git pull`/`git rebase`.

## Root cause

The `#[tool_handler]` macro (rmcp 1.3) only generates `call_tool`, `list_tools`, and `get_tool` — it does **not** override `get_info()`. The default `ServerHandler::get_info()` returns `ServerInfo::default()` with empty capabilities, which is correct only if you have nothing to advertise.

## Test plan

- [x] `it_advertises_tools_in_server_capabilities` — asserts exact `ToolsCapability { list_changed: None }` value
- [x] `it_does_not_advertise_resources_or_prompts_capabilities` — verifies unimplemented caps are absent
- [x] `it_labels_all_change_scope_variants` — covers previously untested Staged/Unstaged arms
- [x] `it_returns_empty_map_when_entries_is_empty` — empty-input path for `functions_per_language_counts`
- [x] All 606 tests pass, clippy clean, fmt clean

---

Generated with [Claude Code](https://claude.ai/claude-code)