### PR TITLE
chore: add .claudeignore to reduce LLM scan noise

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -39,14 +39,25 @@ mutants.out*
 .DS_Store
 Thumbs.db
 
-# Credentials and private keys (defense-in-depth: keep out of agent context)
+# Credentials and private keys (defense-in-depth: keep out of agent context;
+# mirrors .gitignore coverage so adding a pattern to one means adding to both)
 .env
 .env.*
 !.env.example
 *.pem
 *.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+*.crt
+*.cer
+id_rsa
+id_ecdsa
+id_ed25519
 credentials.json
 service-account.json
+google-credentials.json
 *-credentials.json
 
 # Binary assets (recordings, images, documents, archives)

--- a/.claudeignore
+++ b/.claudeignore
@@ -39,7 +39,17 @@ mutants.out*
 .DS_Store
 Thumbs.db
 
-# Binary media (demo recordings, narration, asciinema)
+# Credentials and private keys (defense-in-depth: keep out of agent context)
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+credentials.json
+service-account.json
+*-credentials.json
+
+# Binary assets (recordings, images, documents, archives)
 *.mp4
 *.mp3
 *.gif
@@ -51,8 +61,11 @@ Thumbs.db
 *.zip
 *.tar.gz
 demo/recordings/
-demo/v0.2.0/
+demo/v*/
 recordings/
 
 # Other tooling state
 .opencode/
+
+# vendor/ is intentionally NOT ignored — vendor/tree-sitter-kotlin/ is a Kotlin
+# grammar built by build.rs at compile time and must remain readable.

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,58 @@
+# Rust build artifacts
+target/
+*.rs.bk
+perf.data*
+flamegraph.svg
+
+# Python build artifacts & caches
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+bdd/.venv/
+
+# Mutation testing output
+mutants.out*
+
+# Worktrees (recursive duplicate trees — critical to ignore)
+.worktrees/
+.claude/worktrees/
+
+# Local Claude state (machine-specific)
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# IDE / editor state
+.idea/
+.vscode/
+.vs/
+*.iml
+*.swp
+*.swo
+
+# OS state
+.DS_Store
+Thumbs.db
+
+# Binary media (demo recordings, narration, asciinema)
+*.mp4
+*.mp3
+*.gif
+*.cast
+*.png
+*.jpg
+*.jpeg
+*.pdf
+*.zip
+*.tar.gz
+demo/recordings/
+demo/v0.2.0/
+recordings/
+
+# Other tooling state
+.opencode/


### PR DESCRIPTION
Closes #250. Reduces Claude Code scan surface by excluding build artifacts, worktrees, binary media, and caches. No source code touched.

## What's excluded

| Category | Patterns |
|---|---|
| Rust build | `target/`, `*.rs.bk`, `perf.data*`, `flamegraph.svg` |
| Python/cache | `__pycache__/`, `*.pyc`, `.ruff_cache/`, `.pytest_cache/`, `.mypy_cache/`, `bdd/.venv/`, etc. |
| Worktrees | `.worktrees/`, `.claude/worktrees/` |
| Binary media | `*.mp4`, `*.mp3`, `*.gif`, `*.cast`, `*.png`, `*.jpg`, `*.pdf`, `*.zip`, `*.tar.gz`, `demo/recordings/`, `recordings/` |
| IDE/OS state | `.idea/`, `.vscode/`, `.DS_Store`, `*.swp`, etc. |
| Tooling | `.opencode/`, `.claude/settings.local.json`, `mutants.out*` |

## What stays visible (load-bearing)

`vendor/tree-sitter-kotlin/`, `Cargo.lock`, `Cargo.toml`, `build.rs`, `.claude/{skills,hooks,settings.json}`, `docs/decisions/**`, `CLAUDE*.md`, `CHANGELOG.md`

Generated with [Claude Code](https://claude.ai/claude-code)