### PR TITLE
feat(hooks): bash command tokenizer for redirect hook (#238)

### DIFF
--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -43,28 +43,28 @@ Feature: Redirect hooks for raw git invocations
   # stdout JSON contract.
   # ------------------------------------------------------------------------
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Plain "git diff main..HEAD" is recognized as a redirect target
     Given a hook input with bash command "git diff main..HEAD"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Compound "cd /tmp && git diff main..HEAD" is recognized
     Given a hook input with bash command "cd /tmp && git diff main..HEAD"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Subshell "(git log main..HEAD)" is recognized
     Given a hook input with bash command "(git log main..HEAD)"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_commit_history"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Pipeline "git diff main..HEAD | grep foo" is recognized via the first command
     # The tokenizer must walk into pipelines and recognize git as the head of
     # the first stage. The grep on the right-hand side is a normal command
@@ -74,7 +74,7 @@ Feature: Redirect hooks for raw git invocations
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Command substitution "$(...)" is recognized for both inner and outer git calls
     # `git rev-parse` is not on the watch list (no redirect), but the outer
     # `git diff` must still be recognized after the substitution boundary.
@@ -84,7 +84,7 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
     And the hook stdout does not contain redirect advice for "git rev-parse"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Backtick command substitution is normalized before tokenization
     # Per ADR-0008, backticks are stripped to whitespace by a pre-pass, so the
     # outer `git diff` is the only watch-list match left after normalization.
@@ -94,7 +94,7 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is JSON containing redirect advice for "get_change_manifest"
     And the hook stdout does not contain redirect advice for "git rev-parse"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Variable expansion "git diff $BASE..HEAD" is recognized without expansion
     Given a hook input with bash command "git diff $BASE..HEAD"
     And the environment variable "BASE" is set to "SECRETSENTINEL"
@@ -104,14 +104,14 @@ Feature: Redirect hooks for raw git invocations
     And the hook does not attempt to expand "$BASE"
     And the hook output does not leak the value "SECRETSENTINEL"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: "git blame src/server.rs" is recognized
     Given a hook input with bash command "git blame src/server.rs"
     When I run the bundled redirect hook with that input
     Then the hook exit code is 0
     And the hook stdout is JSON containing redirect advice for "get_file_snapshots"
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario Outline: Read-only/write-side git commands are NOT redirected
     Given a hook input with bash command "<command>"
     When I run the bundled redirect hook with that input
@@ -127,7 +127,7 @@ Feature: Redirect hooks for raw git invocations
       | git push origin  |
       | git fetch origin |
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Heredoc body skip — git inside heredoc is ignored, surrounding command is parsed
     Given a hook input with the bash command from "heredoc_with_git_inside.txt"
     When I run the bundled redirect hook with that input
@@ -135,7 +135,7 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is empty
     And the hook stderr is empty
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Tab-stripped heredoc "<<-EOF" body is also skipped
     # `<<-` strips leading tabs from the body but the tokenizer must still
     # treat the body as opaque. Only the line after the closing tag should
@@ -147,7 +147,7 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is empty
     And the hook stderr is empty
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Quoted heredoc "<<'EOF'" suppresses expansion and is still skipped
     # The quoted form disables shell expansion inside the body. The
     # tokenizer must skip the body regardless — quoting is a shell concern,
@@ -158,7 +158,7 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout is empty
     And the hook stderr is empty
 
-  @ISSUE-238 @not_implemented
+  @ISSUE-238
   Scenario: Tokenizer resumes parsing after the heredoc terminator
     # Catches TWO failure modes at once:
     #   1. Over-eager-skip: parser swallows everything from "<<EOF" to

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -1,0 +1,340 @@
+"""Bash command tokenizer + redirect decision logic.
+
+Part of the bundled redirect hook (Epic #234, ADR 0008). The shell hook
+script (`git-prism-redirect.sh`, shipped by #239) reads a Claude Code
+PreToolUse JSON payload on stdin and shells out to this module via
+`python3 -m bash_redirect_hook`. We expose two public functions:
+
+- `tokenize_command(s: str) -> list[Invocation]` — return a structured
+  list of `git` invocations found in the bash command string.
+- `decide_redirect(invocations: list[Invocation]) -> RedirectDecision` —
+  classify the invocations as allow / advisory / block.
+
+Stdlib only (`shlex`, `dataclasses`). No third-party deps.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from dataclasses import asdict, dataclass, field
+
+# Tokens treated as command boundaries when walking the flat shlex
+# output. Hitting any of these starts a new candidate command.
+_COMMAND_BOUNDARIES = frozenset({"&&", "||", "|", ";", "(", ")"})
+
+# Sentinel token inserted at every newline position before lexing. It
+# carries the same semantics as a top-level command separator AND is
+# what the heredoc body-skipper looks for to recognize the closing
+# tag's "start of a logical line" position.
+_NEWLINE_TOKEN = "\x00NL\x00"
+
+# Map each watch-list git subcommand to the git-prism MCP tool that
+# replaces it. Anything not in this map is allowed without advice
+# (write-side commands, plumbing, etc).
+_REDIRECT_TARGETS = {
+    "diff": "get_change_manifest",
+    "log": "get_commit_history",
+    "show": "get_file_snapshots",
+    "blame": "get_file_snapshots",
+}
+
+
+@dataclass(frozen=True)
+class RedirectDecision:
+    """Result of classifying a list of `git` invocations.
+
+    Attributes:
+        action: `"allow"` (no redirect, command runs unaltered),
+            `"advisory"` (command runs but the agent gets a nudge to
+            use the MCP tool instead), or `"block"` (hard refusal —
+            reserved for `gh pr diff` / `mcp__github__*` shapes that
+            the bundled hook script handles outside this module).
+        advice: User-facing text describing the recommended MCP tool.
+            Empty for `"allow"` decisions.
+    """
+
+    action: str
+    advice: str
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """A single `git` command extracted from a bash string.
+
+    Attributes:
+        subcommand: The git subcommand (e.g. `"diff"`, `"log"`).
+        args: All tokens following the subcommand, with shell quoting
+            already removed by `shlex` but variable references (e.g.
+            `$BASE`) preserved as literal text.
+        position: Character offset in the original input where the
+            invocation starts. Used by the hook script when reporting
+            advice that quotes the original command.
+        raw: The original substring that produced this invocation,
+            useful for verbatim quoting in advisory messages.
+    """
+
+    subcommand: str
+    args: list[str] = field(default_factory=list)
+    position: int = 0
+    raw: str = ""
+
+
+def tokenize_command(command: str) -> list[Invocation]:
+    """Extract every `git` invocation from a bash command string.
+
+    Walks the input with `shlex` configured to recognize bash
+    punctuation (`&&`, `||`, `|`, `;`, `(`, `)`). Backticks are
+    normalized to whitespace before lexing because they delimit command
+    substitution identically to `$(...)` for our purposes. Newlines
+    are pre-replaced with a sentinel token so heredoc termination ("tag
+    appears at the start of a line") survives `shlex`'s default
+    whitespace handling.
+
+    Returns invocations in left-to-right order.
+    """
+    if not command:
+        return []
+
+    normalized = _normalize_substitution_chars(command)
+    tokens = _lex_tokens(normalized)
+    if not tokens:
+        return []
+
+    tokens = _strip_heredoc_bodies(tokens)
+    return _collect_git_invocations(tokens, command)
+
+
+def _normalize_substitution_chars(command: str) -> str:
+    """Pre-process the command for `shlex`.
+
+    - Backticks become a `$(` substitution boundary so the inner
+      command starts a fresh segment, matching `$(...)` semantics from
+      ADR Decision 1. Without this, the inner `git rev-parse` would
+      become a sibling argument of the outer `cd` segment and be
+      suppressed (correctly, per ADR), but the closing backtick would
+      collapse the boundary and the outer `git diff` would fuse into
+      the `cd` segment too.
+    - Newlines become a sentinel token so heredoc termination ("tag
+      appears at the start of a line") survives `shlex`'s default
+      whitespace handling.
+    """
+    return (
+        command.replace("`", " $( ")
+        .replace("\n", f" {_NEWLINE_TOKEN} ")
+    )
+
+
+def _lex_tokens(command: str) -> list[str]:
+    """Tokenize `command` into bash-aware tokens."""
+    lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    return list(lex)
+
+
+def _strip_heredoc_bodies(tokens: list[str]) -> list[str]:
+    """Remove tokens inside heredoc bodies.
+
+    A `<< TAG` (or `<<- TAG`, `<< "TAG"`, `<< 'TAG'`) opens a heredoc
+    whose body ends when the tag appears as a standalone token
+    immediately after a newline sentinel. With newlines preserved as
+    sentinel tokens, the closing tag is the sequence
+    `<sentinel>, <TAG>` followed by another sentinel or end-of-stream.
+    """
+    output: list[str] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "<<":
+            tag = _heredoc_tag_at(tokens, i + 1)
+            if tag is None:
+                output.append(token)
+                i += 1
+                continue
+            i = _skip_heredoc_body(tokens, i + 2, tag)
+            continue
+        output.append(token)
+        i += 1
+    return output
+
+
+def _heredoc_tag_at(tokens: list[str], index: int) -> str | None:
+    """Return the heredoc tag at `index`, stripping `-` and quotes.
+
+    Bash accepts `<<EOF`, `<<-EOF`, `<<"EOF"`, and `<<'EOF'`. shlex
+    splits the operator from the tag (after our newline normalization,
+    `<<EOF` lexes as `['<<', 'EOF']`), so we just grab the next token.
+    """
+    if index >= len(tokens):
+        return None
+    candidate = tokens[index]
+    if candidate.startswith("-"):
+        candidate = candidate[1:]
+    return candidate.strip("'\"") or None
+
+
+def _skip_heredoc_body(
+    tokens: list[str], start: int, tag: str
+) -> int:
+    """Advance past the heredoc body, returning the index after the tag.
+
+    The closing tag must appear immediately after a newline sentinel
+    (mirroring bash's "start of a logical line" rule).
+    """
+    seen_newline = False
+    i = start
+    while i < len(tokens):
+        token = tokens[i]
+        if token == _NEWLINE_TOKEN:
+            seen_newline = True
+            i += 1
+            continue
+        if seen_newline and token == tag:
+            return i + 1
+        seen_newline = False
+        i += 1
+    return i
+
+
+def _collect_git_invocations(
+    tokens: list[str], original: str
+) -> list[Invocation]:
+    """Walk `tokens` left-to-right and emit every `git`-headed segment.
+
+    The walker splits at every command boundary (`&&`, `||`, `|`, `;`,
+    `(`, `)`, newline sentinel) and at any token starting with `$(`
+    (handles `$(...)` substitution boundaries). When the head of a
+    segment is `git`, we record an `Invocation`.
+    """
+    invocations: list[Invocation] = []
+    segment: list[str] = []
+    cursor = 0
+
+    def flush() -> None:
+        nonlocal cursor
+        invocation = _build_invocation(segment, original, cursor)
+        if invocation is not None:
+            cursor = invocation.position + len(invocation.raw)
+            invocations.append(invocation)
+
+    for token in tokens:
+        if _is_segment_terminator(token):
+            flush()
+            segment = []
+            continue
+        segment.append(token)
+
+    flush()
+    return invocations
+
+
+def _is_segment_terminator(token: str) -> bool:
+    """Return True if `token` ends the current candidate command.
+
+    `$` is treated as a boundary because `shlex` with
+    `punctuation_chars=True` splits `$(` into two tokens (`$` then
+    `(`); the bare `$` would otherwise leak into the previous segment
+    as an argument.
+    """
+    if token in _COMMAND_BOUNDARIES:
+        return True
+    if token == _NEWLINE_TOKEN:
+        return True
+    return token == "$" or token.startswith("$(")
+
+
+def _build_invocation(
+    segment: list[str], original: str, search_from: int
+) -> Invocation | None:
+    """Construct an `Invocation` from a `git`-headed segment.
+
+    Returns `None` when the segment is empty or doesn't begin with the
+    bare word `git`. A subcommand-less `git` (segment of length 1) is
+    still returned with empty args — `git status` shapes need that.
+    """
+    if not segment or segment[0] != "git":
+        return None
+    subcommand = segment[1] if len(segment) > 1 else ""
+    args = segment[2:]
+    position = original.find("git", search_from)
+    if position == -1:
+        position = search_from
+    raw = " ".join(segment)
+    return Invocation(
+        subcommand=subcommand, args=args, position=position, raw=raw
+    )
+
+
+def decide_redirect(invocations: list[Invocation]) -> RedirectDecision:
+    """Classify a list of invocations as allow / advisory / block.
+
+    Walks the invocations in order and emits advisory text for every
+    watch-list subcommand (`diff`, `log`, `show`, `blame`). Returns
+    `"allow"` when nothing on the list matches.
+
+    Hard-block targets (`gh pr diff`, `mcp__github__*`) live OUTSIDE
+    the tokenizer because they don't start with `git`; the bundled
+    hook script (#239) detects those at the JSON-payload level before
+    it ever calls this module.
+    """
+    advisory_lines: list[str] = [
+        line
+        for inv in invocations
+        if (line := _redirect_line_for(inv)) is not None
+    ]
+    if not advisory_lines:
+        return RedirectDecision(action="allow", advice="")
+    return RedirectDecision(
+        action="advisory", advice="\n".join(advisory_lines)
+    )
+
+
+def _redirect_line_for(invocation: Invocation) -> str | None:
+    """Format the advisory message for a single watch-list invocation."""
+    tool = _REDIRECT_TARGETS.get(invocation.subcommand)
+    if tool is None:
+        return None
+    return (
+        f"git-prism: prefer `{tool}` over `{invocation.raw}` "
+        f"for structured output."
+    )
+
+
+def _command_from_payload(raw_stdin: str) -> str:
+    """Extract `tool_input.command` from a Claude Code PreToolUse payload.
+
+    Returns an empty string for empty stdin, payloads with no `Bash`
+    tool_name, or malformed JSON. The bundled hook script is the
+    authoritative parser for malformed-payload diagnostics; this
+    module just emits an empty invocation list and exits 0.
+    """
+    if not raw_stdin.strip():
+        return ""
+    try:
+        payload = json.loads(raw_stdin)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command")
+    return command if isinstance(command, str) else ""
+
+
+def _emit_invocations_json(command: str) -> str:
+    """Tokenize `command` and serialize the invocation list to JSON."""
+    return json.dumps([asdict(inv) for inv in tokenize_command(command)])
+
+
+def _main() -> int:
+    raw = sys.stdin.read()
+    command = _command_from_payload(raw)
+    sys.stdout.write(_emit_invocations_json(command))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/hooks/tests/conftest.py
+++ b/hooks/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration for `hooks/` tests.
+
+The bundled redirect hook script invokes the Python helper as
+`python3 -m bash_redirect_hook` after `cd`-ing into `hooks/`, so the
+module loads as a top-level (no `hooks` package). Mirror that here by
+prepending `hooks/` to `sys.path` so `from bash_redirect_hook import ...`
+resolves the same way in the pytest run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).resolve().parent.parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))

--- a/hooks/tests/test_bash_redirect_hook.py
+++ b/hooks/tests/test_bash_redirect_hook.py
@@ -1,0 +1,358 @@
+"""Unit tests for the bash command tokenizer.
+
+Per ADR 0008 Decision 1 the parser is `shlex.shlex(posix=True,
+punctuation_chars=True)` plus two wrappers (heredoc body skip + backtick
+normalization). These tests exercise each shape from the ADR's coverage
+matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from bash_redirect_hook import Invocation, decide_redirect, tokenize_command
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+
+
+def test_tokenize_plain_git_diff() -> None:
+    invocations = tokenize_command("git diff main..HEAD")
+
+    assert invocations == [
+        Invocation(
+            subcommand="diff",
+            args=["main..HEAD"],
+            position=0,
+            raw="git diff main..HEAD",
+        )
+    ]
+
+
+def test_tokenize_plain_git_log_with_oneline() -> None:
+    """Triangulates against a hardcoded `diff main..HEAD` return: a
+    different subcommand AND different args force the parser to actually
+    read the input.
+    """
+    invocations = tokenize_command("git log --oneline")
+
+    assert len(invocations) == 1
+    assert invocations[0].subcommand == "log"
+    assert invocations[0].args == ["--oneline"]
+
+
+def test_tokenize_returns_empty_list_when_no_git_invocation() -> None:
+    """No `git` token in the input means no invocations to redirect."""
+    assert tokenize_command("ls -la") == []
+
+
+def test_tokenize_empty_string_returns_empty_list() -> None:
+    assert tokenize_command("") == []
+
+
+# ---------------------------------------------------------------------------
+# ADR 0008 Decision 4 coverage matrix — every accepted shape from the
+# decision table appears here as a parametrized table-driven case so
+# regressions are easy to localize.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        pytest.param(
+            "cd /tmp && git diff main..HEAD",
+            [("diff", ["main..HEAD"])],
+            id="compound-and",
+        ),
+        pytest.param(
+            "git diff main..HEAD; ls",
+            [("diff", ["main..HEAD"])],
+            id="semicolon-separator",
+        ),
+        pytest.param(
+            "false || git diff main..HEAD",
+            [("diff", ["main..HEAD"])],
+            id="compound-or",
+        ),
+        pytest.param(
+            "(git log main..HEAD)",
+            [("log", ["main..HEAD"])],
+            id="subshell-parens",
+        ),
+        pytest.param(
+            "git diff main..HEAD | grep foo",
+            [("diff", ["main..HEAD"])],
+            id="pipeline",
+        ),
+        pytest.param(
+            "git diff $BASE..HEAD",
+            [("diff", ["$BASE..HEAD"])],
+            id="var-expansion-preserved-literally",
+        ),
+        pytest.param(
+            "cd $(git rev-parse --show-toplevel) && git diff main..HEAD",
+            [
+                ("rev-parse", ["--show-toplevel"]),
+                ("diff", ["main..HEAD"]),
+            ],
+            id="command-substitution-dollar-paren",
+        ),
+        pytest.param(
+            "cd `git rev-parse --show-toplevel` && git diff main..HEAD",
+            [
+                ("rev-parse", ["--show-toplevel"]),
+                ("diff", ["main..HEAD"]),
+            ],
+            id="backtick-substitution-normalized",
+        ),
+        pytest.param(
+            'git diff "main..HEAD"',
+            [("diff", ["main..HEAD"])],
+            id="quoted-arg-stripped-by-shlex",
+        ),
+        pytest.param(
+            "git blame src/server.rs",
+            [("blame", ["src/server.rs"])],
+            id="git-blame",
+        ),
+        pytest.param(
+            "git status",
+            [("status", [])],
+            id="status-no-args-still-recognized",
+        ),
+        pytest.param(
+            "git add file.txt",
+            [("add", ["file.txt"])],
+            id="add-no-redirect-target",
+        ),
+    ],
+)
+def test_tokenize_recognized_shapes(
+    command: str, expected: list[tuple[str, list[str]]]
+) -> None:
+    invocations = tokenize_command(command)
+    actual = [(inv.subcommand, inv.args) for inv in invocations]
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param("ls -la", id="no-git-token"),
+        pytest.param('echo "git diff main..HEAD"', id="git-as-string-literal"),
+        pytest.param("git_helper foo", id="function-name-with-git-prefix"),
+        pytest.param("# git diff main..HEAD", id="leading-comment"),
+    ],
+)
+def test_tokenize_does_not_false_positive(command: str) -> None:
+    """Strings that mention git but don't invoke it must not be flagged."""
+    assert tokenize_command(command) == []
+
+
+# ---------------------------------------------------------------------------
+# Heredoc coverage — the parser must skip the body of every heredoc form
+# (default, dash, single-quoted) and resume tokenizing after the closing
+# tag.
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_skips_default_heredoc_body() -> None:
+    """`<<EOF` body must be opaque — bait `git log a..b` inside is data."""
+    command = "cat <<EOF\ngit diff a..b\ngit log main..HEAD\nEOF\ngit status"
+
+    invocations = tokenize_command(command)
+
+    assert [(inv.subcommand, inv.args) for inv in invocations] == [
+        ("status", []),
+    ]
+
+
+def test_tokenize_skips_tab_stripped_heredoc_body() -> None:
+    """`<<-EOF` strips leading tabs from the body but is still skipped."""
+    command = "cat <<-EOF\n\tgit diff a..b\n\tEOF\ngit status"
+
+    invocations = tokenize_command(command)
+
+    assert [(inv.subcommand, inv.args) for inv in invocations] == [
+        ("status", []),
+    ]
+
+
+def test_tokenize_skips_quoted_heredoc_body() -> None:
+    """`<<'EOF'` quoted form disables expansion; body still opaque."""
+    command = "cat <<'EOF'\ngit diff a..b\nEOF\ngit status"
+
+    invocations = tokenize_command(command)
+
+    assert [(inv.subcommand, inv.args) for inv in invocations] == [
+        ("status", []),
+    ]
+
+
+def test_tokenize_resumes_after_heredoc_terminator() -> None:
+    """Bait inside body must not survive; post-EOF git command must be seen."""
+    command = "cat <<EOF\ngit log a..b\nEOF\ngit diff main..HEAD"
+
+    invocations = tokenize_command(command)
+
+    assert [(inv.subcommand, inv.args) for inv in invocations] == [
+        ("diff", ["main..HEAD"]),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# decide_redirect() — classification logic over a tokenized invocation list
+# ---------------------------------------------------------------------------
+
+
+def test_decide_redirect_no_invocations_is_allow() -> None:
+    """Empty invocation list means no git command — allow with no advice."""
+    decision = decide_redirect([])
+
+    assert decision.action == "allow"
+    assert decision.advice == ""
+
+
+def test_decide_redirect_advises_on_git_diff() -> None:
+    """`git diff` is on the watch list and routes to get_change_manifest."""
+    invocations = tokenize_command("git diff main..HEAD")
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "advisory"
+    assert "get_change_manifest" in decision.advice
+
+
+def test_decide_redirect_advises_on_git_log() -> None:
+    invocations = tokenize_command("git log --oneline main..HEAD")
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "advisory"
+    assert "get_commit_history" in decision.advice
+
+
+def test_decide_redirect_advises_on_git_show() -> None:
+    invocations = tokenize_command("git show HEAD")
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "advisory"
+    assert "get_file_snapshots" in decision.advice
+
+
+def test_decide_redirect_advises_on_git_blame() -> None:
+    invocations = tokenize_command("git blame src/server.rs")
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "advisory"
+    assert "get_file_snapshots" in decision.advice
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git status",
+        "git add file.txt",
+        "git commit -m hi",
+        "git push origin",
+        "git fetch origin",
+    ],
+)
+def test_decide_redirect_allows_write_side_commands(command: str) -> None:
+    """Write-side commands and `git status` must not trigger advice."""
+    invocations = tokenize_command(command)
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "allow"
+    assert decision.advice == ""
+
+
+def test_decide_redirect_skips_inner_git_rev_parse() -> None:
+    """`git rev-parse` is not on the watch list, only the outer `git diff`."""
+    invocations = tokenize_command(
+        "cd $(git rev-parse --show-toplevel) && git diff main..HEAD"
+    )
+
+    decision = decide_redirect(invocations)
+
+    assert decision.action == "advisory"
+    assert "get_change_manifest" in decision.advice
+    assert "rev-parse" not in decision.advice
+
+
+def test_decide_redirect_preserves_var_reference_in_advice() -> None:
+    """The advice text should quote the literal `$BASE`, never an expansion."""
+    invocations = tokenize_command("git diff $BASE..HEAD")
+
+    decision = decide_redirect(invocations)
+
+    assert "$BASE..HEAD" in decision.advice
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point — `python3 -m bash_redirect_hook` reads a Claude Code
+# PreToolUse JSON payload on stdin and writes the tokenized invocation
+# list as JSON on stdout. The bundled shell script (#239) parses that.
+# ---------------------------------------------------------------------------
+
+
+def _run_module(stdin: str) -> tuple[int, str, str]:
+    """Run `python3 -m bash_redirect_hook` with `stdin` and capture output."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "bash_redirect_hook"],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(HOOKS_DIR),
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_module_emits_json_invocations_for_recognized_command() -> None:
+    """`python3 -m bash_redirect_hook` consumes the Claude Code payload."""
+    payload = json.dumps(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git diff main..HEAD"},
+            "hook_event_name": "PreToolUse",
+        }
+    )
+
+    code, stdout, _ = _run_module(payload)
+
+    assert code == 0
+    parsed = json.loads(stdout)
+    assert parsed == [
+        {
+            "subcommand": "diff",
+            "args": ["main..HEAD"],
+            "position": 0,
+            "raw": "git diff main..HEAD",
+        }
+    ]
+
+
+def test_module_emits_empty_list_for_no_git_command() -> None:
+    payload = json.dumps(
+        {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
+    )
+
+    code, stdout, _ = _run_module(payload)
+
+    assert code == 0
+    assert json.loads(stdout) == []
+
+
+def test_module_handles_empty_stdin_as_empty_list() -> None:
+    code, stdout, _ = _run_module("")
+
+    assert code == 0
+    assert json.loads(stdout) == []


### PR DESCRIPTION
## Summary

Closes #238. Implements `hooks/bash_redirect_hook.py`, the stdlib-only Python tokenizer that the bundled redirect hook (#239) will shell out to. Per ADR 0008 Decision 1, the parser is `shlex.shlex(posix=True, punctuation_chars=True)` plus two wrappers — heredoc body skip and backtick normalization.

### Public API

- **`tokenize_command(command: str) -> list[Invocation]`** — walks the input left-to-right and returns every `git`-headed segment with structured `(subcommand, args, position, raw)` data. Splits at `&&`, `||`, `|`, `;`, `(`, `)`, newline-sentinel, and `$(`/`$` substitution boundaries. Backticks are normalized to `$( ` so they delimit substitution identically to `$(...)`.

- **`decide_redirect(invocations: list[Invocation]) -> RedirectDecision`** — classifies the watch-list subcommands (`diff`/`log`/`show`/`blame`) as advisory, mapping each to its replacement git-prism MCP tool. Hard-block targets (`gh pr diff`, `mcp__github__*`) are NOT git invocations and stay in the bundled hook script (#239).

- **CLI entry point** — `python3 -m bash_redirect_hook` reads a Claude Code PreToolUse JSON payload on stdin and writes the tokenized invocation list as JSON on stdout.

### ADR 0008 Decision 1 reference

The implementation follows the decision verbatim: posix-mode `shlex` with punctuation-char awareness, newlines preserved as a sentinel token so heredoc termination ("tag at start of a logical line") survives, backticks normalized to `$(` boundaries. The two wrappers are <30 lines each (`_strip_heredoc_bodies`, `_normalize_substitution_chars`) per the ADR's complexity budget.

### Test plan

- [x] `pytest hooks/tests/` — 39 passed (table-driven coverage of every shape in ADR Decision 4 + decide_redirect classification + CLI subprocess tests)
- [x] `python3 -c "from bash_redirect_hook import tokenize_command, decide_redirect"` — succeeds (sys.path-prepended, mirroring the runtime `python3 -m bash_redirect_hook` resolution per ADR Prevention section)
- [x] `cargo test --bin git-prism` — 680 passed, 0 failed (no Rust changes; verified no regression)
- [x] `behave bdd/features/redirect_hook.feature --tags="@ISSUE-238"` — 17 RED scenarios (every @ISSUE-238 scenario shells out through `hooks/git-prism-redirect.sh`, which is #239's deliverable). The unit tests in `hooks/tests/test_bash_redirect_hook.py` cover the same surface directly.
- [x] `behave bdd/features --tags="not @not_implemented"` — 103 passed, 17 failed (the 17 failures are exactly the @ISSUE-238 scenarios above, all blocked on #239). No pre-existing scenarios regressed.

### Files

- New: `hooks/bash_redirect_hook.py`, `hooks/tests/__init__.py`, `hooks/tests/conftest.py`, `hooks/tests/test_bash_redirect_hook.py`
- Modified: `bdd/features/redirect_hook.feature` (RED commit — `@not_implemented` removed from all 13 @ISSUE-238 scenarios)

### Note on remaining @ISSUE-238 RED scenarios

All 13 @ISSUE-238 scenarios assert end-to-end through the bundled shell script that #239 will create. They will go GREEN after #239 lands the wrapper script that `cd`s into `hooks/` and calls `python3 -m bash_redirect_hook`. Until then, the unit-test layer is the GREEN proof that the tokenizer + decision logic are correct — the BDD layer waits on the wire-protocol layer (exit code, stderr, stdout JSON shape) that the script owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)