### PR TITLE
fix: two hook gaps — heredoc false positive and gh api contents bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Redirect hook: heredoc false positive for `gh pr diff`.** The bash command tokenizer now applies a regex-based pre-pass to strip heredoc bodies from raw text before the line-by-line shlex tokenizer runs. This prevents false-positive hard-blocks when `gh pr diff` text appears verbatim inside a heredoc body that shlex cannot tokenize (e.g., inside a multi-line double-quoted string). (#270)
+- **Redirect hook: `gh api .../contents/...?ref=<sha>` bypass interception.** The hook now detects `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>` calls and redirects to `get_file_snapshots` with advisory JSON on stdout, closing a gap where agents could fetch raw file content via the GitHub API and bypass git-prism entirely. (#270)
+
 ## [0.7.0] — 2026-04-29
 
 ### Breaking Changes

--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -180,6 +180,54 @@ Feature: Redirect hooks for raw git invocations
     And the hook stdout does not contain redirect advice for "get_commit_history"
 
   # ------------------------------------------------------------------------
+  # W3.1: Heredoc tokenizer gaps (#270)
+  #
+  # Bug 1: A heredoc inside a multi-line double-quoted string (e.g.,
+  # `"$(cat <<'EOF'` spanning several lines) cannot be tokenized by shlex
+  # because it throws ValueError on the unterminated quote. The `<<` operator
+  # is lost and the heredoc body leaks into candidate commands, causing a
+  # false positive hard block when `gh pr diff` text appears verbatim inside
+  # the heredoc body.
+  #
+  # Bug 2: `gh api repos/.../contents/...?ref=<sha>` fetches raw file content
+  # from a specific ref via the GitHub API, completely bypassing git-prism.
+  # The hook must intercept this and redirect to `get_file_snapshots`.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-270
+  Scenario: "gh pr diff" inside a quoted heredoc body is NOT blocked
+    # The heredoc body contains `gh pr diff 123 --repo owner/repo` verbatim,
+    # but it's inside a quoted heredoc in a command-substitution. The hook
+    # must not hard-block this — it must recognize the heredoc body is opaque
+    # and skip it, even when shlex cannot tokenize the enclosing line.
+    Given a hook input with the bash command from "heredoc_gh_pr_diff_inside.txt"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  @ISSUE-270
+  Scenario: "gh api repos/.../contents/...?ref=<sha>" is redirected to get_file_snapshots
+    # `gh api` with a `/contents/` path containing a `ref=` query parameter
+    # fetches file content at a specific ref — semantically equivalent to
+    # `git show <sha>:<path>`. Redirect advisably (not hard block).
+    Given a hook input with bash command "gh api repos/owner/repo/contents/src/main.rs?ref=abc123 --jq .content"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is JSON containing redirect advice for "get_file_snapshots"
+
+  @ISSUE-270
+  Scenario: "gh api repos/.../contents/..." without ref parameter is NOT intercepted
+    # Triangulates the ref= detection: a bare `/contents/` path without a
+    # `ref=` query parameter is a metadata or directory-listing call, not a
+    # file-content-at-sha call. No redirect.
+    Given a hook input with bash command "gh api repos/owner/repo/contents/src/main.rs"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout is empty
+    And the hook stderr is empty
+
+  # ------------------------------------------------------------------------
   # W4: Install-hooks subcommand + bundled hook script (#239)
   #
   # `git-prism hooks install --scope <user|project|local>` writes a

--- a/bdd/fixtures/hook_inputs/heredoc_gh_pr_diff_inside.txt
+++ b/bdd/fixtures/hook_inputs/heredoc_gh_pr_diff_inside.txt
@@ -1,0 +1,10 @@
+gh issue create --repo owner/repo \
+  --title "Some title" \
+  --body "$(cat <<'EOF'
+Running:
+
+ gh pr diff 123 --repo owner/repo
+
+produces X behavior.
+EOF
+)"

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -113,7 +113,7 @@ def _heredoc_tag(token: str) -> tuple[str, bool] | None:
         return None
     return tag, is_dash
 
-_HEREDOC_START_PATTERN = re.compile(r"<<(-?)\s*['\"]?([A-Za-z_]\w*)['\"]?")
+_HEREDOC_START_PATTERN = re.compile(r"<<(-?)\s*['\"]?([A-Za-z0-9_]\w*)['\"]?")
 
 
 def _strip_heredocs_from_raw(command: str) -> str:
@@ -151,7 +151,10 @@ def _strip_heredocs_from_raw(command: str) -> str:
         # Skip body lines until the closing tag (the tag alone on its own
         # line, modulo ``<<-`` tab stripping).
         while i < len(lines):
-            stripped = lines[i].lstrip("\t ") if is_dash else lines[i].strip()
+            if is_dash:
+                stripped = lines[i].rstrip().lstrip("\t")
+            else:
+                stripped = lines[i].rstrip()
             if stripped == tag:
                 # Replace the closing tag line with an empty line.
                 result.append("")
@@ -208,7 +211,7 @@ def _drop_heredoc_bodies(tokens: list[str]) -> list[str]:
             if tag_info is None:
                 # ``<<`` at end of input — drop the operator and stop.
                 break
-            tag, _is_dash = tag_info
+            tag, _ = tag_info
             # Step past ``<<`` and the tag word; both are dropped.
             index += 2
             # Drop everything on the same line as the operator (it's
@@ -347,7 +350,7 @@ ADVICE_GET_FILE_SNAPSHOTS_GH_API = (
 )
 
 
-_GH_API_CONTENTS_PATTERN = re.compile(r"repos/[^/]+/[^/]+/contents/.+[?&]ref=")
+_GH_API_CONTENTS_PATTERN = re.compile(r"repos/[^/]+/[^/]+/contents/.*[?&]ref=")
 
 
 def _matches_gh_api_contents(command: str) -> bool:
@@ -464,6 +467,10 @@ class Decision:
     """
 
     __slots__ = ("mode", "advice", "message", "tool_name")
+    mode: str
+    advice: str
+    message: str
+    tool_name: str
 
     def __init__(
         self,

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -361,8 +361,14 @@ def _matches_gh_api_contents(command: str) -> bool:
     Only matches when a ``ref=`` query parameter is present; bare
     ``/contents/`` paths without ``ref=`` are metadata or directory-listing
     calls and pass through silently.
+
+    The heredoc pre-pass is applied to the raw command before regex matching
+    so ``gh api .../contents/...?ref=...`` text inside a heredoc body does
+    not trigger a false-positive redirect.
     """
-    return bool(_GH_API_CONTENTS_PATTERN.search(command))
+    # Strip heredoc bodies first to avoid matching inside opaque body text.
+    cleaned = _strip_heredocs_from_raw(_strip_backticks(command))
+    return bool(_GH_API_CONTENTS_PATTERN.search(cleaned))
 
 
 def _has_ref_range(tokens: Iterable[str]) -> bool:

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -13,12 +13,20 @@ The hook MUST be hermetic and stdlib-only (per ADR-0008): no third-party
 imports, no shelling out for parsing, no environment-variable expansion.
 
 The tokenizer uses ``shlex.shlex(posix=True, punctuation_chars=True)``
-with two wrappers:
+with three wrappers:
+
+  * Heredoc raw-text stripping: a regex-based pre-pass scans the raw
+    command for ``<<TAG`` patterns and replaces heredoc opening, body,
+    and closing lines with empty strings. This catches heredocs whose
+    ``<<`` operator appears inside a quoted context that shlex cannot
+    tokenize (e.g., multi-line double-quoted strings). After this
+    pre-pass, any remaining heredocs are handled by the token-level
+    walker below.
 
   * Heredoc body skipping: ``<<TAG`` (and ``<<-TAG`` / ``<<'TAG'`` /
-    ``<<"TAG"``) trigger a state machine that drops every token until the
-    closing ``TAG`` line. Inline ``TAG`` text inside the body is ignored
-    because we require a preceding newline token.
+    ``<<"TAG"``) trigger a state machine that drops every token until
+    the closing ``TAG`` line. Inline ``TAG`` text inside the body is
+    ignored because we require a preceding newline token.
 
   * Backtick normalization: stray backticks are converted to whitespace
     in a pre-pass so ``cmd`` substitutions split cleanly into candidate

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import shlex
 import sys
 from collections.abc import Iterable
@@ -105,6 +106,54 @@ def _heredoc_tag(token: str) -> tuple[str, bool] | None:
         return None
     return tag, is_dash
 
+_HEREDOC_START_PATTERN = re.compile(r"<<(-?)\s*['\"]?([A-Za-z_]\w*)['\"]?")
+
+
+def _strip_heredocs_from_raw(command: str) -> str:
+    r"""Pre-pass: strip heredoc bodies from raw command text before tokenization.
+
+    Handles heredocs whose ``<<`` operator appears inside a quoted context
+    that ``shlex`` cannot tokenize (e.g., a multi-line double-quoted string
+    containing ``"$(cat <<'EOF'``). In those cases ``_tokenize_line`` raises
+    ``ValueError`` and returns ``[]``, so the ``<<`` operator is lost and
+    ``_drop_heredoc_bodies`` never sees it. The heredoc body leaks into
+    candidate commands, causing false-positive matches.
+
+    This pre-pass regex-scans each line for the ``<<TAG`` pattern and, when
+    found, replaces the heredoc opening line and every body line through the
+    closing tag with empty strings, preserving the surrounding command
+    structure for subsequent tokenization.
+    """
+    lines = command.split("\n")
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = _HEREDOC_START_PATTERN.search(line)
+        if not match:
+            result.append(line)
+            i += 1
+            continue
+
+        is_dash = bool(match.group(1))  # ``<<-`` strips leading tabs
+        tag = match.group(2)
+        # Replace the heredoc opening line with an empty line.
+        result.append("")
+        i += 1
+
+        # Skip body lines until the closing tag (the tag alone on its own
+        # line, modulo ``<<-`` tab stripping).
+        while i < len(lines):
+            stripped = lines[i].lstrip("\t ") if is_dash else lines[i].strip()
+            if stripped == tag:
+                # Replace the closing tag line with an empty line.
+                result.append("")
+                i += 1
+                break
+            result.append("")
+            i += 1
+    return "\n".join(result)
+
 
 def _tokenize_raw(command: str) -> list[str]:
     r"""Produce a flat token list with explicit ``\n`` separator tokens.
@@ -116,6 +165,9 @@ def _tokenize_raw(command: str) -> list[str]:
     cleaned = _strip_backticks(command)
     if not cleaned:
         return []
+    # Pre-pass: regex-strip heredoc bodies that shlex cannot tokenize,
+    # preventing false-positive matches from leaked body text.
+    cleaned = _strip_heredocs_from_raw(cleaned)
     tokens: list[str] = []
     lines = cleaned.split("\n")
     for index, line in enumerate(lines):
@@ -277,6 +329,33 @@ BLOCK_MCP_GITHUB_LIST_COMMITS = (
     "  get_commit_history(repo_path, base_ref, head_ref)\n"
     "Structured commits with per-commit semantic change analysis."
 )
+ADVICE_GET_FILE_SNAPSHOTS_GH_API = (
+    "gh api repos/.../contents/...?ref=<sha> fetches raw file content from a "
+    "specific ref via the GitHub API, bypassing git-prism entirely. "
+    "git-prism alternative:\n"
+    "  get_file_snapshots(repo_path, base_ref='<ref>^', head_ref='<ref>', "
+    "paths=[...], include_before=true, include_after=true)\n"
+    "Returns structured before/after file content at the commit boundary — "
+    "no raw API response to parse."
+)
+
+
+_GH_API_CONTENTS_PATTERN = re.compile(r"repos/[^/]+/[^/]+/contents/.+[?&]ref=")
+
+
+def _matches_gh_api_contents(command: str) -> bool:
+    """Return True if the command is ``gh api .../contents/...?ref=...``.
+
+    ``gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>`` fetches raw
+    file content at a specific ref, semantically equivalent to
+    ``git show <sha>:<path>``. The hook redirects to ``get_file_snapshots``
+    as an advisory nudge (not a hard block).
+
+    Only matches when a ``ref=`` query parameter is present; bare
+    ``/contents/`` paths without ``ref=`` are metadata or directory-listing
+    calls and pass through silently.
+    """
+    return bool(_GH_API_CONTENTS_PATTERN.search(command))
 
 
 def _has_ref_range(tokens: Iterable[str]) -> bool:
@@ -428,6 +507,17 @@ def _decide_redirect_for_bash_command(command: str) -> Decision:
     # claim it, because we want exit 2 not exit 0.
     if _matches_gh_pr_diff(command):
         return Decision("block", message=BLOCK_GH_PR_DIFF, tool_name="Bash")
+
+    # ``gh api .../contents/...?ref=<sha>`` fetches raw file content from
+    # a specific ref, bypassing git-prism. Advisory redirect (not block).
+    if _matches_gh_api_contents(command):
+        return Decision(
+            "advise",
+            advice=_advice_with_echo(
+                ADVICE_GET_FILE_SNAPSHOTS_GH_API, ["gh", "api", "contents"]
+            ),
+            tool_name="Bash",
+        )
 
     candidates = tokenize_command(command)
     if not candidates:

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -31,7 +31,6 @@ through the watch-list matchers; the first match wins.
 
 from __future__ import annotations
 
-import io
 import json
 import re
 import shlex

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -113,6 +113,7 @@ def _heredoc_tag(token: str) -> tuple[str, bool] | None:
         return None
     return tag, is_dash
 
+
 _HEREDOC_START_PATTERN = re.compile(r"<<(-?)\s*['\"]?([A-Za-z0-9_]\w*)['\"]?")
 
 
@@ -708,7 +709,9 @@ def main() -> int:
             sys.stderr.write(decision.message)
             sys.stderr.write("\n")
             return 2
-    except Exception:  # pragma: no cover - BrokenPipeError or similar; never block the agent
+    except (
+        Exception
+    ):  # pragma: no cover - BrokenPipeError or similar; never block the agent
         return 0
 
     return 0

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -136,32 +136,35 @@ def _strip_heredocs_from_raw(command: str) -> str:
     i = 0
     while i < len(lines):
         line = lines[i]
-        match = _HEREDOC_START_PATTERN.search(line)
-        if not match:
+        matches = list(_HEREDOC_START_PATTERN.finditer(line))
+        if not matches:
             result.append(line)
             i += 1
             continue
 
-        is_dash = bool(match.group(1))  # ``<<-`` strips leading tabs
-        tag = match.group(2)
         # Replace the heredoc opening line with an empty line.
         result.append("")
         i += 1
 
-        # Skip body lines until the closing tag (the tag alone on its own
-        # line, modulo ``<<-`` tab stripping).
-        while i < len(lines):
-            if is_dash:
-                stripped = lines[i].rstrip().lstrip("\t")
-            else:
-                stripped = lines[i].rstrip()
-            if stripped == tag:
-                # Replace the closing tag line with an empty line.
+        # Process each heredoc tag found on the line in order.
+        for match in matches:
+            is_dash = bool(match.group(1))  # ``<<-`` strips leading tabs
+            tag = match.group(2)
+
+            # Skip body lines until the closing tag (the tag alone on its own
+            # line, modulo ``<<-`` tab stripping).
+            while i < len(lines):
+                if is_dash:
+                    stripped = lines[i].rstrip().lstrip("\t")
+                else:
+                    stripped = lines[i].rstrip()
+                if stripped == tag:
+                    # Replace the closing tag line with an empty line.
+                    result.append("")
+                    i += 1
+                    break
                 result.append("")
                 i += 1
-                break
-            result.append("")
-            i += 1
     return "\n".join(result)
 
 
@@ -209,8 +212,10 @@ def _drop_heredoc_bodies(tokens: list[str]) -> list[str]:
                 _heredoc_tag(tokens[index + 1]) if index + 1 < len(tokens) else None
             )
             if tag_info is None:
-                # ``<<`` at end of input — drop the operator and stop.
-                break
+                # ``<<`` followed by an invalid/empty tag — skip the
+                # malformed operator and continue.
+                index += 1
+                continue
             tag, _ = tag_info
             # Step past ``<<`` and the tag word; both are dropped.
             index += 2

--- a/hooks/test_bash_redirect_hook.py
+++ b/hooks/test_bash_redirect_hook.py
@@ -78,6 +78,7 @@ class TestHasRefRange(unittest.TestCase):
     def test_bare_double_dot_is_excluded(self) -> None:
         # ".." is the parent-directory shorthand, not a ref range.
         self.assertFalse(_has_ref_range([".."]))
+
     def test_bare_triple_dot_is_excluded(self) -> None:
         self.assertFalse(_has_ref_range(["..."]))
 
@@ -237,21 +238,14 @@ class TestTokenizeCommand(unittest.TestCase):
 
     def test_heredoc_indented_delimiter_in_body_is_not_terminated(self) -> None:
         """Indented EOF inside a heredoc body must NOT terminate the heredoc."""
-        command = (
-            "cat <<EOF\n"
-            "  EOF\n"
-            "git diff main..HEAD\n"
-            "EOF\n"
-        )
+        command = "cat <<EOF\n  EOF\ngit diff main..HEAD\nEOF\n"
         result = tokenize_command(command)
         git_diff_candidates = [
-            c for c in result
-            if c and c[0] == "git" and len(c) > 1 and c[1] == "diff"
+            c for c in result if c and c[0] == "git" and len(c) > 1 and c[1] == "diff"
         ]
         self.assertFalse(
             git_diff_candidates,
-            f"git diff inside heredoc body leaked after indented faux-tag: "
-            f"{result}",
+            f"git diff inside heredoc body leaked after indented faux-tag: {result}",
         )
 
     def test_tokenizer_resumes_after_heredoc_terminator(self) -> None:
@@ -275,20 +269,65 @@ class TestTokenizeCommand(unittest.TestCase):
         multi-line quoted string must still be recognized by the _strip_heredocs
         pre-pass, and its body skipped, preventing ``gh pr diff`` (or any git
         command) from leaking into candidates."""
-        command = (
-            'echo "$(cat <<\'1\'\n'
-            'gh pr diff 123 --repo owner/repo\n'
-            '1\n'
-            ') done"\n'
-        )
+        command = "echo \"$(cat <<'1'\ngh pr diff 123 --repo owner/repo\n1\n) done\"\n"
         result = tokenize_command(command)
         gh_pr_diff = [
-            c for c in result
-            if c and len(c) >= 2 and c[0] == "gh" and c[1] == "pr"
+            c for c in result if c and len(c) >= 2 and c[0] == "gh" and c[1] == "pr"
         ]
         self.assertFalse(
             gh_pr_diff,
             f"gh pr diff inside digit-tag quoted-heredoc body leaked: {result}",
+        )
+
+    def test_two_heredocs_same_line_second_body_leaks(self) -> None:
+        """Two ``<<TAG`` operators on the same line: only the first is found by
+        the pre-pass. The second heredoc's body and closing tag leak into the
+        token stream, causing false-positive hard blocks."""
+        command = (
+            "cat <<EOF1 <<EOF2\nEOF1 body\nEOF1\ngh pr diff 123\nEOF2\necho done\n"
+        )
+        result = tokenize_command(command)
+        gh_pr_candidates = [
+            c for c in result if c and len(c) >= 2 and c[0] == "gh" and c[1] == "pr"
+        ]
+        self.assertFalse(
+            gh_pr_candidates,
+            f"gh pr diff inside second heredoc body on same-line << leaked: {result}",
+        )
+
+    def test_two_heredocs_same_line_git_diff_leaks(self) -> None:
+        """Triangulates same-line bug: git diff in second heredoc body also
+        leaks. Tests a different watch-list command to confirm the bug isn't
+        specific to ``gh pr diff``."""
+        command = (
+            "cat <<EOF1 <<EOF2\nEOF1 body\nEOF1\ngit diff main..HEAD\nEOF2\necho done\n"
+        )
+        result = tokenize_command(command)
+        git_diff_candidates = [
+            c for c in result if c and len(c) >= 2 and c[0] == "git" and c[1] == "diff"
+        ]
+        self.assertFalse(
+            git_diff_candidates,
+            f"git diff inside second heredoc body on same-line << leaked: {result}",
+        )
+
+    def test_two_heredocs_same_line_gh_api_contents_leaks(self) -> None:
+        """Triangulates same-line bug for the gh api contents?ref= matcher."""
+        from bash_redirect_hook import _matches_gh_api_contents
+
+        command = (
+            "cat <<EOF1 <<EOF2\n"
+            "EOF1 body\n"
+            "EOF1\n"
+            "gh api repos/owner/repo/contents/path?ref=abc123\n"
+            "EOF2\n"
+            "echo done\n"
+        )
+        result = _matches_gh_api_contents(command)
+        self.assertFalse(
+            result,
+            f"gh api contents?ref= inside second heredoc body on same-line << "
+            f"triggered false match: {result}",
         )
 
 
@@ -325,6 +364,20 @@ class TestDropHeredocBodies(unittest.TestCase):
     def test_no_heredoc_passes_through_unchanged(self) -> None:
         tokens = ["git", "diff", "main..HEAD"]
         self.assertEqual(_drop_heredoc_bodies(tokens), tokens)
+
+    def test_invalid_heredoc_tag_drops_all_remaining_tokens(self) -> None:
+        """``<<`` followed by an empty/invalid tag token (e.g., ``''``
+        or ``-`` alone) causes ``_heredoc_tag`` to return ``None``,
+        which triggers a ``break`` that drops all remaining tokens
+        instead of just skipping the malformed ``<<``."""
+        tokens = ["echo", "hi", "<<", "''", "\n", "git", "diff", "main..HEAD"]
+        result = _drop_heredoc_bodies(tokens)
+        self.assertIn(
+            "git", result, f"git diff after malformed << was dropped: {result}"
+        )
+        self.assertNotIn(
+            "<<", result, f"<< operator was preserved after malformed tag: {result}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +431,6 @@ class TestMatchesGhPrDiff(unittest.TestCase):
         self.assertFalse(_matches_gh_pr_diff(""))
 
 
-
 # ---------------------------------------------------------------------------
 # _matches_gh_api_contents
 # ---------------------------------------------------------------------------
@@ -387,9 +439,7 @@ class TestMatchesGhPrDiff(unittest.TestCase):
 class TestMatchesGhApiContents(unittest.TestCase):
     def test_gh_api_contents_with_ref_is_matched(self) -> None:
         self.assertTrue(
-            _matches_gh_api_contents(
-                "gh api repos/owner/repo/contents/path?ref=abc123"
-            )
+            _matches_gh_api_contents("gh api repos/owner/repo/contents/path?ref=abc123")
         )
 
     def test_gh_api_contents_with_multiple_params_is_matched(self) -> None:
@@ -401,24 +451,18 @@ class TestMatchesGhApiContents(unittest.TestCase):
 
     def test_gh_api_contents_without_ref_is_not_matched(self) -> None:
         self.assertFalse(
-            _matches_gh_api_contents(
-                "gh api repos/owner/repo/contents/path"
-            )
+            _matches_gh_api_contents("gh api repos/owner/repo/contents/path")
         )
 
     def test_gh_api_other_endpoint_is_not_matched(self) -> None:
-        self.assertFalse(
-            _matches_gh_api_contents("gh api repos/owner/repo/issues")
-        )
+        self.assertFalse(_matches_gh_api_contents("gh api repos/owner/repo/issues"))
 
     def test_gh_api_contents_no_path_before_ref_is_matched(self) -> None:
         """``contents/?ref=sha`` with no path segment before the query must
         still match — the old ``.+`` regex required at least one char between
         ``contents/`` and ``?ref=``."""
         self.assertTrue(
-            _matches_gh_api_contents(
-                "gh api repos/owner/repo/contents/?ref=abc123"
-            )
+            _matches_gh_api_contents("gh api repos/owner/repo/contents/?ref=abc123")
         )
 
     def test_empty_command_is_not_matched(self) -> None:
@@ -517,18 +561,14 @@ class TestDecideRedirect(unittest.TestCase):
 
     def test_gh_api_contents_with_ref_returns_advise(self) -> None:
         decision = decide_redirect(
-            self._bash_payload(
-                "gh api repos/owner/repo/contents/path?ref=abc123"
-            )
+            self._bash_payload("gh api repos/owner/repo/contents/path?ref=abc123")
         )
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_file_snapshots", decision.advice)
 
     def test_gh_api_contents_without_ref_returns_silent(self) -> None:
         decision = decide_redirect(
-            self._bash_payload(
-                "gh api repos/owner/repo/contents/path"
-            )
+            self._bash_payload("gh api repos/owner/repo/contents/path")
         )
         self.assertEqual(decision.mode, "silent")
 

--- a/hooks/test_bash_redirect_hook.py
+++ b/hooks/test_bash_redirect_hook.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from bash_redirect_hook import (
     _advice_with_echo,
+    _matches_gh_api_contents,
     _classify_git_command,
     _drop_heredoc_bodies,
     _has_pickaxe_flag,
@@ -38,27 +39,27 @@ from bash_redirect_hook import (
 
 
 class TestIsFunctionallyEmpty(unittest.TestCase):
-    def test_empty_string_is_empty(self):
+    def test_empty_string_is_empty(self) -> None:
         self.assertTrue(_is_functionally_empty(""))
 
-    def test_whitespace_only_is_empty(self):
+    def test_whitespace_only_is_empty(self) -> None:
         self.assertTrue(_is_functionally_empty("   \t  "))
 
-    def test_newline_only_is_empty(self):
+    def test_newline_only_is_empty(self) -> None:
         self.assertTrue(_is_functionally_empty("\n"))
 
-    def test_escaped_newline_sequence_is_empty(self):
+    def test_escaped_newline_sequence_is_empty(self) -> None:
         # The BDD scenario pipes the literal four-character string "\\n  \\n".
         # _is_functionally_empty must translate escape sequences before checking.
         self.assertTrue(_is_functionally_empty("\\n  \\n"))
 
-    def test_mixed_escape_sequences_are_empty(self):
+    def test_mixed_escape_sequences_are_empty(self) -> None:
         self.assertTrue(_is_functionally_empty("\\n\\t\\r"))
 
-    def test_non_whitespace_is_not_empty(self):
+    def test_non_whitespace_is_not_empty(self) -> None:
         self.assertFalse(_is_functionally_empty("git diff"))
 
-    def test_json_is_not_empty(self):
+    def test_json_is_not_empty(self) -> None:
         self.assertFalse(_is_functionally_empty('{"tool_name": "Bash"}'))
 
 
@@ -68,22 +69,22 @@ class TestIsFunctionallyEmpty(unittest.TestCase):
 
 
 class TestHasRefRange(unittest.TestCase):
-    def test_double_dot_range_is_detected(self):
+    def test_double_dot_range_is_detected(self) -> None:
         self.assertTrue(_has_ref_range(["main..HEAD"]))
 
-    def test_triple_dot_range_is_detected(self):
+    def test_triple_dot_range_is_detected(self) -> None:
         self.assertTrue(_has_ref_range(["main...HEAD"]))
 
-    def test_bare_double_dot_is_excluded(self):
+    def test_bare_double_dot_is_excluded(self) -> None:
         # ".." is the parent-directory shorthand, not a ref range.
         self.assertFalse(_has_ref_range([".."]))
-    def test_bare_triple_dot_is_excluded(self):
+    def test_bare_triple_dot_is_excluded(self) -> None:
         self.assertFalse(_has_ref_range(["..."]))
 
-    def test_no_range_returns_false(self):
+    def test_no_range_returns_false(self) -> None:
         self.assertFalse(_has_ref_range(["git", "diff", "--stat"]))
 
-    def test_range_anywhere_in_list_is_detected(self):
+    def test_range_anywhere_in_list_is_detected(self) -> None:
         self.assertTrue(_has_ref_range(["git", "diff", "feature..main"]))
 
 
@@ -93,23 +94,23 @@ class TestHasRefRange(unittest.TestCase):
 
 
 class TestHasPickaxeFlag(unittest.TestCase):
-    def test_standalone_dash_s(self):
+    def test_standalone_dash_s(self) -> None:
         self.assertTrue(_has_pickaxe_flag(["-S"]))
 
-    def test_standalone_dash_g(self):
+    def test_standalone_dash_g(self) -> None:
         self.assertTrue(_has_pickaxe_flag(["-G"]))
 
-    def test_concatenated_dash_s_term(self):
+    def test_concatenated_dash_s_term(self) -> None:
         # -Sfoo is a single token when the user writes it without a space.
         self.assertTrue(_has_pickaxe_flag(["-Sfoo"]))
 
-    def test_concatenated_dash_g_term(self):
+    def test_concatenated_dash_g_term(self) -> None:
         self.assertTrue(_has_pickaxe_flag(["-Gbar"]))
 
-    def test_other_flags_not_matched(self):
+    def test_other_flags_not_matched(self) -> None:
         self.assertFalse(_has_pickaxe_flag(["-p", "--oneline", "-n"]))
 
-    def test_empty_list_returns_false(self):
+    def test_empty_list_returns_false(self) -> None:
         self.assertFalse(_has_pickaxe_flag([]))
 
 
@@ -119,66 +120,66 @@ class TestHasPickaxeFlag(unittest.TestCase):
 
 
 class TestClassifyGitCommand(unittest.TestCase):
-    def test_git_diff_with_ref_range_returns_change_manifest(self):
+    def test_git_diff_with_ref_range_returns_change_manifest(self) -> None:
         self.assertEqual(
             _classify_git_command(["git", "diff", "main..HEAD"]),
             "get_change_manifest",
         )
 
-    def test_git_log_with_ref_range_returns_commit_history(self):
+    def test_git_log_with_ref_range_returns_commit_history(self) -> None:
         self.assertEqual(
             _classify_git_command(["git", "log", "main..HEAD"]),
             "get_commit_history",
         )
 
-    def test_git_log_with_pickaxe_returns_function_context(self):
+    def test_git_log_with_pickaxe_returns_function_context(self) -> None:
         # Pickaxe check must take priority over the ref-range check for git log.
         self.assertEqual(
             _classify_git_command(["git", "log", "-S", "foo"]),
             "get_function_context",
         )
 
-    def test_git_log_pickaxe_priority_over_range(self):
+    def test_git_log_pickaxe_priority_over_range(self) -> None:
         # Both pickaxe AND range present — pickaxe wins.
         self.assertEqual(
             _classify_git_command(["git", "log", "-S", "foo", "main..HEAD"]),
             "get_function_context",
         )
 
-    def test_git_blame_returns_file_snapshots(self):
+    def test_git_blame_returns_file_snapshots(self) -> None:
         self.assertEqual(
             _classify_git_command(["git", "blame", "src/main.rs"]),
             "get_file_snapshots",
         )
 
-    def test_git_show_returns_file_snapshots(self):
+    def test_git_show_returns_file_snapshots(self) -> None:
         self.assertEqual(
             _classify_git_command(["git", "show", "abc123:src/main.rs"]),
             "get_file_snapshots",
         )
 
-    def test_git_status_returns_none(self):
+    def test_git_status_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["git", "status"]))
 
-    def test_git_add_returns_none(self):
+    def test_git_add_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["git", "add", "file.txt"]))
 
-    def test_git_commit_returns_none(self):
+    def test_git_commit_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["git", "commit", "-m", "msg"]))
 
-    def test_git_push_returns_none(self):
+    def test_git_push_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["git", "push", "origin"]))
 
-    def test_git_fetch_returns_none(self):
+    def test_git_fetch_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["git", "fetch", "origin"]))
 
-    def test_non_git_command_returns_none(self):
+    def test_non_git_command_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command(["ls", "-la"]))
 
-    def test_empty_list_returns_none(self):
+    def test_empty_list_returns_none(self) -> None:
         self.assertIsNone(_classify_git_command([]))
 
-    def test_git_diff_without_range_returns_none(self):
+    def test_git_diff_without_range_returns_none(self) -> None:
         # Plain "git diff" (working-tree diff) — no range token, no redirect.
         self.assertIsNone(_classify_git_command(["git", "diff"]))
 
@@ -189,23 +190,23 @@ class TestClassifyGitCommand(unittest.TestCase):
 
 
 class TestTokenizeCommand(unittest.TestCase):
-    def test_simple_git_diff(self):
+    def test_simple_git_diff(self) -> None:
         result = tokenize_command("git diff main..HEAD")
         self.assertEqual(result, [["git", "diff", "main..HEAD"]])
 
-    def test_compound_and_command(self):
+    def test_compound_and_command(self) -> None:
         result = tokenize_command("cd /tmp && git diff main..HEAD")
         self.assertIn(["git", "diff", "main..HEAD"], result)
 
-    def test_subshell_parentheses(self):
+    def test_subshell_parentheses(self) -> None:
         result = tokenize_command("(git log main..HEAD)")
         self.assertIn(["git", "log", "main..HEAD"], result)
 
-    def test_pipeline(self):
+    def test_pipeline(self) -> None:
         result = tokenize_command("git diff main..HEAD | grep foo")
         self.assertIn(["git", "diff", "main..HEAD"], result)
 
-    def test_backtick_normalization(self):
+    def test_backtick_normalization(self) -> None:
         # Backticks are converted to spaces; outer git diff is still found.
         result = tokenize_command(
             "cd `git rev-parse --show-toplevel` && git diff main..HEAD"
@@ -215,7 +216,7 @@ class TestTokenizeCommand(unittest.TestCase):
         ]
         self.assertTrue(git_diff, f"git diff candidate missing from {result}")
 
-    def test_variable_not_expanded(self):
+    def test_variable_not_expanded(self) -> None:
         # $BASE must appear verbatim — never as the env-var's value.
         result = tokenize_command("git diff $BASE..HEAD")
         flat_tokens = [tok for cand in result for tok in cand]
@@ -224,17 +225,36 @@ class TestTokenizeCommand(unittest.TestCase):
             f"Expected literal '$BASE' in tokens, got: {flat_tokens}",
         )
 
-    def test_empty_command_returns_empty_list(self):
+    def test_empty_command_returns_empty_list(self) -> None:
         self.assertEqual(tokenize_command(""), [])
 
-    def test_heredoc_body_is_skipped(self):
+    def test_heredoc_body_is_skipped(self) -> None:
         # git log inside a heredoc body must NOT produce a candidate.
         command = "cat <<EOF\ngit log a..b\nEOF\n"
         result = tokenize_command(command)
         git_log = [c for c in result if c and c[0] == "git"]
         self.assertFalse(git_log, f"git command inside heredoc body leaked: {result}")
 
-    def test_tokenizer_resumes_after_heredoc_terminator(self):
+    def test_heredoc_indented_delimiter_in_body_is_not_terminated(self) -> None:
+        """Indented EOF inside a heredoc body must NOT terminate the heredoc."""
+        command = (
+            "cat <<EOF\n"
+            "  EOF\n"
+            "git diff main..HEAD\n"
+            "EOF\n"
+        )
+        result = tokenize_command(command)
+        git_diff_candidates = [
+            c for c in result
+            if c and c[0] == "git" and len(c) > 1 and c[1] == "diff"
+        ]
+        self.assertFalse(
+            git_diff_candidates,
+            f"git diff inside heredoc body leaked after indented faux-tag: "
+            f"{result}",
+        )
+
+    def test_tokenizer_resumes_after_heredoc_terminator(self) -> None:
         # After the closing tag, git diff on the next line must be detected.
         command = "cat <<EOF\ngit log a..b\nEOF\ngit diff main..HEAD"
         result = tokenize_command(command)
@@ -250,6 +270,27 @@ class TestTokenizeCommand(unittest.TestCase):
             f"git log inside heredoc body leaked into candidates: {result}",
         )
 
+    def test_digit_starting_heredoc_tag_body_is_skipped(self) -> None:
+        """Heredoc tag starting with a digit (e.g., ``<<'1'``) inside a
+        multi-line quoted string must still be recognized by the _strip_heredocs
+        pre-pass, and its body skipped, preventing ``gh pr diff`` (or any git
+        command) from leaking into candidates."""
+        command = (
+            'echo "$(cat <<\'1\'\n'
+            'gh pr diff 123 --repo owner/repo\n'
+            '1\n'
+            ') done"\n'
+        )
+        result = tokenize_command(command)
+        gh_pr_diff = [
+            c for c in result
+            if c and len(c) >= 2 and c[0] == "gh" and c[1] == "pr"
+        ]
+        self.assertFalse(
+            gh_pr_diff,
+            f"gh pr diff inside digit-tag quoted-heredoc body leaked: {result}",
+        )
+
 
 # ---------------------------------------------------------------------------
 # _drop_heredoc_bodies
@@ -257,31 +298,31 @@ class TestTokenizeCommand(unittest.TestCase):
 
 
 class TestDropHeredocBodies(unittest.TestCase):
-    def test_simple_heredoc_body_is_dropped(self):
+    def test_simple_heredoc_body_is_dropped(self) -> None:
         tokens = ["cat", "<<", "EOF", "\n", "git", "\n", "EOF", "\n", "echo", "done"]
         result = _drop_heredoc_bodies(tokens)
         self.assertNotIn("git", result)
         self.assertIn("echo", result)
         self.assertIn("done", result)
 
-    def test_dash_form_heredoc_body_is_dropped(self):
+    def test_dash_form_heredoc_body_is_dropped(self) -> None:
         # shlex glues the "-" onto the tag word: << then -EOF
         tokens = ["cat", "<<", "-EOF", "\n", "git", "\n", "EOF", "\n", "echo", "done"]
         result = _drop_heredoc_bodies(tokens)
         self.assertNotIn("git", result)
         self.assertIn("echo", result)
 
-    def test_content_before_heredoc_is_preserved(self):
+    def test_content_before_heredoc_is_preserved(self) -> None:
         tokens = ["echo", "hi", "<<", "EOF", "\n", "body", "\n", "EOF"]
         result = _drop_heredoc_bodies(tokens)
         self.assertIn("echo", result)
         self.assertIn("hi", result)
         self.assertNotIn("body", result)
 
-    def test_empty_token_list_returns_empty(self):
+    def test_empty_token_list_returns_empty(self) -> None:
         self.assertEqual(_drop_heredoc_bodies([]), [])
 
-    def test_no_heredoc_passes_through_unchanged(self):
+    def test_no_heredoc_passes_through_unchanged(self) -> None:
         tokens = ["git", "diff", "main..HEAD"]
         self.assertEqual(_drop_heredoc_bodies(tokens), tokens)
 
@@ -292,12 +333,12 @@ class TestDropHeredocBodies(unittest.TestCase):
 
 
 class TestAdviceWithEcho(unittest.TestCase):
-    def test_echo_appends_verbatim_tokens(self):
+    def test_echo_appends_verbatim_tokens(self) -> None:
         tokens = ["git", "diff", "main..HEAD"]
         result = _advice_with_echo("base advice", tokens)
         self.assertIn("You ran: git diff main..HEAD", result)
 
-    def test_variable_not_expanded_in_echo(self):
+    def test_variable_not_expanded_in_echo(self) -> None:
         # The token list contains the literal string "$BASE". The echo must
         # reproduce it verbatim — proving no os.path.expandvars or shell
         # expansion happened anywhere in the call chain.
@@ -309,7 +350,7 @@ class TestAdviceWithEcho(unittest.TestCase):
             f"Expected literal '$BASE..HEAD' in advice, got: {result!r}",
         )
 
-    def test_base_advice_is_included(self):
+    def test_base_advice_is_included(self) -> None:
         tokens = ["git", "log", "main..HEAD"]
         result = _advice_with_echo("USE GET_COMMIT_HISTORY", tokens)
         self.assertIn("USE GET_COMMIT_HISTORY", result)
@@ -321,20 +362,67 @@ class TestAdviceWithEcho(unittest.TestCase):
 
 
 class TestMatchesGhPrDiff(unittest.TestCase):
-    def test_plain_gh_pr_diff_is_matched(self):
+    def test_plain_gh_pr_diff_is_matched(self) -> None:
         self.assertTrue(_matches_gh_pr_diff("gh pr diff 123"))
 
-    def test_compound_gh_pr_diff_is_matched(self):
+    def test_compound_gh_pr_diff_is_matched(self) -> None:
         self.assertTrue(_matches_gh_pr_diff("cd /tmp && gh pr diff 123"))
 
-    def test_gh_pr_view_is_not_matched(self):
+    def test_gh_pr_view_is_not_matched(self) -> None:
         self.assertFalse(_matches_gh_pr_diff("gh pr view 123"))
 
-    def test_git_diff_is_not_matched(self):
+    def test_git_diff_is_not_matched(self) -> None:
         self.assertFalse(_matches_gh_pr_diff("git diff main..HEAD"))
 
-    def test_empty_command_is_not_matched(self):
+    def test_empty_command_is_not_matched(self) -> None:
         self.assertFalse(_matches_gh_pr_diff(""))
+
+
+
+# ---------------------------------------------------------------------------
+# _matches_gh_api_contents
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesGhApiContents(unittest.TestCase):
+    def test_gh_api_contents_with_ref_is_matched(self) -> None:
+        self.assertTrue(
+            _matches_gh_api_contents(
+                "gh api repos/owner/repo/contents/path?ref=abc123"
+            )
+        )
+
+    def test_gh_api_contents_with_multiple_params_is_matched(self) -> None:
+        self.assertTrue(
+            _matches_gh_api_contents(
+                "gh api repos/owner/repo/contents/path?foo=bar&ref=abc123"
+            )
+        )
+
+    def test_gh_api_contents_without_ref_is_not_matched(self) -> None:
+        self.assertFalse(
+            _matches_gh_api_contents(
+                "gh api repos/owner/repo/contents/path"
+            )
+        )
+
+    def test_gh_api_other_endpoint_is_not_matched(self) -> None:
+        self.assertFalse(
+            _matches_gh_api_contents("gh api repos/owner/repo/issues")
+        )
+
+    def test_gh_api_contents_no_path_before_ref_is_matched(self) -> None:
+        """``contents/?ref=sha`` with no path segment before the query must
+        still match — the old ``.+`` regex required at least one char between
+        ``contents/`` and ``?ref=``."""
+        self.assertTrue(
+            _matches_gh_api_contents(
+                "gh api repos/owner/repo/contents/?ref=abc123"
+            )
+        )
+
+    def test_empty_command_is_not_matched(self) -> None:
+        self.assertFalse(_matches_gh_api_contents(""))
 
 
 # ---------------------------------------------------------------------------
@@ -343,43 +431,43 @@ class TestMatchesGhPrDiff(unittest.TestCase):
 
 
 class TestDecideRedirect(unittest.TestCase):
-    def _bash_payload(self, command: str) -> dict:
+    def _bash_payload(self, command: str) -> dict[str, str | dict[str, str]]:
         return {
             "tool_name": "Bash",
             "tool_input": {"command": command},
             "hook_event_name": "PreToolUse",
         }
 
-    def test_git_diff_with_range_returns_advise(self):
+    def test_git_diff_with_range_returns_advise(self) -> None:
         decision = decide_redirect(self._bash_payload("git diff main..HEAD"))
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_change_manifest", decision.advice)
 
-    def test_git_log_with_range_returns_advise(self):
+    def test_git_log_with_range_returns_advise(self) -> None:
         decision = decide_redirect(self._bash_payload("git log main..HEAD"))
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_commit_history", decision.advice)
 
-    def test_git_log_pickaxe_returns_advise_for_function_context(self):
+    def test_git_log_pickaxe_returns_advise_for_function_context(self) -> None:
         decision = decide_redirect(self._bash_payload("git log -S foo"))
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_function_context", decision.advice)
 
-    def test_git_blame_returns_advise_for_file_snapshots(self):
+    def test_git_blame_returns_advise_for_file_snapshots(self) -> None:
         decision = decide_redirect(self._bash_payload("git blame src/main.rs"))
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_file_snapshots", decision.advice)
 
-    def test_git_status_returns_silent(self):
+    def test_git_status_returns_silent(self) -> None:
         decision = decide_redirect(self._bash_payload("git status"))
         self.assertEqual(decision.mode, "silent")
 
-    def test_gh_pr_diff_returns_block(self):
+    def test_gh_pr_diff_returns_block(self) -> None:
         decision = decide_redirect(self._bash_payload("gh pr diff 123"))
         self.assertEqual(decision.mode, "block")
         self.assertIn("get_change_manifest", decision.message)
 
-    def test_mcp_github_get_commit_tool_name_returns_block(self):
+    def test_mcp_github_get_commit_tool_name_returns_block(self) -> None:
         payload = {
             "tool_name": "mcp__github__get_commit",
             "tool_input": {},
@@ -389,13 +477,13 @@ class TestDecideRedirect(unittest.TestCase):
         self.assertEqual(decision.mode, "block")
         self.assertIn("git-prism", decision.message)
 
-    def test_mcp_github_get_commit_as_bash_command_returns_block(self):
+    def test_mcp_github_get_commit_as_bash_command_returns_block(self) -> None:
         decision = decide_redirect(
             self._bash_payload("mcp__github__get_commit owner=foo repo=bar sha=abc")
         )
         self.assertEqual(decision.mode, "block")
 
-    def test_mcp_github_list_commits_tool_name_returns_block(self):
+    def test_mcp_github_list_commits_tool_name_returns_block(self) -> None:
         payload = {
             "tool_name": "mcp__github__list_commits",
             "tool_input": {},
@@ -404,13 +492,13 @@ class TestDecideRedirect(unittest.TestCase):
         decision = decide_redirect(payload)
         self.assertEqual(decision.mode, "block")
 
-    def test_mcp_github_list_commits_as_bash_command_returns_block(self):
+    def test_mcp_github_list_commits_as_bash_command_returns_block(self) -> None:
         decision = decide_redirect(
             self._bash_payload("mcp__github__list_commits owner=foo repo=bar")
         )
         self.assertEqual(decision.mode, "block")
 
-    def test_non_bash_tool_is_silent(self):
+    def test_non_bash_tool_is_silent(self) -> None:
         payload = {
             "tool_name": "Read",
             "tool_input": {"file_path": "/tmp/file"},
@@ -419,15 +507,32 @@ class TestDecideRedirect(unittest.TestCase):
         decision = decide_redirect(payload)
         self.assertEqual(decision.mode, "silent")
 
-    def test_empty_command_is_silent(self):
+    def test_empty_command_is_silent(self) -> None:
         decision = decide_redirect(self._bash_payload(""))
         self.assertEqual(decision.mode, "silent")
 
-    def test_missing_tool_name_is_silent(self):
+    def test_missing_tool_name_is_silent(self) -> None:
         decision = decide_redirect({})
         self.assertEqual(decision.mode, "silent")
 
-    def test_variable_in_command_does_not_expand(self):
+    def test_gh_api_contents_with_ref_returns_advise(self) -> None:
+        decision = decide_redirect(
+            self._bash_payload(
+                "gh api repos/owner/repo/contents/path?ref=abc123"
+            )
+        )
+        self.assertEqual(decision.mode, "advise")
+        self.assertIn("get_file_snapshots", decision.advice)
+
+    def test_gh_api_contents_without_ref_returns_silent(self) -> None:
+        decision = decide_redirect(
+            self._bash_payload(
+                "gh api repos/owner/repo/contents/path"
+            )
+        )
+        self.assertEqual(decision.mode, "silent")
+
+    def test_variable_in_command_does_not_expand(self) -> None:
         # The advice text must contain the literal "$BASE", not an expanded value.
         decision = decide_redirect(self._bash_payload("git diff $BASE..HEAD"))
         self.assertEqual(decision.mode, "advise")
@@ -437,7 +542,7 @@ class TestDecideRedirect(unittest.TestCase):
             f"Expected literal '$BASE' in advice, got: {decision.advice!r}",
         )
 
-    def test_heredoc_body_git_command_is_not_advised(self):
+    def test_heredoc_body_git_command_is_not_advised(self) -> None:
         # git log inside a heredoc body must NOT trigger advice.
         command = "cat <<EOF\ngit log a..b\nEOF\n"
         decision = decide_redirect(self._bash_payload(command))
@@ -447,7 +552,7 @@ class TestDecideRedirect(unittest.TestCase):
             f"Expected silent for heredoc-body git, got mode={decision.mode!r}",
         )
 
-    def test_git_diff_after_heredoc_is_advised(self):
+    def test_git_diff_after_heredoc_is_advised(self) -> None:
         # After the heredoc closes, git diff must still be detected.
         command = "cat <<EOF\ngit log a..b\nEOF\ngit diff main..HEAD"
         decision = decide_redirect(self._bash_payload(command))


### PR DESCRIPTION
## Summary

Fixes two bugs in the bash redirect hook identified in #270:

- **Bug 1 (False positive):** `gh pr diff` inside heredoc bodies was incorrectly blocked when `<<` was inside a multi-line double-quoted string. Fixed by adding a regex pre-pass that strips heredoc bodies before tokenization.
- **Bug 2 (False negative):** `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>` bypassed the hook entirely. Fixed by detecting the contents-API-with-ref pattern and redirecting to `get_file_snapshots`.

## Commits
```
e5c3b4b fix: handle multiple heredocs on same line and malformed << without tag
c900c88 fix: allow digit-starting heredoc tags and match contents/ directly followed by ?ref=
018cfb0 fix: apply heredoc pre-pass to gh api contents interception
eae980e docs: document heredoc pre-pass and gh api contents interception
afccdd6 style: remove unused import io from bash_redirect_hook.py
d3de8fe fix: strip heredoc bodies from raw text and intercept gh api contents ref= calls
bb1a3ba test: add @ISSUE-270 BDD scenarios (RED)
```

## Test plan
- [x] 85 unit tests pass
- [x] 3 `@ISSUE-270` BDD scenarios pass
- [x] All 52 redirect_hook BDD scenarios pass (278 steps)
- [x] Adversarial QA (3 passes): 7 bugs found, all fixed
- [x] Church purification: python-purist, naming-purist, dead-code-purist, observability-purist

Closes #270

Generated with [Claude Code](https://claude.ai/claude-code)