### PR TITLE
fix: surface review_change in bash-redirect hook messages, fix unicode encoding

### DIFF
--- a/bdd/features/redirect_hook.feature
+++ b/bdd/features/redirect_hook.feature
@@ -303,6 +303,7 @@ Feature: Redirect hooks for raw git invocations
     Then the hook exit code is 2
     And the hook stderr contains "git-prism"
     And the hook stderr contains "get_change_manifest"
+    And the hook stderr contains "review_change"
 
   @ISSUE-239
   Scenario: Bundled hook hard-blocks "mcp__github__get_commit" with exit code 2
@@ -538,3 +539,27 @@ Feature: Redirect hooks for raw git invocations
     Given the git-prism MCP server is running over stdio
     When I send a "tools/list" JSON-RPC request
     Then the description for "review_change" mentions "git diff"
+
+  # ------------------------------------------------------------------------
+  # W6: Surface review_change in bash-redirect hook message (#265)
+  #
+  # The bundled hook's redirect messages now recommend `review_change` as the
+  # primary tool for PR review workflows, with `get_change_manifest` as the
+  # quick file-level alternative.
+  # ------------------------------------------------------------------------
+
+  @ISSUE-265
+  Scenario: Advisory path surfaces both review_change and get_change_manifest
+    Given a hook input with bash command "git diff main..HEAD"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 0
+    And the hook stdout contains "review_change"
+    And the hook stdout contains "get_change_manifest"
+
+  @ISSUE-265
+  Scenario: Hard-block path surfaces both review_change and get_change_manifest
+    Given a hook input with bash command "gh pr diff 123"
+    When I run the bundled redirect hook with that input
+    Then the hook exit code is 2
+    And the hook stderr contains "review_change"
+    And the hook stderr contains "get_change_manifest"

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -296,9 +296,11 @@ def tokenize_command(command: str) -> list[list[str]]:
 # instead. The text below is what Claude Code surfaces back to the model
 # via the ``additionalContext`` field on the hook's stdout JSON.
 ADVICE_GET_CHANGE_MANIFEST = (
-    "git diff between refs returns raw text. git-prism alternative:\n"
-    "  get_change_manifest(repo_path, base_ref, head_ref, "
-    "include_function_analysis=true)\n"
+    "git diff between refs returns raw text. git-prism alternatives:\n"
+    "  review_change(repo_path, base_ref, head_ref)       "
+    "← full PR review (manifest + function context)\n"
+    "  get_change_manifest(repo_path, base_ref, head_ref)  "
+    "← quick file-level scan\n"
     "Returns structured per-file change data with function-level semantic "
     "analysis."
 )
@@ -328,8 +330,10 @@ ADVICE_GET_FILE_SNAPSHOTS_SHOW = (
 
 BLOCK_GH_PR_DIFF = (
     "git-prism: gh pr diff returns raw text. Use git-prism instead:\n"
-    "  get_change_manifest(repo_path, base_ref, head_ref, "
-    "include_function_analysis=true)\n"
+    "  review_change(repo_path, base_ref, head_ref)       "
+    "← full PR review (manifest + function context)\n"
+    "  get_change_manifest(repo_path, base_ref, head_ref)  "
+    "← quick file-level scan\n"
     "Structured per-function change data — same info, no diff noise."
 )
 BLOCK_MCP_GITHUB_GET_COMMIT = (

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -74,7 +74,7 @@ def _tokenize_line(line: str) -> list[str]:
     contents would confuse a single-pass lexer (mismatched quotes that
     only close inside the body, for instance) cannot poison the parse
     of the surrounding code. On lex failure the offending line is
-    represented by an empty list — the heredoc walker still sees the
+    represented by an empty list -- the heredoc walker still sees the
     surrounding ``\n`` markers and the matcher safely no-ops on the
     blank slice.
     """
@@ -213,7 +213,7 @@ def _drop_heredoc_bodies(tokens: list[str]) -> list[str]:
                 _heredoc_tag(tokens[index + 1]) if index + 1 < len(tokens) else None
             )
             if tag_info is None:
-                # ``<<`` followed by an invalid/empty tag — skip the
+                # ``<<`` followed by an invalid/empty tag -- skip the
                 # malformed operator and continue.
                 index += 1
                 continue
@@ -222,7 +222,7 @@ def _drop_heredoc_bodies(tokens: list[str]) -> list[str]:
             index += 2
             # Drop everything on the same line as the operator (it's
             # part of the heredoc opening, e.g. ``cat <<EOF; echo hi``
-            # has ``; echo hi`` after the tag — bash treats it as the
+            # has ``; echo hi`` after the tag -- bash treats it as the
             # rest of the command line, not the heredoc body).
             while index < len(tokens) and tokens[index] != _NEWLINE_MARKER:
                 index += 1
@@ -230,7 +230,7 @@ def _drop_heredoc_bodies(tokens: list[str]) -> list[str]:
             # only the closing tag.
             while index < len(tokens):
                 if tokens[index] != _NEWLINE_MARKER:
-                    # Inside body content — keep walking.
+                    # Inside body content -- keep walking.
                     index += 1
                     continue
                 # Just consumed a ``\n``. Peek at the next line.
@@ -264,7 +264,7 @@ def tokenize_command(command: str) -> list[list[str]]:
 
     The outer list represents pipeline / compound boundaries; each inner
     list is the tokens of a single candidate command. Empty inner lists
-    are dropped — for example, ``(git status)`` produces ``['git',
+    are dropped -- for example, ``(git status)`` produces ``['git',
     'status']`` after the ``(`` and ``)`` are consumed as separators.
     """
     flat = _tokenize_raw(command)
@@ -313,7 +313,7 @@ ADVICE_GET_FUNCTION_CONTEXT = (
     "git log -S/-G (pickaxe) returns raw text. git-prism alternative:\n"
     "  get_function_context(repo_path, base_ref, head_ref)\n"
     "Returns callers, definitions, and test references for every changed "
-    "function — structured and cross-referenced."
+    "function -- structured and cross-referenced."
 )
 ADVICE_GET_FILE_SNAPSHOTS_BLAME = (
     "git blame returns raw line-by-line text. git-prism alternative:\n"
@@ -341,7 +341,7 @@ BLOCK_MCP_GITHUB_GET_COMMIT = (
     "git-prism instead:\n"
     "  get_file_snapshots(repo_path, base_ref='<sha>^', head_ref='<sha>', "
     "paths=[...], include_before=true, include_after=true)\n"
-    "Structured before/after content per file — no raw patch format."
+    "Structured before/after content per file -- no raw patch format."
 )
 BLOCK_MCP_GITHUB_LIST_COMMITS = (
     "git-prism: mcp__github__list_commits returns a raw list. Use "
@@ -355,7 +355,7 @@ ADVICE_GET_FILE_SNAPSHOTS_GH_API = (
     "git-prism alternative:\n"
     "  get_file_snapshots(repo_path, base_ref='<ref>^', head_ref='<ref>', "
     "paths=[...], include_before=true, include_after=true)\n"
-    "Returns structured before/after file content at the commit boundary — "
+    "Returns structured before/after file content at the commit boundary -- "
     "no raw API response to parse."
 )
 
@@ -409,7 +409,7 @@ def _has_pickaxe_flag(tokens: Iterable[str]) -> bool:
         if tok in ("-S", "-G"):
             return True
         if tok.startswith("-S") or tok.startswith("-G"):
-            # ``-Sterm`` / ``-Gterm`` — a single-token concatenation.
+            # ``-Sterm`` / ``-Gterm`` -- a single-token concatenation.
             if len(tok) > 2:
                 return True
     return False
@@ -427,7 +427,7 @@ def _classify_git_command(tokens: list[str]) -> str | None:
     git_subcommand = tokens[1]
     rest = tokens[2:]
 
-    # ``git log -S/-G`` is pickaxe — distinct redirect target. Check
+    # ``git log -S/-G`` is pickaxe -- distinct redirect target. Check
     # before the generic ``git log a..b`` rule, which would otherwise
     # claim the same call.
     if git_subcommand == "log" and _has_pickaxe_flag(rest):
@@ -447,7 +447,7 @@ def _advice_for_tool(tool_name: str, git_subcommand: str | None = None) -> str:
     """Return the ``additionalContext`` payload for a redirect target.
 
     ``git_subcommand`` distinguishes ``git blame`` from ``git show`` when both
-    map to ``get_file_snapshots`` — the agent benefits from seeing the form
+    map to ``get_file_snapshots`` -- the agent benefits from seeing the form
     that matches its original intent.
     """
     if tool_name == "get_change_manifest":
@@ -533,7 +533,7 @@ def decide_redirect(hook_event_payload: dict[str, Any]) -> Decision:
 
 def _decide_redirect_for_bash_command(command: str) -> Decision:
     """Dispatch a bash command string to the right Decision."""
-    # ``gh pr diff`` is a hard block — don't even let the bash tokenizer
+    # ``gh pr diff`` is a hard block -- don't even let the bash tokenizer
     # claim it, because we want exit 2 not exit 0.
     if _matches_gh_pr_diff(command):
         return Decision("block", message=BLOCK_GH_PR_DIFF, tool_name="Bash")
@@ -592,7 +592,7 @@ def _advice_with_echo(base_advice: str, tokens: list[str]) -> str:
     surface verbatim in the advice payload, never as the value of the
     surrounding env var. Including the literal command in the advice
     proves the tokenizer kept the raw form AND gives the agent a clear
-    "you typed X — try Y instead" framing.
+    "you typed X -- try Y instead" framing.
     """
     echoed = " ".join(tokens)
     return f"{base_advice}\n\nYou ran: {echoed}"
@@ -655,7 +655,7 @@ def _read_payload(stdin: IO[str]) -> dict[str, Any] | None:
         return parsed
     except json.JSONDecodeError:
         sys.stderr.write(
-            "git-prism-redirect: malformed JSON on stdin — skipping redirect\n"
+            "git-prism-redirect: malformed JSON on stdin -- skipping redirect\n"
         )
         return None
 
@@ -688,7 +688,7 @@ def main() -> int:
         payload = _read_payload(sys.stdin)
     except Exception:  # pragma: no cover - last-resort safety net
         sys.stderr.write(
-            "git-prism-redirect: unexpected stdin error — skipping redirect\n"
+            "git-prism-redirect: unexpected stdin error -- skipping redirect\n"
         )
         return 0
 

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -179,6 +179,11 @@ def _tokenize_raw(command: str) -> list[str]:
     cleaned = _strip_backticks(command)
     if not cleaned:
         return []
+    # Handle escaped newlines: \<newline> is bash line continuation.
+    # Both the backslash and the newline are removed, joining the lines.
+    # This must happen before splitting into lines, otherwise the
+    # second line appears as a separate command.
+    cleaned = re.sub(r'\\\n', '', cleaned)
     # Pre-pass: regex-strip heredoc bodies that shlex cannot tokenize,
     # preventing false-positive matches from leaked body text.
     cleaned = _strip_heredocs_from_raw(cleaned)
@@ -375,13 +380,20 @@ def _matches_gh_api_contents(command: str) -> bool:
     ``/contents/`` paths without ``ref=`` are metadata or directory-listing
     calls and pass through silently.
 
-    The heredoc pre-pass is applied to the raw command before regex matching
-    so ``gh api .../contents/...?ref=...`` text inside a heredoc body does
-    not trigger a false-positive redirect.
+    The tokenizer-based approach correctly handles heredoc bodies (they are
+    stripped before candidate-command matching) and quoted strings (the
+    pattern only matches on actual command tokens, not quoted arguments to
+    echo or other non-gh commands).
     """
-    # Strip heredoc bodies first to avoid matching inside opaque body text.
-    cleaned = _strip_heredocs_from_raw(_strip_backticks(command))
-    return bool(_GH_API_CONTENTS_PATTERN.search(cleaned))
+    candidates = tokenize_command(command)
+    for tokens in candidates:
+        if len(tokens) >= 2 and tokens[0] == "gh" and tokens[1] == "api":
+            # Join remaining tokens to reconstruct URL paths that
+            # shlex may have split at & or other punctuation chars.
+            rest = "".join(tokens[2:])
+            if _GH_API_CONTENTS_PATTERN.search(rest):
+                return True
+    return False
 
 
 def _has_ref_range(tokens: Iterable[str]) -> bool:

--- a/hooks/bash_redirect_hook.py
+++ b/hooks/bash_redirect_hook.py
@@ -298,9 +298,9 @@ def tokenize_command(command: str) -> list[list[str]]:
 ADVICE_GET_CHANGE_MANIFEST = (
     "git diff between refs returns raw text. git-prism alternatives:\n"
     "  review_change(repo_path, base_ref, head_ref)       "
-    "← full PR review (manifest + function context)\n"
+    "--> full PR review (manifest + function context)\n"
     "  get_change_manifest(repo_path, base_ref, head_ref)  "
-    "← quick file-level scan\n"
+    "--> quick file-level scan\n"
     "Returns structured per-file change data with function-level semantic "
     "analysis."
 )
@@ -331,10 +331,10 @@ ADVICE_GET_FILE_SNAPSHOTS_SHOW = (
 BLOCK_GH_PR_DIFF = (
     "git-prism: gh pr diff returns raw text. Use git-prism instead:\n"
     "  review_change(repo_path, base_ref, head_ref)       "
-    "← full PR review (manifest + function context)\n"
+    "--> full PR review (manifest + function context)\n"
     "  get_change_manifest(repo_path, base_ref, head_ref)  "
-    "← quick file-level scan\n"
-    "Structured per-function change data — same info, no diff noise."
+    "--> quick file-level scan\n"
+    "Structured per-function change data -- same info, no diff noise."
 )
 BLOCK_MCP_GITHUB_GET_COMMIT = (
     "git-prism: mcp__github__get_commit returns raw diff text. Use "

--- a/hooks/test_bash_redirect_hook.py
+++ b/hooks/test_bash_redirect_hook.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from bash_redirect_hook import (
     BLOCK_GH_PR_DIFF,
+    BLOCK_MCP_GITHUB_GET_COMMIT,
     _advice_with_echo,
     _matches_gh_api_contents,
     _classify_git_command,
@@ -30,7 +31,9 @@ from bash_redirect_hook import (
     _is_functionally_empty,
     _matches_gh_pr_diff,
     _emit_advice,
+    _read_payload,
     decide_redirect,
+    main,
     tokenize_command,
 )
 
@@ -655,6 +658,82 @@ class TestUnicodeEncoding(unittest.TestCase):
             )
         finally:
             sys.stderr = old_stderr
+
+    def test_block_mcp_github_get_commit_is_ascii_safe(self):
+        """BLOCK_MCP_GITHUB_GET_COMMIT must contain only ASCII characters."""
+        for i, ch in enumerate(BLOCK_MCP_GITHUB_GET_COMMIT):
+            self.assertLess(
+                ord(ch),
+                128,
+                f"Non-ASCII char {ch!r} (U+{ord(ch):04X}) at index {i} in "
+                f"BLOCK_MCP_GITHUB_GET_COMMIT",
+            )
+
+    def test_block_mcp_github_get_commit_stderr_survives_ascii_locale(self):
+        """Block path for mcp__github__get_commit must survive ASCII-only stderr."""
+        import io
+        raw = io.BytesIO()
+        ascii_stderr = io.TextIOWrapper(raw, encoding="ascii")
+        old_stderr = sys.stderr
+        sys.stderr = ascii_stderr
+        try:
+            sys.stderr.write(BLOCK_MCP_GITHUB_GET_COMMIT)
+            sys.stderr.write("\n")
+            ascii_stderr.flush()
+        except UnicodeEncodeError:
+            self.fail(
+                "BLOCK_MCP_GITHUB_GET_COMMIT raised UnicodeEncodeError on ASCII stderr; "
+                "main() would silently downgrade a hard block to allow"
+            )
+        finally:
+            sys.stderr = old_stderr
+
+    def test_malformed_json_warning_survives_ascii_locale(self):
+        """Malformed JSON warning must survive ASCII-only stderr without crashing."""
+        import io
+        raw = io.BytesIO()
+        ascii_stderr = io.TextIOWrapper(raw, encoding="ascii")
+        old_stderr = sys.stderr
+        sys.stderr = ascii_stderr
+        fake_stdin = io.StringIO("this is not json {")
+        try:
+            result = _read_payload(fake_stdin)
+            self.assertIsNone(result)
+        except UnicodeEncodeError:
+            self.fail(
+                "_read_payload raised UnicodeEncodeError on ASCII stderr when "
+                "emitting malformed JSON warning; main() would crash instead of "
+                "returning fail-open exit 0"
+            )
+        finally:
+            sys.stderr = old_stderr
+
+    def test_main_unexpected_error_handler_survives_ascii_locale(self):
+        """main()'s outer exception handler must survive ASCII-only stderr."""
+        import io
+        raw = io.BytesIO()
+        ascii_stderr = io.TextIOWrapper(raw, encoding="ascii")
+        old_stderr = sys.stderr
+        old_stdin = sys.stdin
+        sys.stderr = ascii_stderr
+
+        class BrokenStdin:
+            def read(self):
+                raise RuntimeError("boom")
+
+        sys.stdin = BrokenStdin()
+        try:
+            result = main()
+            # main() should return 0 (fail-open) even when stdin read fails.
+            self.assertEqual(result, 0)
+        except UnicodeEncodeError:
+            self.fail(
+                "main() raised UnicodeEncodeError on ASCII stderr when handling "
+                "unexpected error; hook would crash instead of fail-open"
+            )
+        finally:
+            sys.stderr = old_stderr
+            sys.stdin = old_stdin
 
 
 if __name__ == "__main__":

--- a/hooks/test_bash_redirect_hook.py
+++ b/hooks/test_bash_redirect_hook.py
@@ -20,6 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from bash_redirect_hook import (
+    BLOCK_GH_PR_DIFF,
     _advice_with_echo,
     _matches_gh_api_contents,
     _classify_git_command,
@@ -28,6 +29,7 @@ from bash_redirect_hook import (
     _has_ref_range,
     _is_functionally_empty,
     _matches_gh_pr_diff,
+    _emit_advice,
     decide_redirect,
     tokenize_command,
 )
@@ -598,6 +600,61 @@ class TestDecideRedirect(unittest.TestCase):
         decision = decide_redirect(self._bash_payload(command))
         self.assertEqual(decision.mode, "advise")
         self.assertIn("get_change_manifest", decision.advice)
+
+
+# ---------------------------------------------------------------------------
+# Unicode encoding edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestUnicodeEncoding(unittest.TestCase):
+    """The hook messages added in #265 contain the Unicode arrow '←'.
+
+    The advisory path JSON-encodes the text (json.dumps defaults to
+    ensure_ascii=True), so Unicode is escaped to ← and is safe.
+    The block path writes the message directly to sys.stderr, which
+    raises UnicodeEncodeError in ASCII-only locales and silently
+    downgrades a hard block to a silent allow.
+    """
+
+    def test_advisory_path_is_ascii_safe(self):
+        """Advisory output must be ASCII-safe after json.dumps."""
+        import io
+        fake_stdout = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = fake_stdout
+        try:
+            _emit_advice(BLOCK_GH_PR_DIFF)
+        finally:
+            sys.stdout = old_stdout
+        output = fake_stdout.getvalue()
+        # No literal Unicode arrows; json.dumps would escape them anyway.
+        self.assertNotIn("←", output)
+        # Verify the message was emitted and contains ASCII-only arrows.
+        self.assertIn("-->", output)
+
+    def test_block_path_stderr_fails_on_ascii_locale(self):
+        """Block path must survive ASCII-only stderr without crashing."""
+        import io
+        # Create a TextIOWrapper that enforces ASCII encoding.
+        raw = io.BytesIO()
+        ascii_stderr = io.TextIOWrapper(raw, encoding="ascii")
+        old_stderr = sys.stderr
+        sys.stderr = ascii_stderr
+        try:
+            # This is exactly what main() does for a block decision.
+            sys.stderr.write(BLOCK_GH_PR_DIFF)
+            sys.stderr.write("\n")
+            ascii_stderr.flush()
+        except UnicodeEncodeError:
+            # This exception is the bug: the block is lost and the
+            # outer except in main() returns 0 (silent allow).
+            self.fail(
+                "BLOCK_GH_PR_DIFF raised UnicodeEncodeError on ASCII stderr; "
+                "main() would silently downgrade a hard block to allow"
+            )
+        finally:
+            sys.stderr = old_stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three changes to the bash-redirect hook:

1. **Surface `review_change`** in hook messages — when agents attempt to bypass via `gh pr diff`, the hook now recommends `review_change` as the preferred alternative
2. **Fix unicode encoding** — replace em-dashes and unicode arrows with ASCII-safe characters to prevent `UnicodeEncodeError` in ASCII-only locales
3. **Fix escaped newline handling** — handle bash line continuation (`\<newline>`) before tokenization to prevent false-positive hard blocks
4. **Fix gh api contents matching** — use tokenizer pipeline instead of raw regex to avoid matching inside quoted echo arguments

Closes #265

🤖 Generated with [Claude Code](https://claude.ai/claude-code)