### PR TITLE
test(bdd): scaffold issue-212 size guardrail scenarios @not_implemented

### DIFF
--- a/bdd/features/response_size_guardrails.feature
+++ b/bdd/features/response_size_guardrails.feature
@@ -1,0 +1,90 @@
+@ISSUE-212 @not_implemented
+Feature: Bounded tool responses
+  The cheap read tools `get_change_manifest` and `get_function_context` advertise
+  themselves as first- and second-resort calls that should fit comfortably inside
+  an agent's context window. Without explicit response-size guardrails, a large
+  change can produce tool outputs that exceed MCP context limits, forcing the
+  client to dump the payload to disk and defeating the purpose of an agent-
+  optimized server. This feature enforces a per-tool token budget, standardizes
+  truncation metadata, and emits a bounded-cardinality metric when the budget
+  is hit so operators can detect agents hammering the budget in production.
+
+  Background:
+    Given a git repository with a change affecting 20 files and 50 modified functions
+
+  Rule: get_change_manifest defaults to a cheap response; function analysis is opt-in
+
+    Scenario: Default manifest call omits function analysis
+      When an agent requests the change manifest without opting in to function analysis
+      Then the response lists every changed file with summary counts
+      And the response omits per-function signature diffs
+
+    Scenario: Opt-in manifest call includes function analysis
+      When an agent requests the change manifest with function analysis enabled
+      Then the response includes per-function signature diffs for files within the budget
+
+  Rule: get_change_manifest clamps function detail to its token budget
+
+    Scenario: Over-budget manifest trims function detail to signatures only
+      When an agent requests the change manifest with function analysis enabled and a 512 token budget
+      Then the response token_estimate is at most 512
+      And the response metadata lists every file whose function detail was trimmed
+      And the trimmed files preserve their function signatures
+
+    Scenario: Over-budget manifest emits the token_budget truncation metric
+      When an agent requests the change manifest with function analysis enabled and a 512 token budget
+      Then the git_prism.response.truncated metric records a token_budget event for get_change_manifest
+
+    Scenario: Change manifest surfaces token_estimate in the response metadata
+      When an agent requests the change manifest
+      Then the response metadata includes a token_estimate for the payload
+
+  Rule: get_function_context paginates over changed functions
+
+    Scenario: Default function context call returns the first page with a next-page cursor
+      When an agent requests function context without a cursor
+      Then the response contains the first page of changed functions in deterministic order
+      And the response metadata includes a next-page cursor
+
+    Scenario: Cursor advances through remaining functions
+      Given an agent has retrieved the first page of function context and received a next-page cursor
+      When the agent requests function context with that cursor
+      Then the response contains the next page of changed functions
+      And no function appears in both pages
+
+    Scenario: Function name filter scopes the response to named functions
+      When an agent requests function context scoped to "function_01" and "function_02"
+      Then the response contains exactly those two functions
+      And functions outside the filter are not included
+
+  Rule: get_function_context clamps caller and callee detail to its token budget
+
+    Scenario: Over-budget context trims per-function caller and callee lists
+      When an agent requests function context with a 512 token budget
+      Then the response token_estimate is at most 512
+      And at least one function entry is marked as truncated
+      And the truncated entries have shortened caller and callee lists
+
+    Scenario: Over-budget context emits the token_budget truncation metric
+      When an agent requests function context with a 512 token budget
+      Then the git_prism.response.truncated metric records a token_budget event for get_function_context
+
+    Scenario: Function context surfaces token_estimate in the response metadata
+      When an agent requests function context
+      Then the response metadata includes a token_estimate for the payload
+
+  Rule: Both read tools stay within budget on an extreme change
+
+    Scenario: Change manifest stays within the 8192 token budget on an extreme change
+      Given a git repository with a change affecting 200 files and 1000 modified functions
+      When an agent requests the change manifest with function analysis enabled
+      Then the response token_estimate is at most 8192
+      And the response metadata lists every file whose function detail was trimmed
+      And the git_prism.response.truncated metric records a token_budget event for get_change_manifest
+
+    Scenario: Function context stays within the 8192 token budget on an extreme change
+      Given a git repository with a change affecting 200 files and 1000 modified functions
+      When an agent requests function context without a function name filter
+      Then the response token_estimate is at most 8192
+      And at least one function entry is marked as truncated
+      And the git_prism.response.truncated metric records a token_budget event for get_function_context

--- a/bdd/features/response_size_guardrails.feature
+++ b/bdd/features/response_size_guardrails.feature
@@ -35,7 +35,7 @@ Feature: Bounded tool responses
       When an agent requests the change manifest with function analysis enabled and a 512 token budget
       Then the git_prism.response.truncated metric records a token_budget event for get_change_manifest
 
-    Scenario: Change manifest surfaces token_estimate in the response metadata
+    Scenario: Change manifest reports its payload size for budgeting follow-up calls
       When an agent requests the change manifest
       Then the response metadata includes a token_estimate for the payload
 
@@ -52,8 +52,8 @@ Feature: Bounded tool responses
       Then the response contains the next page of changed functions
       And no function appears in both pages
 
-    Scenario: Function name filter scopes the response to named functions
-      When an agent requests function context scoped to "function_01" and "function_02"
+    Scenario: Agents can scope function context to a specific name list
+      When an agent requests function context scoped to "function_0001" and "function_0002"
       Then the response contains exactly those two functions
       And functions outside the filter are not included
 
@@ -69,11 +69,11 @@ Feature: Bounded tool responses
       When an agent requests function context with a 512 token budget
       Then the git_prism.response.truncated metric records a token_budget event for get_function_context
 
-    Scenario: Function context surfaces token_estimate in the response metadata
+    Scenario: Function context reports its payload size for budgeting follow-up calls
       When an agent requests function context
       Then the response metadata includes a token_estimate for the payload
 
-  Rule: Both read tools stay within budget on an extreme change
+  Rule: Read tools stay within their token budget regardless of change size
 
     Scenario: Change manifest stays within the 8192 token budget on an extreme change
       Given a git repository with a change affecting 200 files and 1000 modified functions

--- a/bdd/steps/large_pr_fixture_steps.py
+++ b/bdd/steps/large_pr_fixture_steps.py
@@ -1,0 +1,101 @@
+"""Fixture builder for large-PR scenarios in the response-size guardrails feature.
+
+Builds a deterministic Rust repository with `file_count` source files, each
+containing `fns_per_file` functions with stable names (`function_01`,
+`function_02`, ...). Two commits are created: an initial commit with all
+functions returning `1`, and a modified commit where every function body is
+changed to return `2`. The git ref range between the two commits drives the
+When-steps for the ISSUE-212 scenarios.
+
+Deterministic naming is required so the function-name-filter scenario can
+assert on specific names without having to know how git-prism orders its
+output.
+"""
+
+from __future__ import annotations
+
+from behave import given
+from behave.runner import Context
+
+from repo_setup_steps import _commit, _init_repo, _write_file
+
+
+def _rust_function(index: int, body_value: int) -> str:
+    """Render one Rust function definition with a deterministic name.
+
+    Function names are zero-padded so lexicographic sort matches numeric sort
+    up to `function_99`. Bodies are just integer literals — tree-sitter does
+    not care about semantics.
+    """
+    name = f"function_{index:02d}"
+    return f"pub fn {name}() -> i32 {{ {body_value} }}\n"
+
+
+def _rust_source_file(start_index: int, fns_per_file: int, body_value: int) -> str:
+    """Render the full content of a single Rust source file.
+
+    Functions in the file are numbered `function_{start_index:02d}` through
+    `function_{start_index + fns_per_file - 1:02d}`, each with a body of
+    `body_value`. Distinct body values across commits produce real function
+    diffs that git-prism's content-aware differ will surface.
+    """
+    return "".join(
+        _rust_function(start_index + i, body_value) for i in range(fns_per_file)
+    )
+
+
+def _build_large_pr_fixture(
+    context: Context, file_count: int, fns_per_file: int,
+) -> None:
+    """Build a deterministic multi-file Rust repo with two commits.
+
+    The INITIAL commit populates `file_count` files under `src/`, each named
+    `src_NN.rs` and containing `fns_per_file` functions. The MODIFIED commit
+    rewrites every file so every function body changes, producing a dense
+    change set that exercises response-size budgets.
+
+    The helper appends the tempdir path to `context.cleanup_dirs` so
+    `bdd/environment.py::after_scenario` cleans it up, and sets
+    `context.repo_path` so existing CLI steps that auto-inject `--repo` work
+    out of the box. It is called twice by this module: once from the feature
+    Background (20 files, ~50 functions) and once from the capstone Rule for
+    the extreme-change stress fixture (200 files, 1000 functions).
+    """
+    repo_dir = _init_repo(context)
+
+    initial_filenames: list[str] = []
+    for file_index in range(file_count):
+        start = file_index * fns_per_file + 1
+        filename = f"src/src_{file_index + 1:03d}.rs"
+        _write_file(repo_dir, filename, _rust_source_file(start, fns_per_file, 1))
+        initial_filenames.append(filename)
+    _commit(repo_dir, "initial: seed functions", initial_filenames)
+
+    modified_filenames: list[str] = []
+    for file_index in range(file_count):
+        start = file_index * fns_per_file + 1
+        filename = f"src/src_{file_index + 1:03d}.rs"
+        _write_file(repo_dir, filename, _rust_source_file(start, fns_per_file, 2))
+        modified_filenames.append(filename)
+    _commit(repo_dir, "modified: bump every function body", modified_filenames)
+
+
+@given(
+    "a git repository with a change affecting {file_count:d} files "
+    "and {fn_count:d} modified functions",
+)
+def step_impl_large_pr_fixture(
+    context: Context, file_count: int, fn_count: int,
+) -> None:
+    """Create the deterministic large-PR fixture for the ISSUE-212 scenarios.
+
+    Both the Background (20 files / 50 functions) and the capstone Rule
+    (200 files / 1000 functions) hit this single step via parameter
+    extraction. We pick `fns_per_file` so that total function count is at
+    least the requested number — the Gherkin language says "affecting X
+    files and Y modified functions" not "exactly Y", so rounding up is fine.
+    """
+    fns_per_file = max(1, fn_count // file_count)
+    if fns_per_file * file_count < fn_count:
+        fns_per_file += 1
+    _build_large_pr_fixture(context, file_count, fns_per_file)

--- a/bdd/steps/large_pr_fixture_steps.py
+++ b/bdd/steps/large_pr_fixture_steps.py
@@ -1,8 +1,8 @@
 """Fixture builder for large-PR scenarios in the response-size guardrails feature.
 
 Builds a deterministic Rust repository with `file_count` source files, each
-containing `fns_per_file` functions with stable names (`function_01`,
-`function_02`, ...). Two commits are created: an initial commit with all
+containing `fns_per_file` functions with stable names (`function_0001`,
+`function_0002`, ...). Two commits are created: an initial commit with all
 functions returning `1`, and a modified commit where every function body is
 changed to return `2`. The git ref range between the two commits drives the
 When-steps for the ISSUE-212 scenarios.
@@ -23,19 +23,20 @@ from repo_setup_steps import _commit, _init_repo, _write_file
 def _rust_function(index: int, body_value: int) -> str:
     """Render one Rust function definition with a deterministic name.
 
-    Function names are zero-padded so lexicographic sort matches numeric sort
-    up to `function_99`. Bodies are just integer literals — tree-sitter does
-    not care about semantics.
+    Function names are zero-padded to four digits so lexicographic sort
+    matches numeric sort all the way up to `function_9999` — wide enough for
+    the 1000-function stress fixture. Bodies are just integer literals —
+    tree-sitter does not care about semantics.
     """
-    name = f"function_{index:02d}"
+    name = f"function_{index:04d}"
     return f"pub fn {name}() -> i32 {{ {body_value} }}\n"
 
 
 def _rust_source_file(start_index: int, fns_per_file: int, body_value: int) -> str:
     """Render the full content of a single Rust source file.
 
-    Functions in the file are numbered `function_{start_index:02d}` through
-    `function_{start_index + fns_per_file - 1:02d}`, each with a body of
+    Functions in the file are numbered `function_{start_index:04d}` through
+    `function_{start_index + fns_per_file - 1:04d}`, each with a body of
     `body_value`. Distinct body values across commits produce real function
     diffs that git-prism's content-aware differ will surface.
     """
@@ -66,7 +67,7 @@ def _build_large_pr_fixture(
     initial_filenames: list[str] = []
     for file_index in range(file_count):
         start = file_index * fns_per_file + 1
-        filename = f"src/src_{file_index + 1:03d}.rs"
+        filename = f"src/src_{file_index + 1:04d}.rs"
         _write_file(repo_dir, filename, _rust_source_file(start, fns_per_file, 1))
         initial_filenames.append(filename)
     _commit(repo_dir, "initial: seed functions", initial_filenames)
@@ -74,7 +75,7 @@ def _build_large_pr_fixture(
     modified_filenames: list[str] = []
     for file_index in range(file_count):
         start = file_index * fns_per_file + 1
-        filename = f"src/src_{file_index + 1:03d}.rs"
+        filename = f"src/src_{file_index + 1:04d}.rs"
         _write_file(repo_dir, filename, _rust_source_file(start, fns_per_file, 2))
         modified_filenames.append(filename)
     _commit(repo_dir, "modified: bump every function body", modified_filenames)
@@ -84,7 +85,7 @@ def _build_large_pr_fixture(
     "a git repository with a change affecting {file_count:d} files "
     "and {fn_count:d} modified functions",
 )
-def step_impl_large_pr_fixture(
+def step_build_large_pr_fixture(
     context: Context, file_count: int, fn_count: int,
 ) -> None:
     """Create the deterministic large-PR fixture for the ISSUE-212 scenarios.

--- a/bdd/steps/size_assertion_steps.py
+++ b/bdd/steps/size_assertion_steps.py
@@ -1,0 +1,416 @@
+"""Step definitions for ISSUE-212 response-size guardrail scenarios.
+
+All scenarios in `bdd/features/response_size_guardrails.feature` are tagged
+`@not_implemented` and expected to fail at the time this module lands. Every
+step therefore attempts a real operation — CLI invocation, JSON navigation,
+or direct field assertion — and surfaces a real error (CLI parse failure,
+`KeyError`, `AssertionError`) when the underlying behavior is absent.
+
+`raise NotImplementedError` and bare `pass` are forbidden by CLAUDE.md's BDD
+framework rule. The two telemetry-metric scenarios have no existing OTLP
+collector fixture that knows how to assert on the `git_prism.response.truncated`
+counter, so they use `assert False` with a TODO message pointing at the
+implementation PRs that will wire the real assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from behave import given, then, when
+from behave.runner import Context
+
+from json_steps import _ensure_json_parsed, _navigate_dotted_path
+
+
+# ---------- Shared CLI invocation helper ----------
+
+
+def _run_cli(context: Context, args: list[str]) -> None:
+    """Invoke the git-prism CLI against the fixture repo and capture output.
+
+    Mirrors the pattern in `bdd/steps/cli_steps.py::step_run_command`: uses
+    `context.binary_path` set by `environment.py::before_all` and the
+    `context.repo_path` stashed by the large-PR fixture helper. Stores the
+    completed process on `context.result` so downstream `_ensure_json_parsed`
+    can load stdout.
+    """
+    cmd = [context.binary_path, *args, "--repo", context.repo_path]
+    context.result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=context.repo_path,
+    )
+    # Reset any cached JSON from a previous step so _ensure_json_parsed
+    # re-parses the new stdout.
+    context.json_data = None
+
+
+def _manifest_args() -> list[str]:
+    """CLI args for invoking the manifest subcommand on the fixture range."""
+    return ["manifest", "HEAD~1..HEAD"]
+
+
+def _context_args() -> list[str]:
+    """CLI args for invoking the context subcommand on the fixture range."""
+    return ["context", "HEAD~1..HEAD"]
+
+
+# ---------- When: manifest invocations ----------
+
+
+@when("an agent requests the change manifest")
+def step_request_change_manifest(context: Context) -> None:
+    _run_cli(context, _manifest_args())
+
+
+@when("an agent requests the change manifest without opting in to function analysis")
+def step_request_manifest_without_function_analysis(context: Context) -> None:
+    # Default-off semantics are what PR 3 will introduce. Today the CLI
+    # hardcodes `include_function_analysis: true` in src/main.rs, so this
+    # call returns function analysis and the paired Then step will fail
+    # (RED). That is the intended state.
+    _run_cli(context, _manifest_args())
+
+
+@when("an agent requests the change manifest with function analysis enabled")
+def step_request_manifest_with_function_analysis(context: Context) -> None:
+    # `--include-function-analysis` is not yet a real CLI flag. Passing it
+    # today produces a non-zero exit and an empty stdout, which causes the
+    # paired Then step to KeyError / JSONDecodeError when it tries to
+    # navigate the response. RED.
+    _run_cli(context, [*_manifest_args(), "--include-function-analysis"])
+
+
+@when(
+    "an agent requests the change manifest with function analysis enabled "
+    "and a {budget:d} token budget",
+)
+def step_request_manifest_with_budget(context: Context, budget: int) -> None:
+    _run_cli(
+        context,
+        [
+            *_manifest_args(),
+            "--include-function-analysis",
+            "--max-response-tokens",
+            str(budget),
+        ],
+    )
+
+
+# ---------- When: context invocations ----------
+
+
+@when("an agent requests function context")
+def step_request_function_context(context: Context) -> None:
+    _run_cli(context, _context_args())
+
+
+@when("an agent requests function context without a cursor")
+def step_request_function_context_without_cursor(context: Context) -> None:
+    _run_cli(context, _context_args())
+
+
+@when("an agent requests function context without a function name filter")
+def step_request_function_context_without_filter(context: Context) -> None:
+    _run_cli(context, _context_args())
+
+
+@when("the agent requests function context with that cursor")
+def step_request_function_context_with_cursor(context: Context) -> None:
+    cursor = getattr(context, "next_cursor", None)
+    assert cursor is not None, (
+        "No next_cursor stashed on context -- the preceding Given step "
+        "should have captured one from the first-page response."
+    )
+    # Stash the first-page response for later set-intersection assertions.
+    context.first_page_response = getattr(context, "response_cache", None)
+    _run_cli(context, [*_context_args(), "--cursor", cursor])
+
+
+@when('an agent requests function context scoped to "{name1}" and "{name2}"')
+def step_request_function_context_scoped(
+    context: Context, name1: str, name2: str,
+) -> None:
+    _run_cli(
+        context,
+        [*_context_args(), "--function-names", f"{name1},{name2}"],
+    )
+
+
+@when("an agent requests function context with a {budget:d} token budget")
+def step_request_function_context_with_budget(
+    context: Context, budget: int,
+) -> None:
+    _run_cli(context, [*_context_args(), "--max-response-tokens", str(budget)])
+
+
+# ---------- Given: mid-scenario precondition ----------
+
+
+@given(
+    "an agent has retrieved the first page of function context "
+    "and received a next-page cursor",
+)
+def step_precondition_first_page_cursor(context: Context) -> None:
+    """Fetch the first page and stash its next_cursor for the follow-up When.
+
+    Today there is no paginated function context, so `metadata.next_cursor`
+    will not exist in the response. The `_navigate_dotted_path` call raises
+    `AssertionError`, failing the scenario at the Given step (which behave
+    surfaces as a scenario failure with a real traceback). That is RED.
+    """
+    _run_cli(context, _context_args())
+    data = _ensure_json_parsed(context)
+    context.response_cache = data
+    context.next_cursor = _navigate_dotted_path(data, "metadata.next_cursor")
+
+
+# ---------- Then: manifest shape assertions ----------
+
+
+@then("the response lists every changed file with summary counts")
+def step_response_lists_every_changed_file(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    files = _navigate_dotted_path(data, "files")
+    assert isinstance(files, list) and files, (
+        f"Expected a non-empty 'files' list; got {type(files).__name__} with "
+        f"length {len(files) if hasattr(files, '__len__') else 'N/A'}"
+    )
+    # Today git-prism reports `lines_added`/`lines_removed` per file. Whichever
+    # name PR 3 standardizes on, every entry must carry both counts so an
+    # agent can render the manifest without follow-up calls.
+    for entry in files:
+        for key in ("lines_added", "lines_removed"):
+            assert key in entry, (
+                f"File entry missing summary count field '{key}': "
+                f"{sorted(entry.keys())}"
+            )
+
+
+@then("the response omits per-function signature diffs")
+def step_response_omits_function_diffs(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    files = _navigate_dotted_path(data, "files")
+    offenders = [
+        entry.get("path", "<unknown>")
+        for entry in files
+        if entry.get("functions_changed")
+    ]
+    assert not offenders, (
+        "Default manifest call should omit per-function signature diffs, "
+        f"but these files carried a populated functions_changed list: {offenders}"
+    )
+
+
+@then("the response includes per-function signature diffs for files within the budget")
+def step_response_includes_function_diffs(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    files = _navigate_dotted_path(data, "files")
+    has_diff = any(entry.get("functions_changed") for entry in files)
+    assert has_diff, (
+        "Opt-in manifest call should include at least one file with a "
+        "populated functions_changed list, but none were found"
+    )
+
+
+@then("the response token_estimate is at most {limit:d}")
+def step_response_token_estimate_at_most(context: Context, limit: int) -> None:
+    data = _ensure_json_parsed(context)
+    actual = _navigate_dotted_path(data, "metadata.token_estimate")
+    assert isinstance(actual, int), (
+        f"metadata.token_estimate should be an int, got {type(actual).__name__}"
+    )
+    assert actual <= limit, (
+        f"metadata.token_estimate = {actual} exceeds budget {limit}"
+    )
+
+
+@then("the response metadata lists every file whose function detail was trimmed")
+def step_response_lists_trimmed_files(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    trimmed = _navigate_dotted_path(data, "metadata.function_analysis_truncated")
+    assert isinstance(trimmed, list) and trimmed, (
+        f"metadata.function_analysis_truncated should be a non-empty list, "
+        f"got {type(trimmed).__name__} with value {trimmed!r}"
+    )
+
+
+@then("the trimmed files preserve their function signatures")
+def step_response_trimmed_files_preserve_signatures(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    trimmed_paths = _navigate_dotted_path(data, "metadata.function_analysis_truncated")
+    files_by_path = {entry.get("path"): entry for entry in data.get("files", [])}
+    for path in trimmed_paths:
+        entry = files_by_path.get(path)
+        assert entry is not None, (
+            f"Trimmed file {path!r} not found in top-level files list"
+        )
+        functions_changed = entry.get("functions_changed") or []
+        assert functions_changed, (
+            f"Trimmed file {path!r} should still carry function signatures, "
+            f"but functions_changed is empty"
+        )
+        for fn in functions_changed:
+            signature = fn.get("signature")
+            assert signature, (
+                f"Trimmed function in {path!r} is missing its signature: {fn}"
+            )
+            assert not fn.get("body"), (
+                f"Trimmed function in {path!r} should have its body dropped, "
+                f"but body is still present: {fn.get('body')!r}"
+            )
+
+
+@then("the response metadata includes a token_estimate for the payload")
+def step_response_metadata_token_estimate(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    estimate = _navigate_dotted_path(data, "metadata.token_estimate")
+    assert isinstance(estimate, int) and estimate >= 0, (
+        f"metadata.token_estimate should be a non-negative int, got {estimate!r}"
+    )
+
+
+# ---------- Then: function context shape assertions ----------
+
+
+@then("the response contains the first page of changed functions in deterministic order")
+def step_response_first_page_deterministic(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    assert isinstance(functions, list) and functions, (
+        f"Expected a non-empty 'functions' list, got {type(functions).__name__}"
+    )
+    names = [fn.get("name") for fn in functions]
+    assert names == sorted(names), (
+        f"Function list is not in deterministic (sorted) order: {names[:10]}..."
+    )
+
+
+@then("the response metadata includes a next-page cursor")
+def step_response_metadata_next_cursor(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    cursor = _navigate_dotted_path(data, "metadata.next_cursor")
+    assert cursor, (
+        f"metadata.next_cursor should be a non-empty string, got {cursor!r}"
+    )
+
+
+@then("the response contains the next page of changed functions")
+def step_response_next_page(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    assert isinstance(functions, list) and functions, (
+        f"Expected a non-empty 'functions' list on page 2, got "
+        f"{type(functions).__name__}"
+    )
+
+
+@then("no function appears in both pages")
+def step_response_no_overlap(context: Context) -> None:
+    first_page = getattr(context, "first_page_response", None)
+    assert first_page is not None, (
+        "first_page_response missing -- the Given step that captures the "
+        "first page did not run"
+    )
+    second_page = _ensure_json_parsed(context)
+    first_names = {fn.get("name") for fn in first_page.get("functions", [])}
+    second_names = {fn.get("name") for fn in second_page.get("functions", [])}
+    overlap = first_names & second_names
+    assert not overlap, f"Functions appeared in both pages: {sorted(overlap)}"
+
+
+@then("the response contains exactly those two functions")
+def step_response_contains_exact_two(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    names = sorted(fn.get("name") for fn in functions)
+    assert names == ["function_01", "function_02"], (
+        f"Filter should return exactly ['function_01', 'function_02'], "
+        f"got {names}"
+    )
+
+
+@then("functions outside the filter are not included")
+def step_response_functions_outside_filter_excluded(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    offenders = [
+        fn.get("name")
+        for fn in functions
+        if fn.get("name") not in {"function_01", "function_02"}
+    ]
+    assert not offenders, (
+        f"Filter leaked functions outside the allow-list: {offenders}"
+    )
+
+
+@then("at least one function entry is marked as truncated")
+def step_response_at_least_one_truncated(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    truncated = [fn for fn in functions if fn.get("truncated")]
+    assert truncated, (
+        "Expected at least one function entry with truncated=true, "
+        "but none were flagged"
+    )
+
+
+@then("the truncated entries have shortened caller and callee lists")
+def step_response_truncated_entries_shortened(context: Context) -> None:
+    data = _ensure_json_parsed(context)
+    functions = _navigate_dotted_path(data, "functions")
+    truncated = [fn for fn in functions if fn.get("truncated")]
+    assert truncated, "No truncated entries to inspect"
+    non_truncated = [fn for fn in functions if not fn.get("truncated")]
+    if not non_truncated:
+        # Without a baseline, assert the absolute shape instead.
+        for fn in truncated:
+            callers = fn.get("callers") or []
+            callees = fn.get("callees") or []
+            assert len(callers) + len(callees) == 0 or fn.get("truncation_reason"), (
+                f"Truncated function {fn.get('name')!r} should either have "
+                "empty caller/callee lists or carry a truncation_reason field"
+            )
+        return
+    baseline_callers = max(len(fn.get("callers") or []) for fn in non_truncated)
+    baseline_callees = max(len(fn.get("callees") or []) for fn in non_truncated)
+    for fn in truncated:
+        callers = fn.get("callers") or []
+        callees = fn.get("callees") or []
+        assert len(callers) < baseline_callers or len(callees) < baseline_callees, (
+            f"Truncated function {fn.get('name')!r} has "
+            f"{len(callers)} callers and {len(callees)} callees, "
+            f"not shorter than the non-truncated baseline "
+            f"({baseline_callers} / {baseline_callees})"
+        )
+
+
+# ---------- Then: telemetry metric assertion (placeholder) ----------
+
+
+@then(
+    "the git_prism.response.truncated metric records a {reason} event "
+    "for {tool}",
+)
+def step_telemetry_metric_truncation(
+    context: Context, reason: str, tool: str,
+) -> None:
+    """Placeholder for the OTLP truncation metric assertion.
+
+    PR 1 intentionally does not wire a telemetry collector fixture for the
+    `git_prism.response.truncated` counter -- that plumbing arrives with the
+    implementation PRs (#3 for manifest, #4 for function context). Forcing a
+    deterministic RED here keeps the scenario @not_implemented until those
+    PRs remove the tag. See the stack plan in issue #212 for details.
+    """
+    assert False, (
+        f"telemetry assertion path not wired in PR 1 scaffold -- "
+        f"expected git_prism.response.truncated event with "
+        f"reason={reason!r} for tool={tool!r}. "
+        f"Implementation PR 3 (manifest) / PR 4 (context) will wire the "
+        f"real assertion via bdd/steps/telemetry_steps.py."
+    )

--- a/bdd/steps/size_assertion_steps.py
+++ b/bdd/steps/size_assertion_steps.py
@@ -15,9 +15,7 @@ implementation PRs that will wire the real assertion.
 
 from __future__ import annotations
 
-import json
 import subprocess
-from typing import Any
 
 from behave import given, then, when
 from behave.runner import Context
@@ -64,24 +62,26 @@ def _context_args() -> list[str]:
 
 @when("an agent requests the change manifest")
 def step_request_change_manifest(context: Context) -> None:
+    """Invoke `git-prism manifest` with default flags to exercise the baseline
+    MCP change-manifest path agents hit first."""
     _run_cli(context, _manifest_args())
 
 
 @when("an agent requests the change manifest without opting in to function analysis")
 def step_request_manifest_without_function_analysis(context: Context) -> None:
-    # Default-off semantics are what PR 3 will introduce. Today the CLI
-    # hardcodes `include_function_analysis: true` in src/main.rs, so this
-    # call returns function analysis and the paired Then step will fail
-    # (RED). That is the intended state.
+    """Invoke the default manifest path to assert that function analysis is
+    off by default. RED today because the CLI hardcodes
+    `include_function_analysis: true` in src/main.rs; PR 3 will introduce the
+    default-off semantics that make the paired Then step pass."""
     _run_cli(context, _manifest_args())
 
 
 @when("an agent requests the change manifest with function analysis enabled")
 def step_request_manifest_with_function_analysis(context: Context) -> None:
-    # `--include-function-analysis` is not yet a real CLI flag. Passing it
-    # today produces a non-zero exit and an empty stdout, which causes the
-    # paired Then step to KeyError / JSONDecodeError when it tries to
-    # navigate the response. RED.
+    """Invoke the manifest with the opt-in flag to exercise the function-
+    analysis path. RED today because `--include-function-analysis` is not yet
+    a real CLI flag — passing it produces a non-zero exit and empty stdout,
+    and the paired Then step fails when it tries to navigate the response."""
     _run_cli(context, [*_manifest_args(), "--include-function-analysis"])
 
 
@@ -90,6 +90,8 @@ def step_request_manifest_with_function_analysis(context: Context) -> None:
     "and a {budget:d} token budget",
 )
 def step_request_manifest_with_budget(context: Context, budget: int) -> None:
+    """Invoke the manifest with function analysis and an explicit token
+    budget to exercise the budget-clamping path."""
     _run_cli(
         context,
         [
@@ -106,16 +108,22 @@ def step_request_manifest_with_budget(context: Context, budget: int) -> None:
 
 @when("an agent requests function context")
 def step_request_function_context(context: Context) -> None:
+    """Invoke `git-prism context` with default flags to exercise the baseline
+    function-context path agents hit after seeing a manifest."""
     _run_cli(context, _context_args())
 
 
 @when("an agent requests function context without a cursor")
 def step_request_function_context_without_cursor(context: Context) -> None:
+    """Invoke the context call with no cursor argument to exercise the
+    first-page pagination path."""
     _run_cli(context, _context_args())
 
 
 @when("an agent requests function context without a function name filter")
 def step_request_function_context_without_filter(context: Context) -> None:
+    """Invoke the context call with no name filter to exercise the unfiltered
+    response path on an extreme-change fixture."""
     _run_cli(context, _context_args())
 
 
@@ -135,6 +143,8 @@ def step_request_function_context_with_cursor(context: Context) -> None:
 def step_request_function_context_scoped(
     context: Context, name1: str, name2: str,
 ) -> None:
+    """Invoke the context call with an explicit two-name filter to exercise
+    the name-scoping path."""
     _run_cli(
         context,
         [*_context_args(), "--function-names", f"{name1},{name2}"],
@@ -145,6 +155,8 @@ def step_request_function_context_scoped(
 def step_request_function_context_with_budget(
     context: Context, budget: int,
 ) -> None:
+    """Invoke the context call with an explicit token budget to exercise the
+    budget-clamping path for callers and callees."""
     _run_cli(context, [*_context_args(), "--max-response-tokens", str(budget)])
 
 
@@ -210,10 +222,11 @@ def step_response_omits_function_diffs(context: Context) -> None:
 def step_response_includes_function_diffs(context: Context) -> None:
     data = _ensure_json_parsed(context)
     files = _navigate_dotted_path(data, "files")
-    has_diff = any(entry.get("functions_changed") for entry in files)
-    assert has_diff, (
-        "Opt-in manifest call should include at least one file with a "
-        "populated functions_changed list, but none were found"
+    with_diffs = sum(1 for entry in files if entry.get("functions_changed"))
+    total = len(files)
+    assert with_diffs == total, (
+        f"expected every changed file to carry function detail when opted in; "
+        f"got {with_diffs} of {total}. RED until PR 3 lands the opt-in handler."
     )
 
 
@@ -269,8 +282,9 @@ def step_response_trimmed_files_preserve_signatures(context: Context) -> None:
 def step_response_metadata_token_estimate(context: Context) -> None:
     data = _ensure_json_parsed(context)
     estimate = _navigate_dotted_path(data, "metadata.token_estimate")
-    assert isinstance(estimate, int) and estimate >= 0, (
-        f"metadata.token_estimate should be a non-negative int, got {estimate!r}"
+    assert isinstance(estimate, int) and estimate > 0, (
+        f"expected a positive integer token_estimate, got {estimate!r} "
+        f"(type {type(estimate).__name__}). RED until PR 2 lands token_estimate metadata."
     )
 
 
@@ -294,8 +308,9 @@ def step_response_first_page_deterministic(context: Context) -> None:
 def step_response_metadata_next_cursor(context: Context) -> None:
     data = _ensure_json_parsed(context)
     cursor = _navigate_dotted_path(data, "metadata.next_cursor")
-    assert cursor, (
-        f"metadata.next_cursor should be a non-empty string, got {cursor!r}"
+    assert isinstance(cursor, str) and cursor, (
+        f"expected a non-empty string cursor, got {cursor!r} "
+        f"(type {type(cursor).__name__}). RED until PR 4 lands pagination."
     )
 
 
@@ -327,9 +342,9 @@ def step_response_no_overlap(context: Context) -> None:
 def step_response_contains_exact_two(context: Context) -> None:
     data = _ensure_json_parsed(context)
     functions = _navigate_dotted_path(data, "functions")
-    names = sorted(fn.get("name") for fn in functions)
-    assert names == ["function_01", "function_02"], (
-        f"Filter should return exactly ['function_01', 'function_02'], "
+    names = sorted(fn.get("name") or "" for fn in functions)
+    assert names == ["function_0001", "function_0002"], (
+        f"Filter should return exactly ['function_0001', 'function_0002'], "
         f"got {names}"
     )
 
@@ -341,7 +356,7 @@ def step_response_functions_outside_filter_excluded(context: Context) -> None:
     offenders = [
         fn.get("name")
         for fn in functions
-        if fn.get("name") not in {"function_01", "function_02"}
+        if fn.get("name") not in {"function_0001", "function_0002"}
     ]
     assert not offenders, (
         f"Filter leaked functions outside the allow-list: {offenders}"


### PR DESCRIPTION
## Summary

PR 1 of 4 in the stack for issue #212 (response-size guardrails and pagination for `get_change_manifest` and `get_function_context`). This PR introduces the executable BDD contract — the RED-state scaffold — before any production code changes land. Every scenario here is expected to fail until PRs 2–4 implement the corresponding behavior.

- Adds `bdd/features/response_size_guardrails.feature` — 13 scenarios across 5 `Rule:` groupings, tagged `@ISSUE-212 @not_implemented`
- Adds `bdd/steps/large_pr_fixture_steps.py` — parametrized `_build_large_pr_fixture(context, file_count, fns_per_file)` helper that reuses `_init_repo` / `_write_file` / `_commit` from `bdd/steps/repo_setup_steps.py`
- Adds `bdd/steps/size_assertion_steps.py` — `@when` and `@then` step definitions that invoke the CLI via subprocess (matching the existing `bdd/steps/cli_steps.py` pattern) and assert on JSON responses using `_navigate_dotted_path` from `bdd/steps/json_steps.py`

## Why

Per CLAUDE.md's BDD framework rule, acceptance scenarios must be written BEFORE implementation begins — tagged `@ISSUE-212 @not_implemented`, failing with real assertion errors (not `NotImplementedError` or `pass`), so that CI is aware of the contract but doesn't block on it until each implementation PR removes the tag as its first commit. This produces a clean RED → GREEN trail in git history per implementation PR:

- **PR 2** (shared infra) will remove `@not_implemented` from the two `token_estimate surfacing` scenarios as its first commit
- **PR 3** (manifest budget + breaking default flip) will remove it from the four manifest scenarios plus the capstone `Change manifest stays within the 8192 token budget on an extreme change`
- **PR 4** (function context pagination) will remove it from the five function context scenarios plus the capstone `Function context stays within the 8192 token budget on an extreme change`. PR 4 is the final PR in the stack and is the one that finally marks the umbrella issue done.

## Feature structure

```gherkin
@ISSUE-212 @not_implemented
Feature: Bounded tool responses
  ...
  Background:
    Given a git repository with a change affecting 20 files and 50 modified functions

  Rule: get_change_manifest defaults to a cheap response; function analysis is opt-in
    Scenario: Default manifest call omits function analysis
    Scenario: Opt-in manifest call includes function analysis

  Rule: get_change_manifest clamps function detail to its token budget
    Scenario: Over-budget manifest trims function detail to signatures only
    Scenario: Over-budget manifest emits the token_budget truncation metric
    Scenario: Change manifest reports its payload size for budgeting follow-up calls

  Rule: get_function_context paginates over changed functions
    Scenario: Default function context call returns the first page with a next-page cursor
    Scenario: Cursor advances through remaining functions
    Scenario: Agents can scope function context to a specific name list

  Rule: get_function_context clamps caller and callee detail to its token budget
    Scenario: Over-budget context trims per-function caller and callee lists
    Scenario: Over-budget context emits the token_budget truncation metric
    Scenario: Function context reports its payload size for budgeting follow-up calls

  Rule: Read tools stay within their token budget regardless of change size
    Scenario: Change manifest stays within the 8192 token budget on an extreme change
    Scenario: Function context stays within the 8192 token budget on an extreme change
```

Thirteen scenarios. Five `Rule:` groupings. Every scenario is single-behavior (one `When`, then `Then`/`And` assertions). Scenario titles describe observable agent-facing behavior — no leaked field names like `token_estimate` or flag names like `function_names`. Steps use declarative "an agent requests …" phrasing rather than imperative "I run CLI with flag X".

## Gauntlet

Full pre-review gauntlet ran against the diff (14 church purists + python-purist). Eleven returned NO_FINDINGS or N/A. Three flagged actionable items, all addressed in commit 2 (`e7d2878`):

- **test-purist** — initial assertions were too loose (`any(files carry function detail)`, `assert cursor` for truthiness, `assert token_estimate >= 0`). Tightened to require every opted-in file to carry function detail, cursors to be non-empty strings, and token estimates to be strictly positive integers. Latent `:02d` padding landmine for the 1000-function stress fixture widened to `:04d` so `function_100` doesn't sort before `function_11`.
- **python-purist** — unused `json` and `typing.Any` imports dropped. Seven undocumented `@when` step handlers received one-line docstrings. Defensive `or ""` added to the `sorted()` name comparison to prevent a cryptic `TypeError` on a `None` name.
- **naming-purist** — three scenario titles leaked implementation identifiers (`token_estimate`, `function name filter`); rephrased to behavior-focused titles. Rule name `Both read tools stay within budget on an extreme change` rephrased to `Read tools stay within their token budget regardless of change size` (was a fixture category, now a business rule). `step_impl_large_pr_fixture` renamed to `step_build_large_pr_fixture` to match the `step_<verb>_<description>` convention used in `cli_steps.py` and `json_steps.py`.

## Verification

- [x] `python -m py_compile bdd/steps/large_pr_fixture_steps.py bdd/steps/size_assertion_steps.py` — both modules parse
- [x] `behave --tags="@ISSUE-212"` — 13 scenarios: 0 passing, 8 failed, 5 errored — all with real assertion errors (no `NotImplementedError`, no bare `pass`). `assert False` appears only in the one parameterized step that serves the four telemetry-metric assertions, with an explanatory message and forward pointer to PRs 3/4 for the OTLP collector wiring
- [x] `behave --tags="~@not_implemented"` — 18 features / 90 scenarios / 478 steps passed, 13 scenarios skipped (exactly the new `@ISSUE-212` set). Baseline unchanged
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 614 passed, 0 failed
- [x] Lefthook pre-push hook ran `fmt + clippy + test` on every push — all green

## Commits

1. `5360f23 test(bdd): scaffold issue-212 size guardrail scenarios @not_implemented` — the initial scaffold (feature file, fixture helper, assertion steps)
2. `e7d2878 test(bdd): tighten issue-212 scaffold per gauntlet findings` — the test-purist / python-purist / naming-purist cleanups

## Deferred

These items surfaced during the gauntlet but are out of scope for PR 1. Flagged for follow-up:

- **OTLP collector fixture for metric assertions.** The four telemetry-metric steps use `assert False` with an explanatory message because `bdd/steps/telemetry_steps.py` doesn't yet have a helper for asserting on specific metric counters (only traces). PR 3 / PR 4 will extend that module when they wire the emission code.
- **Missing default-budget coverage scenario.** Per test-purist, #212's acceptance criterion "default output under 8k tokens" is covered transitively via the extreme-change capstone but not directly on the default 20-file / 50-function fixture. Consider adding a scenario in PR 3.
- **Function name filter edge cases.** Only the happy path is covered (filter matches two names). Nonexistent name, single name, filter + budget combined — deferred to PR 4.
- **Duplicated loop in `_build_large_pr_fixture`.** python-purist flagged the initial/modified commit loops as duplicated but extracting a helper was out of scope for a scaffold PR.

Part of #212.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
