### PR TITLE
test(bdd): scaffold redirect hook + review_change scenarios (#236)

### DIFF
--- a/bdd/environment.py
+++ b/bdd/environment.py
@@ -41,6 +41,21 @@ def before_scenario(context, scenario):
     context.cleanup_dirs = []
     context.json_data = None
     context.server_procs = []
+    # Reset redirect-hook scenario state so values from a previous scenario
+    # cannot leak in (e.g., a stale `fake_home` would skip the isolated-HOME
+    # setup and let the test read the developer's real ~/.claude/...).
+    context.fake_home = None
+    context.hook_payload = None
+    context.hook_command = None
+    context.hook_extra_env = {}
+    context.review_change_payload = None
+    context.captured_sha = None
+    context.captured_pretooluse_length = None
+    context.user_settings_path = None
+    context.user_hooks_dir = None
+    context.project_repo_path = None
+    context.project_settings_path = None
+    context.project_hooks_dir = None
 
 
 def after_scenario(context, scenario):

--- a/bdd/environment.py
+++ b/bdd/environment.py
@@ -9,12 +9,11 @@ import shutil
 import subprocess
 import sys
 
+from behave.model import Scenario
+from behave.runner import Context
 
-BINARY_PATH = None
 
-
-def before_all(context):
-    global BINARY_PATH
+def before_all(context: Context) -> None:
     project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     context.project_root = project_root
 
@@ -33,11 +32,10 @@ def before_all(context):
             check=True,
         )
 
-    BINARY_PATH = binary
-    context.binary_path = BINARY_PATH
+    context.binary_path = binary
 
 
-def before_scenario(context, scenario):
+def before_scenario(context: Context, scenario: Scenario) -> None:
     context.cleanup_dirs = []
     context.json_data = None
     context.server_procs = []
@@ -49,7 +47,7 @@ def before_scenario(context, scenario):
     context.hook_command = None
     context.hook_extra_env = {}
     context.review_change_payload = None
-    context.captured_sha = None
+    context.captured_sha256 = None
     context.captured_pretooluse_length = None
     context.user_settings_path = None
     context.user_hooks_dir = None
@@ -58,7 +56,7 @@ def before_scenario(context, scenario):
     context.project_hooks_dir = None
 
 
-def after_scenario(context, scenario):
+def after_scenario(context: Context, scenario: Scenario) -> None:
     # Telemetry scenarios spawn an MCP server and a mock OTLP collector;
     # tear both down before removing the temp repo directory so file
     # handles can't keep the repo alive on shutdown. The helper no-ops

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -1,0 +1,210 @@
+# BDD bootstrap for epic #234 (bundled redirect hooks).
+#
+# Each scenario is tagged with the implementation issue that will make it
+# GREEN. Until that issue lands, the @not_implemented tag keeps the scenario
+# excluded from CI. The implementation PR's first commit must remove
+# @not_implemented from its targeted scenarios (the RED commit) before any
+# production code is written.
+#
+# All step definitions shell out to the real `git-prism` binary or the
+# bundled `hooks/git-prism-redirect.sh` script. None of them use `pass` or
+# `raise NotImplementedError` — when the underlying feature does not yet
+# exist, the steps fail with assertion errors that document the contract
+# being tested.
+
+Feature: Redirect hooks for raw git invocations
+
+  # ------------------------------------------------------------------------
+  # W2: Tool description rewrites (#237)
+  #
+  # The four MCP tool doc comments must include comparative framing vs the
+  # raw git equivalent (e.g., `get_change_manifest` references `git diff`).
+  # The assertion is end-to-end: shell out to `git-prism serve` over stdio,
+  # send a JSON-RPC `tools/list` request, and read the description fields.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-237 @not_implemented
+  Scenario: All four MCP tool descriptions include comparative framing vs raw git
+    Given the git-prism MCP server is running over stdio
+    When I send a "tools/list" JSON-RPC request
+    Then the description for "get_change_manifest" mentions "git diff"
+    And the description for "get_commit_history" mentions "git log"
+    And the description for "get_file_snapshots" mentions "git show"
+    And the description for "get_function_context" mentions "git log -S"
+
+  # ------------------------------------------------------------------------
+  # W3: Python bash tokenizer (#238)
+  #
+  # The bundled `hooks/bash_redirect_hook.py` exposes `tokenize_command` and
+  # `decide_redirect`. ADR-0008 fixes the parser as `shlex.shlex(posix=True,
+  # punctuation_chars=True)` with two wrappers (heredoc skip, backtick
+  # normalization). These scenarios drive each shape through the real hook
+  # script with mock JSON on stdin and assert on the exit code / stderr /
+  # stdout JSON contract.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-238 @not_implemented
+  Scenario: Plain "git diff main..HEAD" is recognized as a redirect target
+    Given a hook input with bash command "git diff main..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+
+  @ISSUE-238 @not_implemented
+  Scenario: Compound "cd /tmp && git diff main..HEAD" is recognized
+    Given a hook input with bash command "cd /tmp && git diff main..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+
+  @ISSUE-238 @not_implemented
+  Scenario: Subshell "(git log main..HEAD)" is recognized
+    Given a hook input with bash command "(git log main..HEAD)"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_commit_history"
+
+  @ISSUE-238 @not_implemented
+  Scenario: Variable expansion "git diff $BASE..HEAD" is recognized without expansion
+    Given a hook input with bash command "git diff $BASE..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+    And the hook does not attempt to expand "$BASE"
+
+  @ISSUE-238 @not_implemented
+  Scenario: "git blame src/server.rs" is recognized
+    Given a hook input with bash command "git blame src/server.rs"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_file_snapshots"
+
+  @ISSUE-238 @not_implemented
+  Scenario Outline: Read-only/write-side git commands are NOT redirected
+    Given a hook input with bash command "<command>"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+    Examples:
+      | command          |
+      | git status       |
+      | git add file.txt |
+      | git commit -m hi |
+      | git push origin  |
+      | git fetch origin |
+
+  @ISSUE-238 @not_implemented
+  Scenario: Heredoc body skip — git inside heredoc is ignored, surrounding command is parsed
+    Given a hook input with the bash command from "heredoc_with_git_inside.txt"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  # ------------------------------------------------------------------------
+  # W4: Install-hooks subcommand + bundled hook script (#239)
+  #
+  # `git-prism hooks install --scope <user|project|local>` writes a
+  # PreToolUse entry to the corresponding settings.json with a sentinel
+  # `id: git-prism-bash-redirect-v1`, and copies the hook script + Python
+  # helper alongside it. The end-to-end contract (exit code, stderr, stdout
+  # JSON) of the bundled hook is exercised against the same shapes from W3.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-239 @not_implemented
+  Scenario: "hooks install --scope user" writes the expected entry to ~/.claude/settings.json
+    Given an isolated HOME with an empty .claude directory
+    When I install the redirect hook at user scope
+    Then the exit code is 0
+    And the user settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
+    And the user hooks directory contains a "git-prism-redirect.sh" script
+
+  @ISSUE-239 @not_implemented
+  Scenario: "hooks install --scope project" writes to <repo>/.claude/settings.json
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    When I install the redirect hook at project scope in the repo
+    Then the exit code is 0
+    And the project settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
+    And the project hooks directory contains a "git-prism-redirect.sh" script
+
+  @ISSUE-239 @not_implemented
+  Scenario: Re-running "hooks install --scope user" is idempotent
+    Given an isolated HOME with an empty .claude directory
+    When I install the redirect hook at user scope
+    And I capture the user settings file sha256
+    And I install the redirect hook at user scope
+    Then the user settings file sha256 is unchanged
+
+  @ISSUE-239 @not_implemented
+  Scenario: "hooks uninstall --scope user" removes only this command's entries
+    Given an isolated HOME with an empty .claude directory
+    And the user settings file contains an unrelated PreToolUse entry with id "user-custom-hook"
+    When I install the redirect hook at user scope
+    And I uninstall the redirect hook at user scope
+    Then the exit code is 0
+    And the user settings file contains a PreToolUse entry with id "user-custom-hook"
+    And the user settings file does not contain a PreToolUse entry with id "git-prism-bash-redirect-v1"
+
+  @ISSUE-239 @not_implemented
+  Scenario Outline: Bundled hook redirects on tokenizer-recognized shapes (end-to-end)
+    Given an isolated HOME with the bundled hook installed at user scope
+    And a hook input with bash command "<command>"
+    When I run the installed user-scope hook with that input
+    Then the hook exit code is <exit>
+    And the hook stdout matches "<stdout_match>"
+
+    Examples:
+      | command                          | exit | stdout_match                                  |
+      | cd /tmp && git diff main..HEAD   | 0    | get_change_manifest                           |
+      | (git log main..HEAD)             | 0    | get_commit_history                            |
+      | git diff $BASE..HEAD             | 0    | get_change_manifest                           |
+
+  @ISSUE-239 @not_implemented
+  Scenario: Bundled hook hard-blocks "gh pr diff" with exit code 2 and advisory text
+    Given a hook input with bash command "gh pr diff 123"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 2
+    And the hook stderr contains "git-prism"
+    And the hook stderr contains "get_change_manifest"
+
+  # ------------------------------------------------------------------------
+  # W5: review_change MCP tool (#240)
+  #
+  # `review_change(base_ref, head_ref)` returns a single combined payload
+  # with `manifest` + `function_context` sub-responses, sharing one token
+  # budget split 40/60 per ADR-0008. Pagination on either sub-response is
+  # exposed via the same opaque cursor scheme as the existing tools.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-240 @not_implemented
+  Scenario: review_change returns combined manifest + function_context payload
+    Given a git repository with two commits
+    And the git-prism MCP server is running over stdio
+    When I call the "review_change" tool with base "HEAD~1" and head "HEAD"
+    Then the response has key "manifest"
+    And the response has key "function_context"
+    And the response value "manifest.summary.total_files_changed" is greater than 0
+
+  @ISSUE-240 @not_implemented
+  Scenario: review_change splits its token budget 40/60 between sub-responses
+    Given a git repository with two commits
+    And the git-prism MCP server is running over stdio
+    When I call the "review_change" tool with base "HEAD~1", head "HEAD", and max_response_tokens 4096
+    Then the response key "manifest.metadata.budget_tokens" is 1638
+    And the response key "function_context.metadata.budget_tokens" is 2458
+
+  @ISSUE-240 @not_implemented
+  Scenario: review_change paginates when manifest or context exceeds page size
+    Given a git repository with many changed files
+    And the git-prism MCP server is running over stdio
+    When I call the "review_change" tool with base "HEAD~1", head "HEAD", and page_size 5
+    Then at least one sub-response in the result has a non-null "next_cursor"
+
+  @ISSUE-240 @not_implemented
+  Scenario: review_change tool description includes comparative framing vs git diff
+    Given the git-prism MCP server is running over stdio
+    When I send a "tools/list" JSON-RPC request
+    Then the description for "review_change" mentions "git diff"

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -65,12 +65,44 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is JSON containing redirect advice for "get_commit_history"
 
   @ISSUE-238 @not_implemented
+  Scenario: Pipeline "git diff main..HEAD | grep foo" is recognized via the first command
+    # The tokenizer must walk into pipelines and recognize git as the head of
+    # the first stage. The grep on the right-hand side is a normal command
+    # and must not derail recognition.
+    Given a hook input with bash command "git diff main..HEAD | grep foo"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+
+  @ISSUE-238 @not_implemented
+  Scenario: Command substitution "$(...)" is recognized for both inner and outer git calls
+    # `git rev-parse` is not on the watch list (no redirect), but the outer
+    # `git diff` must still be recognized after the substitution boundary.
+    Given a hook input with bash command "cd $(git rev-parse --show-toplevel) && git diff main..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+    And the hook stdout does not contain redirect advice for "git rev-parse"
+
+  @ISSUE-238 @not_implemented
+  Scenario: Backtick command substitution is normalized before tokenization
+    # Per ADR-0008, backticks are stripped to whitespace by a pre-pass, so the
+    # outer `git diff` is the only watch-list match left after normalization.
+    Given a hook input with bash command "cd `git rev-parse --show-toplevel` && git diff main..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+    And the hook stdout does not contain redirect advice for "git rev-parse"
+
+  @ISSUE-238 @not_implemented
   Scenario: Variable expansion "git diff $BASE..HEAD" is recognized without expansion
     Given a hook input with bash command "git diff $BASE..HEAD"
+    And the environment variable "BASE" is set to "SECRETSENTINEL"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
     And the hook does not attempt to expand "$BASE"
+    And the hook output does not leak the value "SECRETSENTINEL"
 
   @ISSUE-238 @not_implemented
   Scenario: "git blame src/server.rs" is recognized
@@ -98,6 +130,29 @@ Feature: Redirect hooks for raw git invocations
   @ISSUE-238 @not_implemented
   Scenario: Heredoc body skip — git inside heredoc is ignored, surrounding command is parsed
     Given a hook input with the bash command from "heredoc_with_git_inside.txt"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  @ISSUE-238 @not_implemented
+  Scenario: Tab-stripped heredoc "<<-EOF" body is also skipped
+    # `<<-` strips leading tabs from the body but the tokenizer must still
+    # treat the body as opaque. Only the line after the closing tag should
+    # be recognized — and the surrounding command (`git status`) is not on
+    # the watch list, so no advice is emitted.
+    Given a hook input with the bash command from "heredoc_dash_with_git_inside.txt"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  @ISSUE-238 @not_implemented
+  Scenario: Quoted heredoc "<<'EOF'" suppresses expansion and is still skipped
+    # The quoted form disables shell expansion inside the body. The
+    # tokenizer must skip the body regardless — quoting is a shell concern,
+    # not a parser one.
+    Given a hook input with the bash command from "heredoc_quoted_with_git_inside.txt"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is empty
@@ -132,11 +187,17 @@ Feature: Redirect hooks for raw git invocations
 
   @ISSUE-239 @not_implemented
   Scenario: Re-running "hooks install --scope user" is idempotent
+    # Triangulates the "no duplicate write" property two ways: the file
+    # bytes are unchanged AND the PreToolUse array length is unchanged.
+    # Either alone could be fooled by a writer that re-orders keys but
+    # appends a duplicate entry; together they pin the contract.
     Given an isolated HOME with an empty .claude directory
     When I install the redirect hook at user scope
     And I capture the user settings file sha256
+    And I capture the user settings PreToolUse length
     And I install the redirect hook at user scope
     Then the user settings file sha256 is unchanged
+    And the user settings PreToolUse length is unchanged
 
   @ISSUE-239 @not_implemented
   Scenario: "hooks uninstall --scope user" removes only this command's entries
@@ -164,11 +225,152 @@ Feature: Redirect hooks for raw git invocations
 
   @ISSUE-239 @not_implemented
   Scenario: Bundled hook hard-blocks "gh pr diff" with exit code 2 and advisory text
+    # Decision logic lives in the bundled hook, not the tokenizer — `gh pr
+    # diff` is a hard-block target because the redirect is not advisory:
+    # the agent must use `get_change_manifest` instead. Hence #239, not #238.
     Given a hook input with bash command "gh pr diff 123"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 2
     And the hook stderr contains "git-prism"
     And the hook stderr contains "get_change_manifest"
+
+  @ISSUE-239 @not_implemented
+  Scenario: Bundled hook hard-blocks "mcp__github__get_commit" with exit code 2
+    # The MCP-shaped GitHub tools have the same structured-data overlap as
+    # `gh pr diff` and are hard-blocked for the same reason. The hook must
+    # detect them via the `tool_name` field, not just `tool_input.command`.
+    Given a hook input with bash command "mcp__github__get_commit owner=foo repo=bar sha=abc"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 2
+    And the hook stderr contains "git-prism"
+
+  @ISSUE-239 @not_implemented
+  Scenario: Empty stdin is a no-op (exit 0, no stdout, no stderr)
+    # If Claude Code invokes the hook without sending a payload (a
+    # non-Bash tool, for instance), it must be a silent no-op. Exit 0 so
+    # the wider workflow keeps running.
+    When I run the bundled redirect hook with empty stdin
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  @ISSUE-239 @not_implemented
+  Scenario: Malformed JSON on stdin fails open with a one-line warning
+    # Per ADR Decision 6: the hook never blocks on its own malfunction.
+    # A garbage payload triggers a single-line stderr warning, exit 0.
+    When I run the bundled redirect hook with stdin "this is not json {"
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr contains "git-prism-redirect"
+    And the hook stderr contains "malformed JSON"
+    And the hook stderr is at most 1 line
+
+  @ISSUE-239 @not_implemented
+  Scenario: Missing python3 fails open with a documented stderr line
+    # Per ADR Decision 6: if the script can't find a python3 interpreter
+    # on PATH, it must announce that on stderr and exit 0 — never block
+    # the agent because of a tooling gap on the host.
+    Given a hook input with bash command "git diff main..HEAD"
+    When I run the bundled redirect hook with that input and PATH "/nonexistent"
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr contains "python3 not found on PATH"
+    And the hook stderr contains "skipping redirect"
+
+  @ISSUE-239 @not_implemented
+  Scenario: Re-install with a stale script path updates the entry in place
+    # Path 3 from the ADR: settings.json already has a v1 entry but its
+    # `command` field points at an old absolute path (the user moved
+    # ~/.claude or upgraded an old install). A fresh install rewrites the
+    # entry — does not append a duplicate.
+    Given an isolated HOME with an empty .claude directory
+    And the user settings file contains a "git-prism-bash-redirect-v1" entry pointing to "/old/stale/path/git-prism-redirect.sh"
+    When I install the redirect hook at user scope
+    Then the exit code is 0
+    And the user settings file contains exactly one PreToolUse entry with id "git-prism-bash-redirect-v1"
+    And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command does not contain "/old/stale/path"
+    And the install stdout or stderr mentions "updated"
+
+  @ISSUE-239 @not_implemented
+  Scenario: User-edited entry is preserved by default and install logs a skip
+    # Path 4a from the ADR: respect user customization. We detect drift by
+    # checking the canonical sentinel fields; if `command` differs, skip.
+    Given an isolated HOME with an empty .claude directory
+    And the user settings file contains a "git-prism-bash-redirect-v1" entry with command "echo HAND-EDITED"
+    When I install the redirect hook at user scope
+    Then the exit code is 0
+    And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command equals "echo HAND-EDITED"
+    And the install stdout or stderr mentions "skipped"
+
+  @ISSUE-239 @not_implemented
+  Scenario: "--force" overwrites a user-edited entry with the canonical entry
+    # Path 4b from the ADR: explicit opt-out of the safety check.
+    Given an isolated HOME with an empty .claude directory
+    And the user settings file contains a "git-prism-bash-redirect-v1" entry with command "echo HAND-EDITED"
+    When I install the redirect hook at user scope with "--force"
+    Then the exit code is 0
+    And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command does not equal "echo HAND-EDITED"
+    And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command contains "git-prism-redirect.sh"
+
+  @ISSUE-239 @not_implemented
+  Scenario: Mixed-version downgrade is refused
+    # Per ADR Decision 3: never downgrade. If a v2 entry already exists
+    # and this binary writes v1, we abort with a clear remediation
+    # message and leave settings.json untouched.
+    Given an isolated HOME with an empty .claude directory
+    And the user settings file contains a "git-prism-bash-redirect-v2" entry with command "echo v2"
+    When I install the redirect hook at user scope
+    Then the exit code is not 0
+    And the hook stderr contains "git-prism-bash-redirect-v2"
+    And the hook stderr contains "this binary writes v1"
+    And the hook stderr contains "uninstall"
+    And the user settings file PreToolUse entry "git-prism-bash-redirect-v2" command equals "echo v2"
+
+  @ISSUE-239 @not_implemented
+  Scenario: "--scope local" writes to settings.local.json, not settings.json
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    When I install the redirect hook at local scope in the repo
+    Then the exit code is 0
+    And the project local settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
+    And the project settings file does not exist
+
+  @ISSUE-239 @not_implemented
+  Scenario: Cross-scope install warns about duplicate redirects and aborts on "n"
+    # User has user-scope already; trying project-scope must prompt because
+    # the result would be two redirect hooks firing on every Bash call.
+    # Answer "n" — assert the project entry was NOT written.
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    And the redirect hook is installed at user scope
+    When I run "hooks install --scope project" in the repo and answer "n"
+    Then the exit code is 0
+    And the hook stderr contains "already installed at user scope"
+    And the hook stderr contains "duplicate redirects"
+    And the project settings file does not exist
+
+  @ISSUE-239 @not_implemented
+  Scenario Outline: "hooks status" reports installed scopes and versions
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    And the redirect hook install state is "<state>"
+    When I run "hooks status" in the repo
+    Then the exit code is 0
+    And the hook stdout contains "<expected>"
+
+    Examples:
+      | state              | expected                          |
+      | none               | not installed                     |
+      | user-only          | user: git-prism-bash-redirect-v1  |
+      | user-and-project   | project: git-prism-bash-redirect-v1 |
+
+  @ISSUE-239 @not_implemented
+  Scenario: "--dry-run" prints a diff but does not write settings.json
+    Given an isolated HOME with an empty .claude directory
+    When I install the redirect hook at user scope with "--dry-run"
+    Then the exit code is 0
+    And the user settings file does not exist
+    And the hook stdout contains "git-prism-bash-redirect-v1"
 
   # ------------------------------------------------------------------------
   # W5: review_change MCP tool (#240)
@@ -189,19 +391,32 @@ Feature: Redirect hooks for raw git invocations
     And the response value "manifest.summary.total_files_changed" is greater than 0
 
   @ISSUE-240 @not_implemented
-  Scenario: review_change splits its token budget 40/60 between sub-responses
+  Scenario Outline: review_change splits its token budget 40/60 between sub-responses
+    # Two budget values triangulate the split. A hard-coded 1638/2458 pair
+    # would pass at 4096 but fail at 16384 — the test must show the split
+    # scales with the input.
     Given a git repository with two commits
     And the git-prism MCP server is running over stdio
-    When I call the "review_change" tool with base "HEAD~1", head "HEAD", and max_response_tokens 4096
-    Then the response key "manifest.metadata.budget_tokens" is 1638
-    And the response key "function_context.metadata.budget_tokens" is 2458
+    When I call the "review_change" tool with base "HEAD~1", head "HEAD", and max_response_tokens <budget>
+    Then the response key "manifest.metadata.budget_tokens" is <manifest_budget>
+    And the response key "function_context.metadata.budget_tokens" is <context_budget>
+
+    Examples:
+      | budget | manifest_budget | context_budget |
+      | 4096   | 1638            | 2458           |
+      | 16384  | 6553            | 9830           |
 
   @ISSUE-240 @not_implemented
-  Scenario: review_change paginates when manifest or context exceeds page size
+  Scenario: review_change paginates and the cursor returns a different page
+    # Triangulates pagination: a hardcoded "always emit cursor X" would
+    # pass the existence check but fail the second-page diff. We assert
+    # both that a cursor exists AND that following it returns a different
+    # set of files than the first page.
     Given a git repository with many changed files
     And the git-prism MCP server is running over stdio
     When I call the "review_change" tool with base "HEAD~1", head "HEAD", and page_size 5
     Then at least one sub-response in the result has a non-null "next_cursor"
+    And following the manifest "next_cursor" returns a different set of files than page 1
 
   @ISSUE-240 @not_implemented
   Scenario: review_change tool description includes comparative framing vs git diff

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -158,6 +158,17 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is empty
     And the hook stderr is empty
 
+  @ISSUE-238 @not_implemented
+  Scenario: Tokenizer resumes parsing after the heredoc terminator
+    # Catches the over-eager-skip failure mode where the parser swallows
+    # everything from "<<EOF" to end-of-input. The fixture has a real
+    # `git diff main..HEAD` on the line AFTER the closing tag — that line
+    # IS on the watch list and must produce advice.
+    Given a hook input with the bash command from "heredoc_then_git_diff.txt"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+
   # ------------------------------------------------------------------------
   # W4: Install-hooks subcommand + bundled hook script (#239)
   #
@@ -172,7 +183,7 @@ Feature: Redirect hooks for raw git invocations
   Scenario: "hooks install --scope user" writes the expected entry to ~/.claude/settings.json
     Given an isolated HOME with an empty .claude directory
     When I install the redirect hook at user scope
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
     And the user hooks directory contains a "git-prism-redirect.sh" script
 
@@ -181,7 +192,7 @@ Feature: Redirect hooks for raw git invocations
     Given an isolated HOME with an empty .claude directory
     And a temporary git repository as the working directory
     When I install the redirect hook at project scope in the repo
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the project settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
     And the project hooks directory contains a "git-prism-redirect.sh" script
 
@@ -205,7 +216,7 @@ Feature: Redirect hooks for raw git invocations
     And the user settings file contains an unrelated PreToolUse entry with id "user-custom-hook"
     When I install the redirect hook at user scope
     And I uninstall the redirect hook at user scope
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file contains a PreToolUse entry with id "user-custom-hook"
     And the user settings file does not contain a PreToolUse entry with id "git-prism-bash-redirect-v1"
 
@@ -256,6 +267,18 @@ Feature: Redirect hooks for raw git invocations
     And the hook stderr is empty
 
   @ISSUE-239 @not_implemented
+  Scenario: Whitespace-only stdin is treated as empty (silent exit 0)
+    # Whitespace-only payloads (a stray newline, a tab, multiple newlines)
+    # must NOT be treated as malformed JSON — they are functionally empty.
+    # Without this scenario, the boundary between "empty" and "malformed"
+    # is undefined and a fail-open impl could emit a stderr warning on
+    # every harmless newline.
+    When I run the bundled redirect hook with stdin "\n  \n"
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  @ISSUE-239 @not_implemented
   Scenario: Malformed JSON on stdin fails open with a one-line warning
     # Per ADR Decision 6: the hook never blocks on its own malfunction.
     # A garbage payload triggers a single-line stderr warning, exit 0.
@@ -271,6 +294,12 @@ Feature: Redirect hooks for raw git invocations
     # Per ADR Decision 6: if the script can't find a python3 interpreter
     # on PATH, it must announce that on stderr and exit 0 — never block
     # the agent because of a tooling gap on the host.
+    #
+    # Implementation note for #239: the bundled hook MUST use an absolute
+    # shebang (`#!/bin/bash`), not `#!/usr/bin/env bash`. With PATH set to
+    # `/nonexistent` the env-form shebang would also fail to find `bash`
+    # and the hook would never run — the test would pass for the wrong
+    # reason. The absolute shebang is the load-bearing convention.
     Given a hook input with bash command "git diff main..HEAD"
     When I run the bundled redirect hook with that input and PATH "/nonexistent"
     Then the hook exit code is 0
@@ -287,7 +316,7 @@ Feature: Redirect hooks for raw git invocations
     Given an isolated HOME with an empty .claude directory
     And the user settings file contains a "git-prism-bash-redirect-v1" entry pointing to "/old/stale/path/git-prism-redirect.sh"
     When I install the redirect hook at user scope
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file contains exactly one PreToolUse entry with id "git-prism-bash-redirect-v1"
     And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command does not contain "/old/stale/path"
     And the install stdout or stderr mentions "updated"
@@ -299,7 +328,7 @@ Feature: Redirect hooks for raw git invocations
     Given an isolated HOME with an empty .claude directory
     And the user settings file contains a "git-prism-bash-redirect-v1" entry with command "echo HAND-EDITED"
     When I install the redirect hook at user scope
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command equals "echo HAND-EDITED"
     And the install stdout or stderr mentions "skipped"
 
@@ -309,7 +338,7 @@ Feature: Redirect hooks for raw git invocations
     Given an isolated HOME with an empty .claude directory
     And the user settings file contains a "git-prism-bash-redirect-v1" entry with command "echo HAND-EDITED"
     When I install the redirect hook at user scope with "--force"
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command does not equal "echo HAND-EDITED"
     And the user settings file PreToolUse entry "git-prism-bash-redirect-v1" command contains "git-prism-redirect.sh"
 
@@ -321,18 +350,19 @@ Feature: Redirect hooks for raw git invocations
     Given an isolated HOME with an empty .claude directory
     And the user settings file contains a "git-prism-bash-redirect-v2" entry with command "echo v2"
     When I install the redirect hook at user scope
-    Then the exit code is not 0
+    Then the hook exit code is not 0
     And the hook stderr contains "git-prism-bash-redirect-v2"
     And the hook stderr contains "this binary writes v1"
     And the hook stderr contains "uninstall"
     And the user settings file PreToolUse entry "git-prism-bash-redirect-v2" command equals "echo v2"
+    And the user settings file does not contain a PreToolUse entry with id "git-prism-bash-redirect-v1"
 
   @ISSUE-239 @not_implemented
   Scenario: "--scope local" writes to settings.local.json, not settings.json
     Given an isolated HOME with an empty .claude directory
     And a temporary git repository as the working directory
     When I install the redirect hook at local scope in the repo
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the project local settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
     And the project settings file does not exist
 
@@ -345,10 +375,23 @@ Feature: Redirect hooks for raw git invocations
     And a temporary git repository as the working directory
     And the redirect hook is installed at user scope
     When I run "hooks install --scope project" in the repo and answer "n"
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the hook stderr contains "already installed at user scope"
     And the hook stderr contains "duplicate redirects"
     And the project settings file does not exist
+
+  @ISSUE-239 @not_implemented
+  Scenario: Cross-scope install proceeds when the user answers "y"
+    # Triangulates the cross-scope prompt — "n" rejects, "y" must accept.
+    # Without this branch an impl that ignored the prompt entirely (always
+    # aborting) would pass the "n" scenario above and silently break the
+    # "I really do want both scopes" use case.
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    And the redirect hook is installed at user scope
+    When I run "hooks install --scope project" in the repo and answer "y"
+    Then the hook exit code is 0
+    And the project settings file contains a PreToolUse entry with id "git-prism-bash-redirect-v1"
 
   @ISSUE-239 @not_implemented
   Scenario Outline: "hooks status" reports installed scopes and versions
@@ -356,20 +399,33 @@ Feature: Redirect hooks for raw git invocations
     And a temporary git repository as the working directory
     And the redirect hook install state is "<state>"
     When I run "hooks status" in the repo
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the hook stdout contains "<expected>"
 
     Examples:
-      | state              | expected                          |
-      | none               | not installed                     |
-      | user-only          | user: git-prism-bash-redirect-v1  |
-      | user-and-project   | project: git-prism-bash-redirect-v1 |
+      | state              | expected                            |
+      | none               | not installed                       |
+      | user-only          | user: git-prism-bash-redirect-v1    |
+      | project-only       | project: git-prism-bash-redirect-v1 |
+
+  @ISSUE-239 @not_implemented
+  Scenario: "hooks status" reports BOTH scopes when both are installed
+    # The Scenario Outline above can pass for "user-and-project" with a
+    # substring match on either user: or project: alone. This scenario
+    # forces an AND — both lines must appear — so an impl that prints
+    # only the first installed scope cannot fake it.
+    Given an isolated HOME with an empty .claude directory
+    And a temporary git repository as the working directory
+    And the redirect hook install state is "user-and-project"
+    When I run "hooks status" in the repo
+    Then the hook exit code is 0
+    And the hook stdout contains both "user: git-prism-bash-redirect-v1" and "project: git-prism-bash-redirect-v1"
 
   @ISSUE-239 @not_implemented
   Scenario: "--dry-run" prints a diff but does not write settings.json
     Given an isolated HOME with an empty .claude directory
     When I install the redirect hook at user scope with "--dry-run"
-    Then the exit code is 0
+    Then the hook exit code is 0
     And the user settings file does not exist
     And the hook stdout contains "git-prism-bash-redirect-v1"
 

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -160,14 +160,23 @@ Feature: Redirect hooks for raw git invocations
 
   @ISSUE-238 @not_implemented
   Scenario: Tokenizer resumes parsing after the heredoc terminator
-    # Catches the over-eager-skip failure mode where the parser swallows
-    # everything from "<<EOF" to end-of-input. The fixture has a real
-    # `git diff main..HEAD` on the line AFTER the closing tag — that line
-    # IS on the watch list and must produce advice.
+    # Catches TWO failure modes at once:
+    #   1. Over-eager-skip: parser swallows everything from "<<EOF" to
+    #      end-of-input. Would emit no advice — fails the get_change_manifest
+    #      assertion.
+    #   2. Heredoc-ignored: parser doesn't recognize `<<EOF` syntax and
+    #      tokenizes everything as one stream. Would emit advice for
+    #      get_commit_history (from `git log a..b` inside the body) AND
+    #      get_change_manifest (from the post-EOF line) — fails the
+    #      no-advice-for-get_commit_history assertion.
+    # The bait `git log a..b` inside the heredoc body forces the parser
+    # to actually skip the body (not just ignore heredoc syntax) AND
+    # resume after the closing tag.
     Given a hook input with the bash command from "heredoc_then_git_diff.txt"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
+    And the hook stdout does not contain redirect advice for "get_commit_history"
 
   # ------------------------------------------------------------------------
   # W4: Install-hooks subcommand + bundled hook script (#239)

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -219,6 +219,7 @@ Feature: Redirect hooks for raw git invocations
 
     Examples:
       | command                          | exit | stdout_match                                  |
+      | git diff main..HEAD              | 0    | get_change_manifest                           |
       | cd /tmp && git diff main..HEAD   | 0    | get_change_manifest                           |
       | (git log main..HEAD)             | 0    | get_commit_history                            |
       | git diff $BASE..HEAD             | 0    | get_change_manifest                           |

--- a/bdd/fixtures/hook_inputs/heredoc_dash_with_git_inside.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_dash_with_git_inside.txt
@@ -1,0 +1,5 @@
+cat <<-EOF
+	git diff a..b
+	git log main..HEAD
+	EOF
+git status

--- a/bdd/fixtures/hook_inputs/heredoc_quoted_with_git_inside.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_quoted_with_git_inside.txt
@@ -1,0 +1,5 @@
+cat <<'EOF'
+git diff a..b
+git log main..HEAD
+EOF
+git status

--- a/bdd/fixtures/hook_inputs/heredoc_then_git_diff.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_then_git_diff.txt
@@ -1,4 +1,4 @@
 cat <<EOF
-some text inside heredoc body
+git log a..b
 EOF
 git diff main..HEAD

--- a/bdd/fixtures/hook_inputs/heredoc_then_git_diff.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_then_git_diff.txt
@@ -1,0 +1,4 @@
+cat <<EOF
+some text inside heredoc body
+EOF
+git diff main..HEAD

--- a/bdd/fixtures/hook_inputs/heredoc_with_git_inside.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_with_git_inside.txt
@@ -1,0 +1,5 @@
+cat <<EOF
+git diff a..b
+git log main..HEAD
+EOF
+git status

--- a/bdd/steps/redirect_hook_steps.py
+++ b/bdd/steps/redirect_hook_steps.py
@@ -1,0 +1,715 @@
+"""Step definitions for the bundled redirect-hook epic (#234).
+
+Every step shells out to the real `git-prism` binary or to the bundled
+`hooks/git-prism-redirect.sh` script in the repo. None of them mock the
+subprocess. Until the implementation issues land, the binary will not
+ship the `hooks` subcommand and the `hooks/` directory will not exist —
+the steps fail with explicit assertion errors that document the contract
+under test.
+
+Hermeticity: every scenario gets a per-scenario `tempfile.TemporaryDirectory()`
+under `context.hook_tempdirs` (cleaned up in `after_scenario`). The
+`@given("an isolated HOME ...")` step overrides `HOME` for that scenario
+only — no test mutates the developer's real `~/.claude/settings.json`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from behave import given, then, when
+from behave.runner import Context
+
+from repo_setup_steps import _commit, _init_repo, _write_file
+
+
+# ---------------------------------------------------------------------------
+# Common helpers
+# ---------------------------------------------------------------------------
+
+
+def _project_root(context: Context) -> Path:
+    """Return the absolute path of the git-prism repo root."""
+    return Path(context.project_root)
+
+
+def _bundled_hook_script(context: Context) -> Path:
+    """Return the path to the bundled `hooks/git-prism-redirect.sh` script.
+
+    This file does not exist until #239 lands. Asserting on its presence
+    is part of the failing test's contract.
+    """
+    return _project_root(context) / "hooks" / "git-prism-redirect.sh"
+
+
+def _scenario_tempdir(context: Context) -> Path:
+    """Allocate a fresh tempdir for the current scenario.
+
+    All allocated dirs are tracked on `context.hook_tempdirs` so
+    `after_scenario` can tear them down deterministically.
+    """
+    tmp = tempfile.mkdtemp(prefix="git-prism-bdd-")
+    context.cleanup_dirs.append(tmp)
+    return Path(tmp)
+
+
+def _hook_input_payload(command: str) -> dict:
+    """Build a Claude Code Bash-tool PreToolUse payload around `command`."""
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "hook_event_name": "PreToolUse",
+    }
+
+
+def _run_hook_script(
+    context: Context,
+    script_path: Path,
+    payload: dict,
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke a hook script with the given JSON payload on stdin.
+
+    The script's exit code, stdout, and stderr are stored on `context.result`
+    using the same shape the rest of the BDD steps expect, so the existing
+    `the exit code is N` / `the output contains X` assertions can layer on
+    top of these without duplication.
+    """
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        [str(script_path)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    context.result = proc
+    return proc
+
+
+def _sha256_of_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# W2: tools/list assertions (#237)
+# ---------------------------------------------------------------------------
+
+
+def _send_jsonrpc_to_server(
+    context: Context, method: str, params: dict | None = None
+) -> dict:
+    """Spawn `git-prism serve`, send one JSON-RPC request, return the response.
+
+    The MCP server speaks line-delimited JSON-RPC over stdio. We send an
+    `initialize` first (the rmcp framework requires it before `tools/list`
+    will return anything) followed by the method under test, then close
+    stdin and parse the responses.
+    """
+    binary = context.binary_path
+    initialize_req = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "behave", "version": "0.0"},
+        },
+    }
+    initialized_notif = {
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {},
+    }
+    target_req = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": method,
+        "params": params or {},
+    }
+    payload = (
+        json.dumps(initialize_req)
+        + "\n"
+        + json.dumps(initialized_notif)
+        + "\n"
+        + json.dumps(target_req)
+        + "\n"
+    )
+
+    proc = subprocess.run(
+        [binary, "serve"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    context.result = proc
+    # Find the response with id == 2
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("id") == 2:
+            return obj
+    raise AssertionError(
+        f"No JSON-RPC response with id=2 found.\n"
+        f"stdout: {proc.stdout[:1000]}\n"
+        f"stderr: {proc.stderr[:1000]}"
+    )
+
+
+@given("the git-prism MCP server is running over stdio")
+def step_mcp_server_running(context: Context) -> None:
+    """No-op marker; the server is spawned per-request below.
+
+    The behave `Given` slot would normally set up long-running state, but
+    spawning a real persistent MCP child here would leak state across
+    scenarios. Instead, each `When` step that needs the server respawns
+    it with the canonical `initialize` -> `notifications/initialized` ->
+    `<target>` triple. We capture that intent here to keep the Gherkin
+    readable.
+    """
+    context.mcp_server_marker = True
+
+
+@when('I send a "tools/list" JSON-RPC request')
+def step_send_tools_list(context: Context) -> None:
+    response = _send_jsonrpc_to_server(context, "tools/list")
+    context.tools_list_response = response
+    assert "result" in response, (
+        f"tools/list returned no 'result': {response}"
+    )
+    tools = response["result"].get("tools", [])
+    assert tools, f"tools/list returned an empty tool list: {response}"
+    context.tool_descriptions = {t.get("name"): t.get("description", "") for t in tools}
+
+
+@then('the description for "{tool_name}" mentions "{phrase}"')
+def step_description_mentions(
+    context: Context, tool_name: str, phrase: str
+) -> None:
+    descriptions = getattr(context, "tool_descriptions", None)
+    assert descriptions is not None, (
+        "tool_descriptions not populated -- the 'tools/list' step did not run"
+    )
+    assert tool_name in descriptions, (
+        f"Tool '{tool_name}' not found in tools/list response. "
+        f"Got: {sorted(descriptions.keys())}"
+    )
+    desc = descriptions[tool_name]
+    assert phrase.lower() in desc.lower(), (
+        f"Description for '{tool_name}' does not mention '{phrase}'.\n"
+        f"Description was: {desc!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# W3: bash tokenizer scenarios (#238)
+# ---------------------------------------------------------------------------
+
+
+@given('a hook input with bash command "{command}"')
+def step_hook_input_with_command(context: Context, command: str) -> None:
+    context.hook_payload = _hook_input_payload(command)
+    context.hook_command = command
+
+
+@given('a hook input with the bash command from "{fixture}"')
+def step_hook_input_from_fixture(context: Context, fixture: str) -> None:
+    fixture_path = (
+        _project_root(context) / "bdd" / "fixtures" / "hook_inputs" / fixture
+    )
+    assert fixture_path.is_file(), (
+        f"Hook-input fixture not found: {fixture_path}"
+    )
+    command = fixture_path.read_text()
+    context.hook_payload = _hook_input_payload(command)
+    context.hook_command = command
+
+
+@when("I run the bundled redirect hook with that input")
+def step_run_bundled_hook(context: Context) -> None:
+    script = _bundled_hook_script(context)
+    assert script.is_file(), (
+        f"Bundled hook script not found at {script}. "
+        f"It must be shipped by the install-hooks subcommand work (#239)."
+    )
+    _run_hook_script(context, script, context.hook_payload)
+
+
+@then("the hook exit code is {code:d}")
+def step_hook_exit_code(context: Context, code: int) -> None:
+    actual = context.result.returncode
+    assert actual == code, (
+        f"Expected hook exit code {code}, got {actual}.\n"
+        f"command: {context.hook_command!r}\n"
+        f"stdout: {context.result.stdout!r}\n"
+        f"stderr: {context.result.stderr!r}"
+    )
+
+
+@then('the hook stdout is JSON containing redirect advice for "{tool_name}"')
+def step_hook_stdout_redirect_advice(context: Context, tool_name: str) -> None:
+    out = context.result.stdout.strip()
+    assert out, (
+        f"Hook stdout is empty -- expected redirect advice for {tool_name}.\n"
+        f"command: {context.hook_command!r}\n"
+        f"stderr: {context.result.stderr!r}"
+    )
+    try:
+        payload = json.loads(out)
+    except json.JSONDecodeError as e:
+        raise AssertionError(
+            f"Hook stdout is not valid JSON: {e}\nstdout: {out!r}"
+        ) from e
+    hook_specific = payload.get("hookSpecificOutput", {})
+    advice = hook_specific.get("additionalContext", "")
+    assert tool_name in advice, (
+        f"Redirect advice does not mention '{tool_name}'.\n"
+        f"hookSpecificOutput: {hook_specific!r}"
+    )
+
+
+@then('the hook does not attempt to expand "{var}"')
+def step_hook_does_not_expand(context: Context, var: str) -> None:
+    """The advice text must contain the literal `$VAR` rather than an
+    expanded value. The shell expansion would be a security/privacy bug
+    (the hook would leak env vars into stdout/telemetry).
+    """
+    out = context.result.stdout
+    assert var in out, (
+        f"Expected literal {var!r} to appear in hook stdout (proving no "
+        f"expansion happened). stdout: {out!r}"
+    )
+
+
+@then("the hook stdout is empty")
+def step_hook_stdout_empty(context: Context) -> None:
+    out = context.result.stdout
+    assert out.strip() == "", (
+        f"Expected empty hook stdout for command "
+        f"{getattr(context, 'hook_command', '?')!r}, got: {out!r}"
+    )
+
+
+@then("the hook stderr is empty")
+def step_hook_stderr_empty(context: Context) -> None:
+    err = context.result.stderr
+    assert err.strip() == "", (
+        f"Expected empty hook stderr for command "
+        f"{getattr(context, 'hook_command', '?')!r}, got: {err!r}"
+    )
+
+
+@then('the hook stderr contains "{phrase}"')
+def step_hook_stderr_contains(context: Context, phrase: str) -> None:
+    err = context.result.stderr
+    assert phrase in err, (
+        f"Expected hook stderr to contain {phrase!r}.\nstderr: {err!r}"
+    )
+
+
+@then('the hook stdout matches "{phrase}"')
+def step_hook_stdout_matches(context: Context, phrase: str) -> None:
+    out = context.result.stdout
+    assert phrase in out, (
+        f"Expected hook stdout to contain {phrase!r}.\nstdout: {out!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# W4: install-hooks scenarios (#239)
+# ---------------------------------------------------------------------------
+
+
+def _isolated_home(context: Context) -> Path:
+    """Allocate a fresh tempdir to use as $HOME and create ~/.claude in it.
+
+    Mutates `context.fake_home` and `context.user_settings_path` so later
+    steps can locate the settings file without re-deriving the path.
+    """
+    home = _scenario_tempdir(context)
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    context.fake_home = home
+    context.user_settings_path = home / ".claude" / "settings.json"
+    context.user_hooks_dir = home / ".claude" / "hooks"
+    return home
+
+
+@given("an isolated HOME with an empty .claude directory")
+def step_isolated_home(context: Context) -> None:
+    _isolated_home(context)
+
+
+@given("a temporary git repository as the working directory")
+def step_temp_repo_as_cwd(context: Context) -> None:
+    repo_dir = _init_repo(context)
+    _write_file(repo_dir, "README.md", "# test\n")
+    _commit(repo_dir, "initial commit", ["README.md"])
+    context.project_repo_path = Path(repo_dir)
+    context.project_settings_path = (
+        Path(repo_dir) / ".claude" / "settings.json"
+    )
+    context.project_hooks_dir = Path(repo_dir) / ".claude" / "hooks"
+
+
+@given(
+    'the user settings file contains an unrelated PreToolUse entry with '
+    'id "{entry_id}"'
+)
+def step_seed_user_setting(context: Context, entry_id: str) -> None:
+    """Seed an existing entry in the user settings before install runs.
+
+    This proves uninstall is surgical (only touches our own entries).
+    """
+    settings_path = context.user_settings_path
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "hooks": {
+            "PreToolUse": [
+                {"id": entry_id, "matcher": "Bash", "command": "echo unrelated"}
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(existing, indent=2))
+
+
+def _run_git_prism(
+    context: Context,
+    args: list[str],
+    cwd: Path | None = None,
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    """Run `git-prism <args>` with HOME overridden to the isolated tempdir."""
+    env = os.environ.copy()
+    if hasattr(context, "fake_home"):
+        env["HOME"] = str(context.fake_home)
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        [context.binary_path, *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+    )
+    context.result = proc
+    return proc
+
+
+@when("I install the redirect hook at user scope")
+def step_install_user_scope(context: Context) -> None:
+    _run_git_prism(context, ["hooks", "install", "--scope", "user"])
+
+
+@when("I install the redirect hook at project scope in the repo")
+def step_install_project_scope(context: Context) -> None:
+    _run_git_prism(
+        context,
+        ["hooks", "install", "--scope", "project"],
+        cwd=context.project_repo_path,
+    )
+
+
+@when("I uninstall the redirect hook at user scope")
+def step_uninstall_user_scope(context: Context) -> None:
+    _run_git_prism(context, ["hooks", "uninstall", "--scope", "user"])
+
+
+@when("I capture the user settings file sha256")
+def step_capture_user_settings_sha(context: Context) -> None:
+    settings_path = context.user_settings_path
+    assert settings_path.is_file(), (
+        f"Expected settings file at {settings_path} after install"
+    )
+    context.captured_sha = _sha256_of_file(settings_path)
+
+
+@then(
+    'the user settings file contains a PreToolUse entry with id "{entry_id}"'
+)
+def step_user_settings_has_entry(context: Context, entry_id: str) -> None:
+    settings_path = context.user_settings_path
+    assert settings_path.is_file(), (
+        f"Expected user settings file at {settings_path} -- "
+        f"`git-prism hooks install` did not write it."
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    ids = [e.get("id") for e in entries]
+    assert entry_id in ids, (
+        f"Expected PreToolUse entry with id {entry_id!r} in {settings_path}.\n"
+        f"Found ids: {ids}"
+    )
+
+
+@then(
+    'the user settings file does not contain a PreToolUse entry with id '
+    '"{entry_id}"'
+)
+def step_user_settings_lacks_entry(context: Context, entry_id: str) -> None:
+    settings_path = context.user_settings_path
+    assert settings_path.is_file(), (
+        f"Expected user settings file at {settings_path}"
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    ids = [e.get("id") for e in entries]
+    assert entry_id not in ids, (
+        f"Expected PreToolUse id {entry_id!r} to be ABSENT from "
+        f"{settings_path}, but found it. ids: {ids}"
+    )
+
+
+@then(
+    'the project settings file contains a PreToolUse entry with id "{entry_id}"'
+)
+def step_project_settings_has_entry(context: Context, entry_id: str) -> None:
+    settings_path = context.project_settings_path
+    assert settings_path.is_file(), (
+        f"Expected project settings file at {settings_path} -- "
+        f"`git-prism hooks install --scope project` did not write it."
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    ids = [e.get("id") for e in entries]
+    assert entry_id in ids, (
+        f"Expected PreToolUse entry with id {entry_id!r} in {settings_path}.\n"
+        f"Found ids: {ids}"
+    )
+
+
+@then('the user hooks directory contains a "{filename}" script')
+def step_user_hooks_dir_has_script(context: Context, filename: str) -> None:
+    script = context.user_hooks_dir / filename
+    assert script.is_file(), (
+        f"Expected hook script at {script}. "
+        f"`git-prism hooks install --scope user` did not copy the bundled hook."
+    )
+    # Sanity: must be executable so Claude Code can run it directly.
+    mode = script.stat().st_mode
+    assert mode & 0o111, (
+        f"Hook script at {script} is not executable (mode={oct(mode)})."
+    )
+
+
+@then('the project hooks directory contains a "{filename}" script')
+def step_project_hooks_dir_has_script(context: Context, filename: str) -> None:
+    script = context.project_hooks_dir / filename
+    assert script.is_file(), (
+        f"Expected hook script at {script}. "
+        f"`git-prism hooks install --scope project` did not copy the bundled hook."
+    )
+    mode = script.stat().st_mode
+    assert mode & 0o111, (
+        f"Hook script at {script} is not executable (mode={oct(mode)})."
+    )
+
+
+@then("the user settings file sha256 is unchanged")
+def step_user_settings_sha_unchanged(context: Context) -> None:
+    settings_path = context.user_settings_path
+    captured = getattr(context, "captured_sha", None)
+    assert captured is not None, (
+        "captured_sha not set -- did the 'I capture the user settings file "
+        "sha256' step run?"
+    )
+    current = _sha256_of_file(settings_path)
+    assert current == captured, (
+        f"Settings file changed between installs (expected idempotency).\n"
+        f"before: {captured}\nafter:  {current}\n"
+        f"path: {settings_path}"
+    )
+
+
+@given("an isolated HOME with the bundled hook installed at user scope")
+def step_isolated_home_with_install(context: Context) -> None:
+    _isolated_home(context)
+    proc = _run_git_prism(context, ["hooks", "install", "--scope", "user"])
+    assert proc.returncode == 0, (
+        f"`git-prism hooks install --scope user` failed in fixture setup.\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    )
+
+
+@when("I run the installed user-scope hook with that input")
+def step_run_installed_user_hook(context: Context) -> None:
+    script = context.user_hooks_dir / "git-prism-redirect.sh"
+    assert script.is_file(), (
+        f"Installed user-scope hook missing at {script}. "
+        f"`git-prism hooks install --scope user` did not copy it."
+    )
+    _run_hook_script(context, script, context.hook_payload)
+
+
+# ---------------------------------------------------------------------------
+# W5: review_change MCP tool scenarios (#240)
+# ---------------------------------------------------------------------------
+
+
+@given("a git repository with many changed files")
+def step_repo_with_many_changes(context: Context) -> None:
+    """Create a repo with 12 changed files so a page_size of 5 forces
+    pagination on at least one sub-response."""
+    repo_dir = _init_repo(context)
+    # Anchor commit so HEAD~1 resolves.
+    _write_file(repo_dir, "anchor.txt", "anchor\n")
+    _commit(repo_dir, "anchor", ["anchor.txt"])
+
+    files: list[str] = []
+    for i in range(12):
+        name = f"file_{i:02d}.py"
+        _write_file(
+            repo_dir,
+            name,
+            f"def fn_{i}():\n    return {i}\n",
+        )
+        files.append(name)
+    _commit(repo_dir, "add many files", files)
+
+
+def _call_review_change(
+    context: Context,
+    base: str,
+    head: str,
+    *,
+    max_response_tokens: int | None = None,
+    page_size: int | None = None,
+) -> dict:
+    """Call the `review_change` MCP tool over stdio and return the result."""
+    args: dict = {
+        "repo_path": str(context.repo_path),
+        "base_ref": base,
+        "head_ref": head,
+    }
+    if max_response_tokens is not None:
+        args["max_response_tokens"] = max_response_tokens
+    if page_size is not None:
+        args["page_size"] = page_size
+    response = _send_jsonrpc_to_server(
+        context,
+        "tools/call",
+        {"name": "review_change", "arguments": args},
+    )
+    assert "result" in response, (
+        f"review_change returned no 'result': {response}"
+    )
+    # MCP tool responses wrap the JSON payload in `content[0].text` (or
+    # `structuredContent`, depending on the rmcp version). Try both.
+    result = response["result"]
+    if "structuredContent" in result:
+        return result["structuredContent"]
+    content = result.get("content", [])
+    assert content, f"review_change result has no content: {result}"
+    text = content[0].get("text", "")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise AssertionError(
+            f"review_change content[0].text is not valid JSON: {e}\ntext: {text!r}"
+        ) from e
+
+
+@when(
+    'I call the "review_change" tool with base "{base}" and head "{head}"'
+)
+def step_call_review_change_simple(
+    context: Context, base: str, head: str
+) -> None:
+    context.review_change_payload = _call_review_change(context, base, head)
+
+
+@when(
+    'I call the "review_change" tool with base "{base}", head "{head}", and '
+    'max_response_tokens {tokens:d}'
+)
+def step_call_review_change_with_budget(
+    context: Context, base: str, head: str, tokens: int
+) -> None:
+    context.review_change_payload = _call_review_change(
+        context, base, head, max_response_tokens=tokens
+    )
+
+
+@when(
+    'I call the "review_change" tool with base "{base}", head "{head}", and '
+    'page_size {size:d}'
+)
+def step_call_review_change_with_page_size(
+    context: Context, base: str, head: str, size: int
+) -> None:
+    context.review_change_payload = _call_review_change(
+        context, base, head, page_size=size
+    )
+
+
+def _navigate_review_change(payload: dict, path: str):
+    current = payload
+    for part in path.split("."):
+        assert isinstance(current, dict), (
+            f"Expected dict at '{part}' in path '{path}', got {type(current).__name__}"
+        )
+        assert part in current, (
+            f"Key '{part}' missing in path '{path}'. "
+            f"Available: {sorted(current.keys())}"
+        )
+        current = current[part]
+    return current
+
+
+@then('the response has key "{key}"')
+def step_review_response_has_key(context: Context, key: str) -> None:
+    payload = getattr(context, "review_change_payload", None)
+    assert payload is not None, (
+        "review_change_payload not set -- did the When step run?"
+    )
+    _navigate_review_change(payload, key)
+
+
+@then('the response value "{path}" is greater than {value:d}')
+def step_review_response_value_gt(
+    context: Context, path: str, value: int
+) -> None:
+    payload = context.review_change_payload
+    actual = _navigate_review_change(payload, path)
+    assert actual > value, (
+        f"Expected {path} > {value}, got {actual}"
+    )
+
+
+@then('the response key "{path}" is {expected:d}')
+def step_review_response_key_eq_int(
+    context: Context, path: str, expected: int
+) -> None:
+    payload = context.review_change_payload
+    actual = _navigate_review_change(payload, path)
+    assert actual == expected, (
+        f"Expected {path} == {expected}, got {actual!r}"
+    )
+
+
+@then('at least one sub-response in the result has a non-null "next_cursor"')
+def step_at_least_one_subresponse_paginated(context: Context) -> None:
+    payload = context.review_change_payload
+    cursors: list = []
+    for sub_key in ("manifest", "function_context"):
+        sub = payload.get(sub_key, {})
+        cursor = sub.get("pagination", {}).get("next_cursor")
+        cursors.append((sub_key, cursor))
+    paginated = [k for k, c in cursors if c]
+    assert paginated, (
+        f"No sub-response paginated. cursors={cursors}\n"
+        f"Expected at least one non-null next_cursor when page_size is small."
+    )

--- a/bdd/steps/redirect_hook_steps.py
+++ b/bdd/steps/redirect_hook_steps.py
@@ -70,22 +70,40 @@ def _hook_input_payload(command: str) -> dict:
 def _run_hook_script(
     context: Context,
     script_path: Path,
-    payload: dict,
+    payload: dict | None,
     extra_env: dict | None = None,
+    raw_stdin: str | None = None,
 ) -> subprocess.CompletedProcess:
     """Invoke a hook script with the given JSON payload on stdin.
 
-    The script's exit code, stdout, and stderr are stored on `context.result`
-    using the same shape the rest of the BDD steps expect, so the existing
-    `the exit code is N` / `the output contains X` assertions can layer on
-    top of these without duplication.
+    Hermeticity: HOME is forced to the per-scenario `context.fake_home`
+    when one has been allocated (matching `_run_git_prism`), so the hook
+    cannot read the developer's real `~/.claude/...`. If the scenario
+    never set up a fake HOME, fall back to a fresh tempdir so we still
+    don't touch the real home directory.
+
+    `payload` is JSON-encoded and sent as stdin. Pass `raw_stdin` instead
+    to send arbitrary bytes (used for the malformed-JSON and empty-stdin
+    fail-open scenarios).
     """
     env = os.environ.copy()
+    fake_home = getattr(context, "fake_home", None)
+    if fake_home is None:
+        fake_home = Path(_scenario_tempdir(context))
+    env["HOME"] = str(fake_home)
     if extra_env:
         env.update(extra_env)
+
+    if raw_stdin is not None:
+        stdin = raw_stdin
+    elif payload is None:
+        stdin = ""
+    else:
+        stdin = json.dumps(payload)
+
     proc = subprocess.run(
         [str(script_path)],
-        input=json.dumps(payload),
+        input=stdin,
         capture_output=True,
         text=True,
         env=env,
@@ -246,7 +264,8 @@ def step_run_bundled_hook(context: Context) -> None:
         f"Bundled hook script not found at {script}. "
         f"It must be shipped by the install-hooks subcommand work (#239)."
     )
-    _run_hook_script(context, script, context.hook_payload)
+    extra_env = getattr(context, "hook_extra_env", None)
+    _run_hook_script(context, script, context.hook_payload, extra_env=extra_env)
 
 
 @then("the hook exit code is {code:d}")
@@ -394,8 +413,9 @@ def _run_git_prism(
 ) -> subprocess.CompletedProcess:
     """Run `git-prism <args>` with HOME overridden to the isolated tempdir."""
     env = os.environ.copy()
-    if hasattr(context, "fake_home"):
-        env["HOME"] = str(context.fake_home)
+    fake_home = getattr(context, "fake_home", None)
+    if fake_home is not None:
+        env["HOME"] = str(fake_home)
     if extra_env:
         env.update(extra_env)
     proc = subprocess.run(
@@ -712,4 +732,513 @@ def step_at_least_one_subresponse_paginated(context: Context) -> None:
     assert paginated, (
         f"No sub-response paginated. cursors={cursors}\n"
         f"Expected at least one non-null next_cursor when page_size is small."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer triangulation: env var leakage, command-substitution boundaries
+# ---------------------------------------------------------------------------
+
+
+@given('the environment variable "{name}" is set to "{value}"')
+def step_set_env_var(context: Context, name: str, value: str) -> None:
+    """Stash an env var that `_run_hook_script` will inject via extra_env.
+
+    Used to triangulate the "tokenizer does not expand variables" property:
+    if the impl accidentally calls `os.path.expandvars` or shells out, the
+    secret value would leak into stdout/stderr. The follow-up `does not
+    leak` step asserts that doesn't happen.
+    """
+    context.hook_extra_env = getattr(context, "hook_extra_env", {})
+    context.hook_extra_env[name] = value
+
+
+@then('the hook output does not leak the value "{value}"')
+def step_hook_output_no_leak(context: Context, value: str) -> None:
+    out = context.result.stdout
+    err = context.result.stderr
+    combined = f"{out}\n{err}"
+    assert value not in combined, (
+        f"Expected secret value {value!r} to NOT appear in hook output, "
+        f"but found it. This indicates the tokenizer expanded "
+        f"environment variables (security/privacy bug).\n"
+        f"stdout: {out!r}\nstderr: {err!r}"
+    )
+
+
+@then('the hook stdout does not contain redirect advice for "{phrase}"')
+def step_hook_stdout_no_advice_for(context: Context, phrase: str) -> None:
+    """Assert a watch-list-miss command did not trigger advice.
+
+    Some payloads contain BOTH a watch-list match (e.g., outer `git diff`)
+    and a non-match (`git rev-parse`); the advice payload must mention
+    only the match. The assertion looks at the parsed `additionalContext`
+    field rather than raw stdout to avoid false positives from JSON
+    structure that happens to contain the phrase as a substring.
+    """
+    out = context.result.stdout.strip()
+    if not out:
+        return  # Nothing emitted means nothing to leak.
+    try:
+        payload = json.loads(out)
+    except json.JSONDecodeError:
+        # If stdout isn't JSON the test will fail elsewhere; nothing to
+        # check here.
+        return
+    advice = payload.get("hookSpecificOutput", {}).get("additionalContext", "")
+    assert phrase not in advice, (
+        f"Hook advice unexpectedly mentions {phrase!r}.\n"
+        f"advice: {advice!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hard-block / fail-open scenarios (#239)
+# ---------------------------------------------------------------------------
+
+
+@when("I run the bundled redirect hook with empty stdin")
+def step_run_hook_empty_stdin(context: Context) -> None:
+    script = _bundled_hook_script(context)
+    assert script.is_file(), (
+        f"Bundled hook script not found at {script}. "
+        f"It must be shipped by the install-hooks subcommand work (#239)."
+    )
+    _run_hook_script(context, script, payload=None, raw_stdin="")
+
+
+@when('I run the bundled redirect hook with stdin "{stdin}"')
+def step_run_hook_raw_stdin(context: Context, stdin: str) -> None:
+    script = _bundled_hook_script(context)
+    assert script.is_file(), (
+        f"Bundled hook script not found at {script}. "
+        f"It must be shipped by the install-hooks subcommand work (#239)."
+    )
+    _run_hook_script(context, script, payload=None, raw_stdin=stdin)
+
+
+@when('I run the bundled redirect hook with that input and PATH "{path}"')
+def step_run_hook_with_path(context: Context, path: str) -> None:
+    script = _bundled_hook_script(context)
+    assert script.is_file(), (
+        f"Bundled hook script not found at {script}. "
+        f"It must be shipped by the install-hooks subcommand work (#239)."
+    )
+    _run_hook_script(
+        context,
+        script,
+        context.hook_payload,
+        extra_env={"PATH": path},
+    )
+
+
+@then("the hook stderr is at most {n:d} line")
+@then("the hook stderr is at most {n:d} lines")
+def step_hook_stderr_at_most_n_lines(context: Context, n: int) -> None:
+    err = context.result.stderr.rstrip("\n")
+    if not err:
+        return
+    line_count = len(err.split("\n"))
+    assert line_count <= n, (
+        f"Expected hook stderr to be at most {n} line(s), got {line_count}.\n"
+        f"stderr: {err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency / install-path triangulation (#239)
+# ---------------------------------------------------------------------------
+
+
+def _seed_user_settings_with_redirect_entry(
+    context: Context, entry_id: str, command: str
+) -> None:
+    """Write a single PreToolUse entry with the given id+command to user settings.
+
+    Used to set up Path 3 (stale script path), Path 4a (user-edited
+    command), Path 4b (--force overwrites), and the v2 downgrade-refusal
+    scenarios.
+    """
+    settings_path = context.user_settings_path
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "hooks": {
+            "PreToolUse": [
+                {"id": entry_id, "matcher": "Bash", "command": command}
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(existing, indent=2))
+
+
+@given(
+    'the user settings file contains a "{entry_id}" entry pointing to "{path}"'
+)
+def step_seed_user_settings_with_path(
+    context: Context, entry_id: str, path: str
+) -> None:
+    _seed_user_settings_with_redirect_entry(context, entry_id, path)
+
+
+@given(
+    'the user settings file contains a "{entry_id}" entry with command "{command}"'
+)
+def step_seed_user_settings_with_command(
+    context: Context, entry_id: str, command: str
+) -> None:
+    _seed_user_settings_with_redirect_entry(context, entry_id, command)
+
+
+@when("I capture the user settings PreToolUse length")
+def step_capture_user_pretooluse_length(context: Context) -> None:
+    settings_path = context.user_settings_path
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    context.captured_pretooluse_length = len(entries)
+
+
+@when('I install the redirect hook at user scope with "{flag}"')
+def step_install_user_with_flag(context: Context, flag: str) -> None:
+    _run_git_prism(context, ["hooks", "install", "--scope", "user", flag])
+
+
+@when("I install the redirect hook at local scope in the repo")
+def step_install_local_scope(context: Context) -> None:
+    _run_git_prism(
+        context,
+        ["hooks", "install", "--scope", "local"],
+        cwd=context.project_repo_path,
+    )
+
+
+@given("the redirect hook is installed at user scope")
+def step_redirect_hook_installed_at_user(context: Context) -> None:
+    proc = _run_git_prism(context, ["hooks", "install", "--scope", "user"])
+    assert proc.returncode == 0, (
+        f"Setup failed: hooks install --scope user did not succeed.\n"
+        f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+    )
+
+
+@when(
+    'I run "hooks install --scope project" in the repo and answer "{answer}"'
+)
+def step_install_project_with_answer(context: Context, answer: str) -> None:
+    """Drive the cross-scope confirmation prompt by piping `answer` to stdin.
+
+    The installer must write the prompt to stderr (so a piped stdout still
+    works for diff output) and read a single character from stdin.
+    """
+    env = os.environ.copy()
+    fake_home = getattr(context, "fake_home", None)
+    if fake_home is not None:
+        env["HOME"] = str(fake_home)
+    proc = subprocess.run(
+        [context.binary_path, "hooks", "install", "--scope", "project"],
+        input=f"{answer}\n",
+        capture_output=True,
+        text=True,
+        cwd=str(context.project_repo_path),
+        env=env,
+    )
+    context.result = proc
+
+
+@given('the redirect hook install state is "{state}"')
+def step_redirect_hook_state(context: Context, state: str) -> None:
+    """Drive `hooks status` triangulation by setting up three different states.
+
+    `none` leaves both settings files absent; `user-only` runs the user
+    install; `user-and-project` runs both. The status command must
+    distinguish all three.
+    """
+    if state == "none":
+        return
+    proc = _run_git_prism(context, ["hooks", "install", "--scope", "user"])
+    assert proc.returncode == 0, (
+        f"Setup failed for state={state!r}: user install failed. "
+        f"stdout: {proc.stdout!r} stderr: {proc.stderr!r}"
+    )
+    if state == "user-only":
+        return
+    if state == "user-and-project":
+        proc = _run_git_prism(
+            context,
+            ["hooks", "install", "--scope", "project", "--force"],
+            cwd=context.project_repo_path,
+        )
+        assert proc.returncode == 0, (
+            f"Setup failed for state={state!r}: project install failed. "
+            f"stdout: {proc.stdout!r} stderr: {proc.stderr!r}"
+        )
+        return
+    raise AssertionError(f"Unknown install state: {state!r}")
+
+
+@when('I run "hooks status" in the repo')
+def step_run_hooks_status(context: Context) -> None:
+    _run_git_prism(
+        context, ["hooks", "status"], cwd=context.project_repo_path
+    )
+
+
+@then("the user settings PreToolUse length is unchanged")
+def step_user_settings_pretooluse_length_unchanged(context: Context) -> None:
+    captured = getattr(context, "captured_pretooluse_length", None)
+    assert captured is not None, (
+        "captured_pretooluse_length not set -- did the capture step run?"
+    )
+    settings_path = context.user_settings_path
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    assert len(entries) == captured, (
+        f"PreToolUse array length changed across idempotent installs: "
+        f"before={captured}, after={len(entries)}.\n"
+        f"This indicates a duplicate-entry bug masked by hash equality."
+    )
+
+
+@then(
+    'the user settings file contains exactly one PreToolUse entry with id '
+    '"{entry_id}"'
+)
+def step_user_settings_exactly_one_entry(
+    context: Context, entry_id: str
+) -> None:
+    settings_path = context.user_settings_path
+    assert settings_path.is_file(), (
+        f"Expected user settings file at {settings_path}"
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    matching = [e for e in entries if e.get("id") == entry_id]
+    assert len(matching) == 1, (
+        f"Expected exactly one PreToolUse entry with id {entry_id!r}, "
+        f"got {len(matching)}.\nentries: {entries}"
+    )
+
+
+def _user_pretooluse_entry(context: Context, entry_id: str) -> dict:
+    settings_path = context.user_settings_path
+    assert settings_path.is_file(), (
+        f"Expected user settings file at {settings_path}"
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    for entry in entries:
+        if entry.get("id") == entry_id:
+            return entry
+    raise AssertionError(
+        f"No PreToolUse entry with id {entry_id!r} in {settings_path}.\n"
+        f"entries: {entries}"
+    )
+
+
+@then(
+    'the user settings file PreToolUse entry "{entry_id}" command does not '
+    'contain "{phrase}"'
+)
+def step_user_pretooluse_command_lacks(
+    context: Context, entry_id: str, phrase: str
+) -> None:
+    entry = _user_pretooluse_entry(context, entry_id)
+    command = entry.get("command", "")
+    assert phrase not in command, (
+        f"Expected entry {entry_id!r} command to NOT contain {phrase!r}, "
+        f"but command was {command!r}."
+    )
+
+
+@then(
+    'the user settings file PreToolUse entry "{entry_id}" command contains '
+    '"{phrase}"'
+)
+def step_user_pretooluse_command_contains(
+    context: Context, entry_id: str, phrase: str
+) -> None:
+    entry = _user_pretooluse_entry(context, entry_id)
+    command = entry.get("command", "")
+    assert phrase in command, (
+        f"Expected entry {entry_id!r} command to contain {phrase!r}, "
+        f"but command was {command!r}."
+    )
+
+
+@then(
+    'the user settings file PreToolUse entry "{entry_id}" command equals '
+    '"{expected}"'
+)
+def step_user_pretooluse_command_equals(
+    context: Context, entry_id: str, expected: str
+) -> None:
+    entry = _user_pretooluse_entry(context, entry_id)
+    command = entry.get("command", "")
+    assert command == expected, (
+        f"Expected entry {entry_id!r} command to equal {expected!r}, "
+        f"but command was {command!r}."
+    )
+
+
+@then(
+    'the user settings file PreToolUse entry "{entry_id}" command does not '
+    'equal "{expected}"'
+)
+def step_user_pretooluse_command_not_equals(
+    context: Context, entry_id: str, expected: str
+) -> None:
+    entry = _user_pretooluse_entry(context, entry_id)
+    command = entry.get("command", "")
+    assert command != expected, (
+        f"Expected entry {entry_id!r} command to NOT equal {expected!r}, "
+        f"but it does. The user-edited command was overwritten."
+    )
+
+
+@then('the install stdout or stderr mentions "{phrase}"')
+def step_install_output_mentions(context: Context, phrase: str) -> None:
+    combined = f"{context.result.stdout}\n{context.result.stderr}"
+    assert phrase in combined, (
+        f"Expected install output to mention {phrase!r}.\n"
+        f"stdout: {context.result.stdout!r}\nstderr: {context.result.stderr!r}"
+    )
+
+
+@then("the exit code is not {expected:d}")
+def step_exit_code_not(context: Context, expected: int) -> None:
+    actual = context.result.returncode
+    assert actual != expected, (
+        f"Expected exit code != {expected}, got {actual}.\n"
+        f"stdout: {context.result.stdout!r}\nstderr: {context.result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scope semantics (#239)
+# ---------------------------------------------------------------------------
+
+
+@then(
+    'the project local settings file contains a PreToolUse entry with id '
+    '"{entry_id}"'
+)
+def step_project_local_settings_has_entry(
+    context: Context, entry_id: str
+) -> None:
+    settings_path = (
+        Path(context.project_repo_path) / ".claude" / "settings.local.json"
+    )
+    assert settings_path.is_file(), (
+        f"Expected project-local settings file at {settings_path} -- "
+        f"`hooks install --scope local` did not write it."
+    )
+    data = json.loads(settings_path.read_text())
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    ids = [e.get("id") for e in entries]
+    assert entry_id in ids, (
+        f"Expected PreToolUse entry with id {entry_id!r} in {settings_path}.\n"
+        f"Found ids: {ids}"
+    )
+
+
+@then("the project settings file does not exist")
+def step_project_settings_does_not_exist(context: Context) -> None:
+    settings_path = (
+        Path(context.project_repo_path) / ".claude" / "settings.json"
+    )
+    assert not settings_path.exists(), (
+        f"Expected project settings file at {settings_path} to NOT exist, "
+        f"but it does. (Wrong scope wrote here.)"
+    )
+
+
+@then("the user settings file does not exist")
+def step_user_settings_does_not_exist(context: Context) -> None:
+    settings_path = context.user_settings_path
+    assert not settings_path.exists(), (
+        f"Expected user settings file at {settings_path} to NOT exist, "
+        f"but it does. (--dry-run wrote when it should not have.)"
+    )
+
+
+@then('the hook stdout contains "{phrase}"')
+def step_hook_stdout_contains(context: Context, phrase: str) -> None:
+    out = context.result.stdout
+    assert phrase in out, (
+        f"Expected hook stdout to contain {phrase!r}.\nstdout: {out!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# review_change cursor walk + budget triangulation (#240)
+# ---------------------------------------------------------------------------
+
+
+def _files_in_manifest_page(payload: dict) -> set[str]:
+    manifest = payload.get("manifest", {})
+    files = manifest.get("files", []) or manifest.get("file_changes", [])
+    out: set[str] = set()
+    for entry in files:
+        if isinstance(entry, dict):
+            path = entry.get("path") or entry.get("file_path")
+            if path:
+                out.add(path)
+    return out
+
+
+@then(
+    'following the manifest "next_cursor" returns a different set of files than '
+    'page 1'
+)
+def step_follow_cursor_returns_different_files(context: Context) -> None:
+    """Page 1 was already captured; call review_change again with the cursor.
+
+    Catches a hardcoded-cursor bug (e.g., the impl always emits the same
+    opaque token but ignores it on the next call). If the second page
+    has the same file set as the first, pagination is fake.
+    """
+    payload = context.review_change_payload
+    page1_files = _files_in_manifest_page(payload)
+    cursor = (
+        payload.get("manifest", {})
+        .get("pagination", {})
+        .get("next_cursor")
+    )
+    assert cursor, (
+        f"No manifest cursor to follow. payload keys: "
+        f"{list(payload.get('manifest', {}).keys())}"
+    )
+
+    # Re-issue the call with the cursor. We assume the same base/head/page_size
+    # the first call used; agents replay it via the manifest's own cursor.
+    args: dict = {
+        "repo_path": str(context.repo_path),
+        "base_ref": "HEAD~1",
+        "head_ref": "HEAD",
+        "page_size": 5,
+        "manifest_cursor": cursor,
+    }
+    response = _send_jsonrpc_to_server(
+        context,
+        "tools/call",
+        {"name": "review_change", "arguments": args},
+    )
+    assert "result" in response, (
+        f"Cursor walk returned no 'result': {response}"
+    )
+    result = response["result"]
+    if "structuredContent" in result:
+        page2 = result["structuredContent"]
+    else:
+        content = result.get("content", [])
+        assert content, f"Cursor walk has no content: {result}"
+        page2 = json.loads(content[0]["text"])
+
+    page2_files = _files_in_manifest_page(page2)
+    assert page1_files != page2_files, (
+        f"Cursor walk returned the same files as page 1 — pagination is "
+        f"hardcoded.\npage1: {sorted(page1_files)}\npage2: {sorted(page2_files)}"
+    )
+    assert page2_files, (
+        f"Cursor walk returned an empty manifest page; expected the next "
+        f"slice of files.\npage2: {page2}"
     )

--- a/bdd/steps/redirect_hook_steps.py
+++ b/bdd/steps/redirect_hook_steps.py
@@ -1128,12 +1128,24 @@ def step_install_output_mentions(context: Context, phrase: str) -> None:
     )
 
 
-@then("the exit code is not {expected:d}")
-def step_exit_code_not(context: Context, expected: int) -> None:
+@then("the hook exit code is not {expected:d}")
+def step_hook_exit_code_not(context: Context, expected: int) -> None:
     actual = context.result.returncode
     assert actual != expected, (
         f"Expected exit code != {expected}, got {actual}.\n"
         f"stdout: {context.result.stdout!r}\nstderr: {context.result.stderr!r}"
+    )
+
+
+@then('the hook stdout contains both "{phrase_a}" and "{phrase_b}"')
+def step_hook_stdout_contains_both(
+    context: Context, phrase_a: str, phrase_b: str
+) -> None:
+    out = context.result.stdout
+    missing = [p for p in (phrase_a, phrase_b) if p not in out]
+    assert not missing, (
+        f"Expected hook stdout to contain BOTH {phrase_a!r} and {phrase_b!r}, "
+        f"but missing: {missing!r}.\nstdout: {out!r}"
     )
 
 

--- a/bdd/steps/redirect_hook_steps.py
+++ b/bdd/steps/redirect_hook_steps.py
@@ -180,8 +180,8 @@ def _send_jsonrpc_to_server(
     )
     context.result = proc
     # Find the response with id == 2
-    for line in proc.stdout.splitlines():
-        line = line.strip()
+    for raw_line in proc.stdout.splitlines():
+        line = raw_line.strip()
         if not line:
             continue
         try:
@@ -748,7 +748,7 @@ def step_review_response_key_eq_int(
 @then('at least one sub-response in the result has a non-null "next_cursor"')
 def step_at_least_one_subresponse_paginated(context: Context) -> None:
     payload = context.review_change_payload
-    cursors: list = []
+    cursors: list[tuple[str, str | None]] = []
     for sub_key in ("manifest", "function_context"):
         sub = payload.get(sub_key, {})
         cursor = sub.get("pagination", {}).get("next_cursor")
@@ -1247,7 +1247,7 @@ def step_follow_cursor_returns_different_files(context: Context) -> None:
 
     # Re-issue the call with the cursor. We assume the same base/head/page_size
     # the first call used; agents replay it via the manifest's own cursor.
-    args: dict = {
+    args: JsonObject = {
         "repo_path": str(context.repo_path),
         "base_ref": "HEAD~1",
         "head_ref": "HEAD",

--- a/bdd/steps/redirect_hook_steps.py
+++ b/bdd/steps/redirect_hook_steps.py
@@ -20,12 +20,21 @@ import json
 import os
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from behave import given, then, when
 from behave.runner import Context
 
 from repo_setup_steps import _commit, _init_repo, _write_file
+
+
+# A loose alias for "JSON-shaped object" — we accept any value type because
+# these helpers shuttle Claude Code hook payloads, JSON-RPC envelopes, and
+# MCP tool responses, all of which mix strings, ints, lists, and nested
+# objects under the same `dict[str, Any]` shape.
+JsonObject = dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +67,7 @@ def _scenario_tempdir(context: Context) -> Path:
     return Path(tmp)
 
 
-def _hook_input_payload(command: str) -> dict:
+def _hook_input_payload(command: str) -> JsonObject:
     """Build a Claude Code Bash-tool PreToolUse payload around `command`."""
     return {
         "tool_name": "Bash",
@@ -70,10 +79,10 @@ def _hook_input_payload(command: str) -> dict:
 def _run_hook_script(
     context: Context,
     script_path: Path,
-    payload: dict | None,
-    extra_env: dict | None = None,
+    payload: JsonObject | None,
+    extra_env: Mapping[str, str] | None = None,
     raw_stdin: str | None = None,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Invoke a hook script with the given JSON payload on stdin.
 
     Hermeticity: HOME is forced to the per-scenario `context.fake_home`
@@ -122,8 +131,8 @@ def _sha256_of_file(path: Path) -> str:
 
 
 def _send_jsonrpc_to_server(
-    context: Context, method: str, params: dict | None = None
-) -> dict:
+    context: Context, method: str, params: JsonObject | None = None
+) -> JsonObject:
     """Spawn `git-prism serve`, send one JSON-RPC request, return the response.
 
     The MCP server speaks line-delimited JSON-RPC over stdio. We send an
@@ -227,6 +236,17 @@ def step_description_mentions(
         f"Got: {sorted(descriptions.keys())}"
     )
     desc = descriptions[tool_name]
+    # Minimum-length check defends against keyword stuffing: an impl could
+    # satisfy the substring check by jamming all four expected phrases into
+    # a 30-character description. Tool descriptions are user-facing prose
+    # and need enough context for an LLM agent to make a routing decision.
+    minimum_description_chars = 80
+    assert len(desc) >= minimum_description_chars, (
+        f"Description for '{tool_name}' is too short to be meaningful "
+        f"(got {len(desc)} chars, expected >= {minimum_description_chars}). "
+        f"This guards against keyword stuffing.\n"
+        f"Description was: {desc!r}"
+    )
     assert phrase.lower() in desc.lower(), (
         f"Description for '{tool_name}' does not mention '{phrase}'.\n"
         f"Description was: {desc!r}"
@@ -409,8 +429,8 @@ def _run_git_prism(
     context: Context,
     args: list[str],
     cwd: Path | None = None,
-    extra_env: dict | None = None,
-) -> subprocess.CompletedProcess:
+    extra_env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Run `git-prism <args>` with HOME overridden to the isolated tempdir."""
     env = os.environ.copy()
     fake_home = getattr(context, "fake_home", None)
@@ -454,7 +474,7 @@ def step_capture_user_settings_sha(context: Context) -> None:
     assert settings_path.is_file(), (
         f"Expected settings file at {settings_path} after install"
     )
-    context.captured_sha = _sha256_of_file(settings_path)
+    context.captured_sha256 = _sha256_of_file(settings_path)
 
 
 @then(
@@ -541,10 +561,10 @@ def step_project_hooks_dir_has_script(context: Context, filename: str) -> None:
 @then("the user settings file sha256 is unchanged")
 def step_user_settings_sha_unchanged(context: Context) -> None:
     settings_path = context.user_settings_path
-    captured = getattr(context, "captured_sha", None)
+    captured = getattr(context, "captured_sha256", None)
     assert captured is not None, (
-        "captured_sha not set -- did the 'I capture the user settings file "
-        "sha256' step run?"
+        "captured_sha256 not set -- did the 'I capture the user settings "
+        "file sha256' step run?"
     )
     current = _sha256_of_file(settings_path)
     assert current == captured, (
@@ -607,9 +627,9 @@ def _call_review_change(
     *,
     max_response_tokens: int | None = None,
     page_size: int | None = None,
-) -> dict:
+) -> JsonObject:
     """Call the `review_change` MCP tool over stdio and return the result."""
-    args: dict = {
+    args: JsonObject = {
         "repo_path": str(context.repo_path),
         "base_ref": base,
         "head_ref": head,
@@ -675,8 +695,13 @@ def step_call_review_change_with_page_size(
     )
 
 
-def _navigate_review_change(payload: dict, path: str):
-    current = payload
+def _get_dotted_path(payload: JsonObject, path: str) -> Any:
+    """Walk a dotted path through a JSON-shaped dict and return the leaf.
+
+    Generic helper — not specific to `review_change`. Used by every step
+    that asserts on a nested key in any MCP tool response.
+    """
+    current: Any = payload
     for part in path.split("."):
         assert isinstance(current, dict), (
             f"Expected dict at '{part}' in path '{path}', got {type(current).__name__}"
@@ -695,7 +720,7 @@ def step_review_response_has_key(context: Context, key: str) -> None:
     assert payload is not None, (
         "review_change_payload not set -- did the When step run?"
     )
-    _navigate_review_change(payload, key)
+    _get_dotted_path(payload, key)
 
 
 @then('the response value "{path}" is greater than {value:d}')
@@ -703,7 +728,7 @@ def step_review_response_value_gt(
     context: Context, path: str, value: int
 ) -> None:
     payload = context.review_change_payload
-    actual = _navigate_review_change(payload, path)
+    actual = _get_dotted_path(payload, path)
     assert actual > value, (
         f"Expected {path} > {value}, got {actual}"
     )
@@ -714,7 +739,7 @@ def step_review_response_key_eq_int(
     context: Context, path: str, expected: int
 ) -> None:
     payload = context.review_change_payload
-    actual = _navigate_review_change(payload, path)
+    actual = _get_dotted_path(payload, path)
     assert actual == expected, (
         f"Expected {path} == {expected}, got {actual!r}"
     )
@@ -1018,7 +1043,7 @@ def step_user_settings_exactly_one_entry(
     )
 
 
-def _user_pretooluse_entry(context: Context, entry_id: str) -> dict:
+def _user_pretooluse_entry(context: Context, entry_id: str) -> JsonObject:
     settings_path = context.user_settings_path
     assert settings_path.is_file(), (
         f"Expected user settings file at {settings_path}"
@@ -1173,7 +1198,7 @@ def step_hook_stdout_contains(context: Context, phrase: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _files_in_manifest_page(payload: dict) -> set[str]:
+def _files_in_manifest_page(payload: JsonObject) -> set[str]:
     manifest = payload.get("manifest", {})
     files = manifest.get("files", []) or manifest.get("file_changes", [])
     out: set[str] = set()


### PR DESCRIPTION
## Summary

BDD bootstrap for epic #234. All 44 scenarios across the four implementation issues are tagged `@ISSUE-NN @not_implemented` and currently RED — they fail with assertion errors against a real `git-prism` binary and the (not-yet-existing) bundled hook script.

Closes #236.

## What's new

| Tag | Scenario count | Covers |
|---|---|---|
| `@ISSUE-237` | 1 | Tool-description comparative framing (substring assertion; deep insta snapshot deferred to #237 PR) |
| `@ISSUE-238` | 12 | Python tokenizer matrix: plain, compound, subshell, var-expansion, blame, write-side, heredoc default + `<<-EOF` + `<<'EOF'`, pipeline, command substitution `\$(...)`, backticks, `\$BASE` no-leak triangulation |
| `@ISSUE-239` | 18 | install-hooks subcommand: scope user/project/local, idempotency paths 2/3/4a/4b, mixed-version downgrade abort, `--force`, `--dry-run`, `hooks status`, duplicate-scope warning, `gh pr diff` and `mcp__github__*` hard-block, fail-open paths (empty stdin, malformed JSON, missing python3) |
| `@ISSUE-240` | 4 | review_change tool: combined payload, 40/60 split with two budget values, cursor-walks-to-different-page, doc comment framing |

## Discipline

- Step defs in Python (cross-language to Rust production) — no internal imports.
- Real `subprocess.run` shell-out to the binary at `target/release/git-prism` and the bundled hook script (when it exists). No mocks, no `pass`, no `raise NotImplementedError`.
- Hermetic: per-scenario `tempfile.TemporaryDirectory()` with `HOME` override on every shell-out (binary AND hook script). No mutation of the developer's real `~/.claude/...`.
- `before_scenario` resets all redirect-hook context attrs to defaults so state cannot leak between scenarios.

## SDLC gates

- **Spec review (adversarial-qa Gate 1)**: ran on the initial 24-scenario scaffold, found gap list (pipeline/cmd-sub/backticks, idempotency paths 3/4a/4b, mixed-version downgrade, scope local, fail-open, hooks status, --force, --dry-run, triangulation hardening). All addressed in this PR.
- **Tag fix**: \`gh pr diff\` hard-block was mis-tagged \`@ISSUE-238\`, retagged \`@ISSUE-239\` (it is bundled-hook decision logic).
- **Verify**: \`behave bdd/features/redirect_hook.feature --tags="@not_implemented"\` runs 44 scenarios, all fail with assertion errors. \`behave bdd/features --tags="not @not_implemented"\` runs 103 existing scenarios, all pass.

## Implementation handoff

Each implementation PR's first commit removes \`@not_implemented\` from its tagged scenarios as the RED commit. See \`~/.claude/rules/bdd-framework.md\` for the \`sed -i ''\` pattern.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)