### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.7.0] — 2026-04-29
+
 ### Breaking Changes
 
 - **`get_change_manifest` default for `include_function_analysis` flipped to `false`.** Function-level diffs are now opt-in, aligning the tool's default with its "cheap first-resort" contract. Pass `include_function_analysis: true` to restore the previous behavior. The CLI adds an `--include-function-analysis` flag with the same effect.
@@ -172,6 +180,7 @@ Function-level analysis now covers 13 languages (was 8). The selection targets w
 - Binary file detection and truncation handling
 - Homebrew tap and cargo-dist cross-platform binary releases
 
+[0.7.0]: https://github.com/mikelane/git-prism/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mikelane/git-prism/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mikelane/git-prism/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mikelane/git-prism/compare/v0.3.1...v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "git-prism"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-prism"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Agent-optimized git data MCP server — structured change manifests and full file snapshots for LLM agents"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Release v0.7.0 — redirect-hook epic (#234).

## What's in this release
- **Bundled redirect hook** — intercepts Claude's git porcelain defaults (`gh pr diff`, `git diff`, `git log`) and redirects to git-prism structured tools. Install: `git-prism hooks install`
- **`review_change` MCP tool** — combined manifest + function-context in one call, the recommended replacement for `git diff <ref>..<ref>` in PR review
- **Manifest token budget** — default 8192 token response budget prevents context overflow; pagination for large diffs
- **Tool description rewrites** — comparative framing vs raw git commands helps agents discover git-prism
- **Dependency bumps**: sha2 0.11.0, gix 0.83.0, tree-sitter-c 0.24.2
- **Capstone demo** — narrated mp4 proving end-to-end: muscle memory → hook → structured payoff

### Breaking Changes
- `get_change_manifest` `include_function_analysis` now defaults to `false` (opt-in)
- `get_change_manifest` enforces token budget (pass `max_response_tokens: 0` to disable)
- `record_truncated` metric carries a `reason` label

## Changes
- Cargo.toml: version 0.6.0 → 0.7.0
- CHANGELOG.md: [Unreleased] → [0.7.0] with today's date
- Cargo.lock: regenerated via `cargo update -p git-prism`