### PR TITLE
feat(metrics)!: add token_estimate helper and bounded truncation reasons

### DIFF
--- a/bdd/features/response_size_guardrails.feature
+++ b/bdd/features/response_size_guardrails.feature
@@ -1,4 +1,4 @@
-@ISSUE-212 @not_implemented
+@ISSUE-212
 Feature: Bounded tool responses
   The cheap read tools `get_change_manifest` and `get_function_context` advertise
   themselves as first- and second-resort calls that should fit comfortably inside
@@ -14,23 +14,27 @@ Feature: Bounded tool responses
 
   Rule: get_change_manifest defaults to a cheap response; function analysis is opt-in
 
+    @not_implemented
     Scenario: Default manifest call omits function analysis
       When an agent requests the change manifest without opting in to function analysis
       Then the response lists every changed file with summary counts
       And the response omits per-function signature diffs
 
+    @not_implemented
     Scenario: Opt-in manifest call includes function analysis
       When an agent requests the change manifest with function analysis enabled
       Then the response includes per-function signature diffs for files within the budget
 
   Rule: get_change_manifest clamps function detail to its token budget
 
+    @not_implemented
     Scenario: Over-budget manifest trims function detail to signatures only
       When an agent requests the change manifest with function analysis enabled and a 512 token budget
       Then the response token_estimate is at most 512
       And the response metadata lists every file whose function detail was trimmed
       And the trimmed files preserve their function signatures
 
+    @not_implemented
     Scenario: Over-budget manifest emits the token_budget truncation metric
       When an agent requests the change manifest with function analysis enabled and a 512 token budget
       Then the git_prism.response.truncated metric records a token_budget event for get_change_manifest
@@ -41,17 +45,20 @@ Feature: Bounded tool responses
 
   Rule: get_function_context paginates over changed functions
 
+    @not_implemented
     Scenario: Default function context call returns the first page with a next-page cursor
       When an agent requests function context without a cursor
       Then the response contains the first page of changed functions in deterministic order
       And the response metadata includes a next-page cursor
 
+    @not_implemented
     Scenario: Cursor advances through remaining functions
       Given an agent has retrieved the first page of function context and received a next-page cursor
       When the agent requests function context with that cursor
       Then the response contains the next page of changed functions
       And no function appears in both pages
 
+    @not_implemented
     Scenario: Agents can scope function context to a specific name list
       When an agent requests function context scoped to "function_0001" and "function_0002"
       Then the response contains exactly those two functions
@@ -59,12 +66,14 @@ Feature: Bounded tool responses
 
   Rule: get_function_context clamps caller and callee detail to its token budget
 
+    @not_implemented
     Scenario: Over-budget context trims per-function caller and callee lists
       When an agent requests function context with a 512 token budget
       Then the response token_estimate is at most 512
       And at least one function entry is marked as truncated
       And the truncated entries have shortened caller and callee lists
 
+    @not_implemented
     Scenario: Over-budget context emits the token_budget truncation metric
       When an agent requests function context with a 512 token budget
       Then the git_prism.response.truncated metric records a token_budget event for get_function_context
@@ -75,6 +84,7 @@ Feature: Bounded tool responses
 
   Rule: Read tools stay within their token budget regardless of change size
 
+    @not_implemented
     Scenario: Change manifest stays within the 8192 token budget on an extreme change
       Given a git repository with a change affecting 200 files and 1000 modified functions
       When an agent requests the change manifest with function analysis enabled
@@ -82,6 +92,7 @@ Feature: Bounded tool responses
       And the response metadata lists every file whose function detail was trimmed
       And the git_prism.response.truncated metric records a token_budget event for get_change_manifest
 
+    @not_implemented
     Scenario: Function context stays within the 8192 token budget on an extreme change
       Given a git repository with a change affecting 200 files and 1000 modified functions
       When an agent requests function context without a function name filter

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -343,13 +343,39 @@ mod tests {
 
     #[test]
     fn it_normalizes_unknown_truncation_reason_without_panicking() {
-        // Indirect behavior check: an unrecognized reason string must pass
-        // through record_truncated cleanly, because classify_truncation_reason
-        // folds it to "unknown" at the metric boundary. The real per-arm
-        // assertion lives in src/privacy.rs::tests; this test locks in the
-        // wiring so a future refactor that drops the normalization call would
-        // fail to compile or panic here.
+        // The global meter is a no-op in unit tests, so we cannot read back
+        // the attribute value record_truncated emits. That makes the final
+        // three calls below a smoke test for the call path, NOT a substitute
+        // for the per-arm assertions on classify_truncation_reason that live
+        // in src/privacy.rs::tests.
+        //
+        // To keep the "record_truncated goes through the classifier" wiring
+        // honest without observing the meter, the assertions below also
+        // exercise the classifier directly on the same inputs. A mutation
+        // that removed the classify_truncation_reason call from
+        // record_truncated would leave the emitted label unbounded — and
+        // while THIS test cannot observe that directly, the type signature
+        // of `KeyValue::new("reason", normalized)` inside record_truncated
+        // requires a `&'static str`, so any mutant that tried to substitute
+        // the raw `reason: &str` parameter would fail to compile.
         let metrics = Metrics::new();
+
+        // Known labels must pass through unchanged.
+        assert_eq!(
+            crate::privacy::classify_truncation_reason("paginated"),
+            "paginated",
+        );
+        assert_eq!(
+            crate::privacy::classify_truncation_reason("token_budget"),
+            "token_budget",
+        );
+        // Unrecognized labels must fold to the "unknown" safety-net arm so
+        // metric cardinality stays bounded.
+        assert_eq!(
+            crate::privacy::classify_truncation_reason("wildly_unrecognized_reason_42"),
+            "unknown",
+        );
+
         metrics.record_truncated("test_tool", "wildly_unrecognized_reason_42");
         metrics.record_truncated("test_tool", "paginated");
         metrics.record_truncated("test_tool", "token_budget");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -221,11 +221,16 @@ impl Metrics {
     }
 
     pub fn record_truncated(&self, tool: &str, reason: &str) {
+        // Normalize at the metric boundary so attribute cardinality on the
+        // `reason` label is bounded by construction regardless of what the
+        // caller passes. The classifier is a flat exact-match — see
+        // `crate::privacy::classify_truncation_reason` for the full rationale.
+        let normalized = crate::privacy::classify_truncation_reason(reason);
         self.response_truncated.add(
             1,
             &[
                 KeyValue::new("tool", tool.to_string()),
-                KeyValue::new("reason", reason.to_string()),
+                KeyValue::new("reason", normalized),
             ],
         );
     }
@@ -334,5 +339,19 @@ mod tests {
         ] {
             metrics.record_error("test_tool", kind);
         }
+    }
+
+    #[test]
+    fn it_normalizes_unknown_truncation_reason_without_panicking() {
+        // Indirect behavior check: an unrecognized reason string must pass
+        // through record_truncated cleanly, because classify_truncation_reason
+        // folds it to "unknown" at the metric boundary. The real per-arm
+        // assertion lives in src/privacy.rs::tests; this test locks in the
+        // wiring so a future refactor that drops the normalization call would
+        // fail to compile or panic here.
+        let metrics = Metrics::new();
+        metrics.record_truncated("test_tool", "wildly_unrecognized_reason_42");
+        metrics.record_truncated("test_tool", "paginated");
+        metrics.record_truncated("test_tool", "token_budget");
     }
 }

--- a/src/privacy.rs
+++ b/src/privacy.rs
@@ -94,6 +94,24 @@ pub fn classify_ref_mode(base_ref: &str, head_ref: Option<&str>) -> &'static str
     }
 }
 
+/// Maps raw truncation-reason strings to a bounded label set for metrics.
+///
+/// Unlike [`classify_error_kind`], which does substring matching on error
+/// messages coming from third-party libraries, this function uses a flat
+/// exact match because the caller is always the codebase itself passing a
+/// known-good literal. An exhaustive match means mutation testing can kill
+/// every arm cleanly, and `unknown` exists as a safety net for future
+/// refactors that might introduce a typo or a forgotten label.
+pub fn classify_truncation_reason(reason: &str) -> &'static str {
+    match reason {
+        "paginated" => "paginated",
+        "max_files" => "max_files",
+        "max_file_size" => "max_file_size",
+        "token_budget" => "token_budget",
+        _ => "unknown",
+    }
+}
+
 /// Maps error description strings to a bounded label set for metrics.
 pub fn classify_error_kind(err: &str) -> &'static str {
     let lower = err.to_lowercase();
@@ -337,5 +355,38 @@ mod tests {
         assert_eq!(classify_ref_mode("main", Some("HEAD")), "branch");
         assert_eq!(classify_ref_mode("HEAD~3", Some("HEAD")), "single_commit");
         assert_eq!(classify_ref_mode(&"a".repeat(40), Some("HEAD")), "sha");
+    }
+
+    // --- classify_truncation_reason ---
+    //
+    // One test per arm so mutation testing can point at exactly one killed
+    // mutant per test. The final "unknown" test covers both the fallthrough
+    // arm and the safety-net behavior for unrecognized labels.
+
+    #[test]
+    fn it_classifies_paginated_as_paginated() {
+        assert_eq!(classify_truncation_reason("paginated"), "paginated");
+    }
+
+    #[test]
+    fn it_classifies_max_files_as_max_files() {
+        assert_eq!(classify_truncation_reason("max_files"), "max_files");
+    }
+
+    #[test]
+    fn it_classifies_max_file_size_as_max_file_size() {
+        assert_eq!(classify_truncation_reason("max_file_size"), "max_file_size");
+    }
+
+    #[test]
+    fn it_classifies_token_budget_as_token_budget() {
+        assert_eq!(classify_truncation_reason("token_budget"), "token_budget");
+    }
+
+    #[test]
+    fn it_classifies_unknown_reason_as_unknown() {
+        assert_eq!(classify_truncation_reason("TOKEN_BUDGET"), "unknown");
+        assert_eq!(classify_truncation_reason("something_else"), "unknown");
+        assert_eq!(classify_truncation_reason(""), "unknown");
     }
 }

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -497,6 +497,27 @@ mod tests {
     }
 
     #[test]
+    fn it_reports_a_positive_token_estimate_for_a_non_trivial_context_response() {
+        // Symmetric with manifest.rs::it_reports_a_positive_token_estimate_for_a_non_trivial_manifest.
+        // The fixture repo produces several changed functions plus callers
+        // and callees, so the serialized response is well over 4 characters
+        // and the two-pass estimate must be strictly positive. Without this
+        // test, a mutation that replaced the `estimate_response_tokens`
+        // call in build_function_context with a hardcoded `0` would escape:
+        // no other test reads metadata.token_estimate on the context path.
+        // Exact value is not asserted because metadata.generated_at varies
+        // at runtime; we only lock in the "wired and > 0" contract.
+        let (_dir, path) = create_context_test_repo();
+        let result = build_function_context(&path, "HEAD~1", "HEAD").unwrap();
+
+        assert!(
+            result.metadata.token_estimate > 0,
+            "expected a positive token_estimate on a non-trivial function context response, got {}",
+            result.metadata.token_estimate,
+        );
+    }
+
+    #[test]
     fn leaf_function_name_extracts_simple() {
         assert_eq!(leaf_function_name("foo"), "foo");
     }

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -262,16 +262,20 @@ pub fn build_function_context(
     _root_span.record("files_scanned", file_calls.len() as i64);
     _root_span.record("total_callers_found", total_callers as i64);
 
-    Ok(FunctionContextResponse {
+    let mut response = FunctionContextResponse {
         metadata: ContextMetadata {
             base_ref: base_ref.to_string(),
             head_ref: head_ref.to_string(),
             base_sha: base_commit.sha,
             head_sha: head_commit.sha,
             generated_at: Utc::now(),
+            // Placeholder; see build_manifest for the two-pass estimate trick.
+            token_estimate: 0,
         },
         functions: function_entries,
-    })
+    };
+    response.metadata.token_estimate = crate::tools::size::estimate_response_tokens(&response);
+    Ok(response)
 }
 
 /// Extract the callees (functions called) from a specific function's body.

--- a/src/tools/manifest.rs
+++ b/src/tools/manifest.rs
@@ -8,6 +8,7 @@ use crate::git::diff::ChangeType;
 use crate::git::generated::GeneratedFileDetector;
 use crate::git::reader::RepoReader;
 use crate::pagination::{PaginationCursor, PaginationInfo, encode_cursor};
+use crate::tools::size;
 use crate::tools::types::{
     FunctionChange, FunctionChangeType, ImportChange, ManifestFileEntry, ManifestMetadata,
     ManifestOptions, ManifestResponse, ManifestSummary, ToolError, detect_language,
@@ -368,7 +369,7 @@ pub fn build_manifest(
         languages_affected: all_languages_affected,
     };
 
-    Ok(ManifestResponse {
+    let mut response = ManifestResponse {
         metadata: ManifestMetadata {
             repo_path: repo_path.display().to_string(),
             base_ref: base_ref.to_string(),
@@ -377,6 +378,10 @@ pub fn build_manifest(
             head_sha: head_commit.sha,
             generated_at: Utc::now(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            // Placeholder; overwritten below via a two-pass estimate so the
+            // final value reflects the fully-populated response. See the
+            // ManifestMetadata::token_estimate doc comment for the caveat.
+            token_estimate: 0,
         },
         summary,
         files: manifest_files,
@@ -387,7 +392,9 @@ pub fn build_manifest(
             page_size,
             next_cursor,
         },
-    })
+    };
+    response.metadata.token_estimate = size::estimate_response_tokens(&response);
+    Ok(response)
 }
 
 /// Build a manifest comparing a committed ref against the current working tree.
@@ -591,7 +598,7 @@ pub fn build_worktree_manifest(
         languages_affected: all_languages_affected,
     };
 
-    Ok(ManifestResponse {
+    let mut response = ManifestResponse {
         metadata: ManifestMetadata {
             repo_path: repo_path.display().to_string(),
             base_ref: base_ref.to_string(),
@@ -600,6 +607,8 @@ pub fn build_worktree_manifest(
             head_sha: "WORKTREE".to_string(),
             generated_at: Utc::now(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            // Placeholder; see build_manifest for the two-pass rationale.
+            token_estimate: 0,
         },
         summary,
         files: manifest_files,
@@ -610,7 +619,9 @@ pub fn build_worktree_manifest(
             page_size,
             next_cursor,
         },
-    })
+    };
+    response.metadata.token_estimate = size::estimate_response_tokens(&response);
+    Ok(response)
 }
 
 fn read_worktree_file(repo_path: &Path, file_path: &str) -> Option<String> {
@@ -1196,6 +1207,27 @@ mod tests {
             .unwrap();
 
         (dir, path)
+    }
+
+    #[test]
+    fn it_reports_a_positive_token_estimate_for_a_non_trivial_manifest() {
+        let (_dir, path) = create_repo_with_go_file();
+        let options = ManifestOptions {
+            include_patterns: vec![],
+            exclude_patterns: vec![],
+            include_function_analysis: true,
+        };
+        let manifest = build_manifest(&path, "HEAD~1", "HEAD", &options, 0, 200).unwrap();
+
+        // The response includes two changed files plus function/import detail,
+        // so the serialized JSON is well over 4 characters and the estimate
+        // must be strictly positive. Exact value is not asserted because it
+        // depends on metadata fields like `generated_at` that vary at runtime.
+        assert!(
+            manifest.metadata.token_estimate > 0,
+            "expected a positive token_estimate on a non-trivial manifest response, got {}",
+            manifest.metadata.token_estimate,
+        );
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod history;
 pub mod import_scope;
 pub mod manifest;
+pub mod size;
 pub mod snapshots;
 pub mod types;
 

--- a/src/tools/size.rs
+++ b/src/tools/size.rs
@@ -1,0 +1,115 @@
+//! Response-size estimation helpers shared by the MCP tool handlers.
+//!
+//! These live in their own module so the pagination / token-budget work in
+//! later PRs of issue #212 can import a single canonical estimate function
+//! instead of re-deriving the "~4 characters per token" rule at every call
+//! site. Keeping the function free (rather than a method on a type) matches
+//! the rest of `src/tools/` where pure utilities are free functions and stateful
+//! orchestration lives on structs.
+
+use serde::Serialize;
+
+/// Estimate the number of tokens in a serialized JSON payload from its character
+/// count, using the standard "~4 characters per token" heuristic.
+///
+/// `char_count` is the length of the UTF-8 JSON payload in bytes or characters —
+/// for ASCII-heavy JSON the two are equivalent, and the helper deliberately
+/// accepts whichever the caller has cheapest to compute. Uses integer division
+/// (floor), which matches the existing inline implementation in
+/// [`crate::tools::snapshots`] so the refactor there is a behavior-preserving
+/// swap.
+#[must_use]
+pub fn estimate_tokens(char_count: usize) -> usize {
+    char_count / 4
+}
+
+/// Estimate tokens for any `Serialize` value by serializing it to JSON and
+/// applying [`estimate_tokens`] to the resulting string length.
+///
+/// Returns `0` if serialization fails. For types that derive `Serialize`
+/// cleanly this is effectively unreachable, but we prefer a degraded budgeting
+/// hint over a panic at the metric boundary. Callers that care about real
+/// serialization errors should serialize themselves — this helper is meant
+/// to be called right before returning a response struct that will be
+/// serialized anyway, where a failure here would also break the actual
+/// response.
+#[must_use]
+pub fn estimate_response_tokens<T: Serialize>(value: &T) -> usize {
+    serde_json::to_string(value)
+        .map(|s| estimate_tokens(s.len()))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_returns_zero_for_zero_chars() {
+        assert_eq!(estimate_tokens(0), 0);
+    }
+
+    #[test]
+    fn it_rounds_down_three_chars_to_zero_tokens() {
+        assert_eq!(estimate_tokens(3), 0);
+    }
+
+    #[test]
+    fn it_counts_four_chars_as_one_token() {
+        assert_eq!(estimate_tokens(4), 1);
+    }
+
+    #[test]
+    fn it_rounds_down_seven_chars_to_one_token() {
+        assert_eq!(estimate_tokens(7), 1);
+    }
+
+    #[test]
+    fn it_counts_eight_chars_as_two_tokens() {
+        assert_eq!(estimate_tokens(8), 2);
+    }
+
+    #[test]
+    fn it_counts_one_hundred_chars_as_twenty_five_tokens() {
+        assert_eq!(estimate_tokens(100), 25);
+    }
+
+    #[test]
+    fn it_estimates_tokens_for_a_serializable_struct() {
+        #[derive(Serialize)]
+        struct Payload {
+            name: &'static str,
+            count: usize,
+        }
+        let payload = Payload {
+            name: "manifest",
+            count: 42,
+        };
+        let serialized = serde_json::to_string(&payload).unwrap();
+        let expected = estimate_tokens(serialized.len());
+
+        assert_eq!(estimate_response_tokens(&payload), expected);
+    }
+
+    #[test]
+    fn it_returns_a_positive_estimate_for_a_non_trivial_struct() {
+        #[derive(Serialize)]
+        struct Payload {
+            items: Vec<&'static str>,
+        }
+        let payload = Payload {
+            items: vec!["alpha", "beta", "gamma", "delta"],
+        };
+
+        // "items":["alpha","beta","gamma","delta"] serializes to well over 4
+        // characters, so the estimate must be strictly positive and match the
+        // direct computation on the serialized string.
+        let serialized = serde_json::to_string(&payload).unwrap();
+        assert!(serialized.len() >= 4);
+        assert!(estimate_response_tokens(&payload) > 0);
+        assert_eq!(
+            estimate_response_tokens(&payload),
+            estimate_tokens(serialized.len())
+        );
+    }
+}

--- a/src/tools/snapshots.rs
+++ b/src/tools/snapshots.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use chrono::Utc;
 
 use crate::git::reader::RepoReader;
+use crate::tools::size;
 use crate::tools::types::{
     FileContent, SnapshotFileEntry, SnapshotMetadata, SnapshotOptions, SnapshotResponse, ToolError,
     detect_language,
@@ -45,7 +46,7 @@ pub fn build_snapshots(
             generated_at: Utc::now(),
         },
         files,
-        token_estimate: total_chars / 4,
+        token_estimate: size::estimate_tokens(total_chars),
     })
 }
 

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -66,6 +66,16 @@ pub struct ManifestMetadata {
     pub head_sha: String,
     pub generated_at: DateTime<Utc>,
     pub version: String,
+    /// Estimated token count of the serialized response, via the ~4-chars-
+    /// per-token heuristic in [`crate::tools::size::estimate_response_tokens`].
+    /// Agents use this as a cheap pre-flight hint before requesting a follow-
+    /// up call (e.g., `get_function_context` on the same range). Populated in
+    /// a two-pass build: the response is first constructed with `0`, then the
+    /// estimate is computed on that struct and written back. The final value
+    /// is therefore a lower bound that undercounts by the single-digit
+    /// character delta between `"token_estimate":0` and the real value, which
+    /// is acceptable for a budgeting hint.
+    pub token_estimate: usize,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -322,6 +332,10 @@ pub struct ContextMetadata {
     pub base_sha: String,
     pub head_sha: String,
     pub generated_at: DateTime<Utc>,
+    /// Estimated token count of the serialized response. See
+    /// [`ManifestMetadata::token_estimate`] for the semantics and caveats;
+    /// the same two-pass construction trick applies.
+    pub token_estimate: usize,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -514,6 +528,7 @@ mod tests {
                     .unwrap()
                     .with_timezone(&Utc),
                 version: "0.1.0".into(),
+                token_estimate: 0,
             },
             summary: ManifestSummary {
                 total_files_changed: 1,
@@ -540,6 +555,7 @@ mod tests {
         assert_eq!(json["summary"]["total_files_changed"], 1);
         assert!(json["summary"]["total_functions_changed"].is_null());
         assert!(json["pagination"]["next_cursor"].is_null());
+        assert_eq!(json["metadata"]["token_estimate"], 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR 2 of 4 in the stack for #212 (response-size guardrails and pagination for `get_change_manifest` and `get_function_context`). This is the **shared infrastructure layer** — nothing in this PR enforces a budget yet, but PRs 3 and 4 now have the helpers they need to do so:

- New `src/tools/size.rs` module with `estimate_tokens(char_count)` and `estimate_response_tokens<T: Serialize>(&T)` helpers
- New `classify_truncation_reason` flat-match classifier in `src/privacy.rs` (mirrors `classify_error_kind`, per issue #212 Design Decision B)
- `Metrics::record_truncated` normalizes the `reason` label at the metric boundary, so `git_prism.response.truncated` cardinality is bounded by construction regardless of what the caller passes
- `token_estimate: usize` field added to `ManifestResponse::metadata` and `FunctionContextResponse::metadata`, populated via the two-pass `estimate_response_tokens` pattern in `build_manifest` / `build_worktree_manifest` / `build_function_context`
- `src/tools/snapshots.rs` refactored to use `size::estimate_tokens(total_chars)` instead of the inline `total_chars / 4`

## BDD RED → GREEN

Two scenarios from `bdd/features/response_size_guardrails.feature` transition out of `@not_implemented`:

- `Change manifest reports its payload size for budgeting follow-up calls`
- `Function context reports its payload size for budgeting follow-up calls`

Both now assert `metadata.token_estimate` is a positive integer on a non-trivial fixture. The remaining 11 scenarios in the feature stay tagged `@not_implemented` — they will be unblocked by PRs 3 and 4.

Verified locally:

```console
$ behave --tags="@ISSUE-212 and not @not_implemented" bdd/features/response_size_guardrails.feature
1 feature passed, 0 failed, 0 skipped
2 scenarios passed, 0 failed, 11 skipped
6 steps passed, 0 failed, 48 skipped
```

## Why `classify_truncation_reason` is a flat exact-match (not substring)

Unlike `classify_error_kind` — which substring-matches error messages coming from third-party libraries like `gix` and `tree-sitter` — `classify_truncation_reason` is called only from within the codebase, always with a known-good string literal. An exhaustive flat match means mutation testing can kill every arm with one test each, and the `_ => "unknown"` safety net catches future typos without unbounding the cardinality.

Known labels: `paginated`, `max_files`, `max_file_size`, `token_budget`. Only `paginated` and `max_file_size` are emitted by existing call sites (`src/server.rs:206,475`). `token_budget` is reserved for PRs 3 and 4; `max_files` is reserved for a future change to the file-count truncation path.

## Why `token_estimate` uses a two-pass pattern

`estimate_response_tokens` serializes the struct to JSON and divides byte length by 4, but the struct contains the estimate itself — a chicken-and-egg. The builders work around this by constructing the response with `token_estimate: 0`, computing the estimate, then writing it back into the metadata before returning. This undercounts by 1 token at worst (the byte delta between `"token_estimate":0` and `"token_estimate":<N>` crosses one 4-byte boundary on realistic-sized responses), which is acceptable for a budgeting hint. Documented at the call sites.

Same pattern appears three times (`build_manifest`, `build_worktree_manifest`, `build_function_context`). Per CLAUDE.md's "Three similar lines is better than a premature abstraction," the duplication is intentional — PRs 3 and 4 will add budget-enforcement logic that reshapes these call sites, and extracting a helper now would get un-extracted then.

## Gauntlet

Ran the full pre-review gauntlet (bug hunt → quality → security → 4 church purists: rust, test, observability, arch). Results:

- **Bug hunt**: CLEAN
- **Quality**: 1 medium (three-site duplication) deferred as above per CLAUDE.md rule; 3 low notes
- **Security**: 0 CRITICAL/HIGH/MEDIUM/LOW. 1 INFO — pre-existing `ManifestMetadata.repo_path` raw-path exposure is now materialized in a transient `serde_json::to_string` buffer during estimation. Not introduced by this PR, worth a follow-up
- **rust-purist**: CLEAN
- **test-purist**: strengthened `it_normalizes_unknown_truncation_reason_without_panicking` to also exercise `classify_truncation_reason` directly; added symmetric `it_reports_a_positive_token_estimate_for_a_non_trivial_context_response` in `context.rs`. Pushed as `56d714e`
- **observability-purist**: flagged a ≤1-token divergence between the `token_estimate` field and `git_prism.response.tokens_estimated` metric (server.rs recomputes on the final serialization, which contains the non-zero estimate string). Deferred to a follow-up issue — out of PR 2's scope, and Design Decision B says "zero signature changes at existing call sites"
- **arch-purist**: proposed moving `classify_truncation_reason` from `privacy.rs` to `metrics.rs` on cohesion grounds. Reverted — issue #212 Design Decision (B) explicitly chose `privacy.rs` and "mirror classify_error_kind"; a gauntlet agent does not override the ticket's design decisions

## Commits

1. `98a88d6` — `test(bdd): remove @not_implemented from token_estimate surfacing scenarios` (RED)
2. `c20a3f6` — `feat(tools): add size::estimate_tokens helper and estimate_response_tokens`
3. `b29cbe3` — `refactor(snapshots): use size::estimate_tokens for token estimate`
4. `300adef` — `feat(tools)!: surface token_estimate on manifest and function context metadata`
5. `f632634` — `feat(metrics,privacy): bound truncation reason label cardinality`
6. `56d714e` — `test(tools,metrics): lock in token_estimate wiring and truncation classifier call path`

## Verification

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin git-prism` — 630 passed, 0 failed
- [x] `behave --tags="@ISSUE-212 and not @not_implemented" bdd/features/response_size_guardrails.feature` — 2 scenarios pass, 11 skipped
- [x] `behave --tags="~@not_implemented"` — no regressions elsewhere in the BDD suite
- [x] Lefthook pre-push hook (fmt + clippy + test) green on every push

## Deferred follow-ups

These surfaced during the gauntlet but are out of scope for PR 2. Not blockers.

- **Field/metric divergence.** `server.rs::record_tokens_estimated` recomputes tokens from the final serialization; `ManifestMetadata.token_estimate` is computed before the write-back. They differ by ≤1 token. Consider making `server.rs` read from the field instead when PR 3 reshapes the budget path. (observability agent, CRITICAL per its framing)
- **`ManifestMetadata.repo_path` privacy.** The raw absolute path is in the response body and now also in a transient serialization buffer. Pre-existing on main. Consider hashing via `privacy::hash_repo_path` or dropping the field entirely. (security agent, INFO)
- **`SIZE_BUCKETS` shared between bytes and tokens histograms.** `git_prism.response.tokens_estimated` uses the same histogram buckets as `response_bytes`, which means the top tail is dead weight for tokens. Consider a separate `TOKEN_BUCKETS` at ~25% scale. (observability agent, MEDIUM)
- **Structured log alongside `record_truncated`.** `record_truncated` fires a metric but no `tracing::info!`. On-call can see *that* truncation happened but not *which* requests. Consider adding when PR 3 wires the `token_budget` label. (observability agent, LOW)
- **`response_truncated` span attribute as bool.** Will need to become a reason string in PR 3 when multiple truncation reasons coexist. (observability agent, LOW)

Part of #212.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
