### PR TITLE
deps: bump OpenTelemetry crate family to 0.31 in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry"
+          - "opentelemetry_sdk"
+          - "opentelemetry-otlp"
+          - "tracing-opentelemetry"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,8 @@ updates:
     groups:
       opentelemetry:
         patterns:
-          - "opentelemetry"
-          - "opentelemetry_sdk"
-          - "opentelemetry-otlp"
-          - "tracing-opentelemetry"
+          - "opentelemetry*"
+          - "tracing-opentelemetry*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,13 +578,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -595,7 +596,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -2078,9 +2079,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2092,26 +2093,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
  "reqwest",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.28.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "async-trait",
- "futures-core",
  "http",
  "opentelemetry",
  "opentelemetry-http",
@@ -2125,35 +2123,32 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
  "rand",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -2286,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2296,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2318,26 +2313,31 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -2345,11 +2345,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -2906,11 +2906,22 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper",
  "tokio-stream",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -3003,14 +3014,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ glob = "0.3"
 base64 = "0.22"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
-tracing-opentelemetry = "0.29"
-opentelemetry = "0.28"
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.28", features = ["http-proto"] }
+tracing-opentelemetry = "0.32"
+opentelemetry = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", features = ["http-proto"] }
 sha2 = "0.10"
 
 [build-dependencies]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -18,7 +18,7 @@ const ENV_SERVICE_VERSION: &str = "GIT_PRISM_SERVICE_VERSION";
 
 /// Compute the per-signal OTLP HTTP endpoints from a base URL.
 ///
-/// `opentelemetry-otlp` 0.28's HTTP exporter does not auto-append the
+/// `opentelemetry-otlp`'s HTTP exporter does not auto-append the
 /// per-signal path (`/v1/traces`, `/v1/metrics`) when the endpoint is
 /// supplied via `with_endpoint()` — only the env-var-driven path
 /// (`OTEL_EXPORTER_OTLP_ENDPOINT`) triggers that behavior. We construct


### PR DESCRIPTION
## Summary

- Bumps the OpenTelemetry crate family in lockstep so a single resolved version lives in the dep graph: `opentelemetry` 0.28 → 0.31, `opentelemetry_sdk` 0.28 → 0.31, `opentelemetry-otlp` 0.28 → 0.31, `tracing-opentelemetry` 0.29 → 0.32. Features `http-proto` (on `opentelemetry-otlp`) and `rt-tokio` (on `opentelemetry_sdk`) are preserved verbatim — the HTTP/protobuf transport from #210 is unchanged.
- Adds a dependabot group that covers the full `opentelemetry*` and `tracing-opentelemetry*` prefixes so these crates can never drift apart again.
- Drops a stale "0.28" version reference from the `signal_endpoints` doc comment in `src/telemetry.rs` (the described behavior still applies in 0.31, only the version stamp was stale).

## Why

Dependabot opened #200 (`opentelemetry_sdk` → 0.31 alone) and #201 (`tracing-opentelemetry` → 0.32 alone). Each of them left the rest of the OTEL family at 0.28, so `tracing-opentelemetry 0.32` pulled `opentelemetry 0.31` transitively while our direct deps stayed on 0.28 — two incompatible versions of the same crate in the dep graph. `SdkTracer` from 0.31 no longer satisfied the `Tracer` trait bound in `OpenTelemetryLayer::with_tracer` when the bound was resolved against our 0.28 direct dep, so `.with(otel_layer).try_init()` failed with four cascading clippy errors in `src/telemetry.rs:86-88`:

```
error[E0277]: the trait bound `opentelemetry_sdk::trace::SdkTracer:
              opentelemetry::trace::tracer::Tracer` is not satisfied
note: there are multiple different versions of crate `opentelemetry` in the dependency graph
```

Run on #201: https://github.com/mikelane/git-prism/actions/runs/24318127632/job/70999332615

Both PRs have been closed. This PR is the coordinated fix, and the dependabot grouping prevents the drift from recurring.

## What changed

| File | Change |
|---|---|
| `Cargo.toml` | OTEL family version bumps (4 lines) |
| `Cargo.lock` | regenerated — single `opentelemetry v0.31.0` throughout (`cargo tree -i opentelemetry` verified) |
| `.github/dependabot.yml` | new `opentelemetry` group; glob patterns `opentelemetry*` and `tracing-opentelemetry*` for future-proof coverage |
| `src/telemetry.rs` | one-line doc comment correction (removed stale version stamp) |

No changes to the OTEL init flow — the 0.28 → 0.31 window preserved the public builder surface (`SpanExporter::builder().with_http()`, `SdkTracerProvider::builder()`, `Resource::builder().with_service_name()`, `tracing_opentelemetry::layer().with_tracer()`), so `src/telemetry.rs` compiles and runs unchanged against the new crates. The existing test suite (`test_init_with_endpoint_creates_providers` and friends) flexes the real builder chain end-to-end, so the bump is empirically verified rather than faith-based.

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (was the failing check on #200/#201)
- [x] `cargo test` — 609/609 passing
- [x] `cargo tree -i opentelemetry` — single `v0.31.0`; no duplicates introduced by this bump (pre-existing `hashbrown`/`getrandom` duplicates in `gix`/`tempfile` subgraphs are unaffected and out of scope)
- [x] `cargo audit` — no advisories against the new dep graph (347 crates scanned, exit 0)
- [x] HTTP/protobuf transport preserved (`http-proto` feature still gates `with_http()` in `opentelemetry-otlp 0.31.1`)
- [x] B1 regression test (`it_returns_noop_guard_when_tracing_subscriber_init_fails`) still pins the "don't print success after subscriber-attach failure" invariant
- [x] All three commits GPG-signed (lefthook `validate-pr-refs` + pre-push `fmt`/`clippy`/`test` gauntlet pass on each push)

## Gauntlet

Full pre-review gauntlet (bug hunting → quality → security → 14 church purist agents) ran against the 4 changed files:

- **dep-purist, secret-purist, observability-purist, git-purist, test-purist**: NO_FINDINGS
- **arch/size/dead-code/ts/react/a11y/copy/adaptive purists**: N/A (Rust backend, no frontend surface, no structural changes)
- **naming-purist** flagged that the initial explicit-list dependabot group would miss future direct OTEL deps (e.g., `opentelemetry-semantic-conventions`) whose names start with `opentelemetry` but weren't in the list. Fix applied as commit 3 — group now uses glob patterns matching the group name's implied promise.

## Commits

1. `deps: bump opentelemetry family to 0.31 in lockstep (closes #213)` — the core bump + initial dependabot grouping
2. `docs: drop stale 0.28 version reference from signal_endpoints comment` — gauntlet Phase 2 doc-drift finding
3. `ci(dependabot): widen opentelemetry group to glob patterns` — gauntlet Phase 4 naming-purist finding

Closes #213. Supersedes #200 and #201.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)