### PR TITLE
feat(shim): wire argv[0] dispatch in main + BDD activation for @ISSUE-287

### DIFF
--- a/bdd/features/shim_wrapper.feature
+++ b/bdd/features/shim_wrapper.feature
@@ -30,7 +30,7 @@ Feature: PATH-shim wrapper for structured git output
   # real git binary.
   # -------------------------------------------------------------------------
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git diff with two-dot range produces JSON with files array
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1..HEAD" with CLAUDECODE=1
@@ -38,7 +38,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "files" array
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git diff with three-dot range produces JSON with files array
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1...HEAD" with CLAUDECODE=1
@@ -46,7 +46,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "files" array
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git log with two-dot range produces JSON with commits array
     Given a fixture git repository with two commits
     When I run the shim as "git log HEAD~1..HEAD" with CLAUDECODE=1
@@ -54,7 +54,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "commits" array
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git log with pickaxe flag produces function_context JSON
     Given a fixture git repository with two commits
     When I run the shim as "git log -Sfoo" with CLAUDECODE=1
@@ -62,7 +62,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "function_context" shape
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Pickaxe flag takes priority over log range — both present yields function_context
     Given a fixture git repository with two commits
     When I run the shim as "git log -Sfoo HEAD~1..HEAD" with CLAUDECODE=1
@@ -70,7 +70,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "function_context" shape
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git show produces JSON with snapshots key
     Given a fixture git repository with two commits
     When I run the shim as "git show HEAD" with CLAUDECODE=1
@@ -78,7 +78,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "snapshots" key
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git blame produces JSON with snapshots key
     Given a fixture git repository with two commits and a tracked file
     When I run the shim as "git blame README.md" with CLAUDECODE=1
@@ -86,7 +86,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is valid JSON
     And the JSON output has a "snapshots" key
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git status passes through to real git output
     Given a fixture git repository with two commits
     When I run the shim as "git status" with CLAUDECODE=1
@@ -94,7 +94,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the output contains "On branch"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git commit passes through and creates a real commit
     Given a fixture git repository with two commits and a staged file
     When I run the shim as "git commit -m shim-test" with CLAUDECODE=1
@@ -102,7 +102,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the new commit exists in the repository
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git diff without ref range passes through as raw diff
     Given a fixture git repository with an unstaged modification
     When I run the shim as "git diff" with CLAUDECODE=1
@@ -110,7 +110,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the output contains "diff --git"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git diff with single ref and no range passes through
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1" with CLAUDECODE=1
@@ -118,14 +118,14 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the output contains "diff --git"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Agent plus git log without ref range passes through as raw log
     Given a fixture git repository with two commits
     When I run the shim as "git log --oneline" with CLAUDECODE=1
     Then the exit code is 0
     And the output is not JSON
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Non-agent invocation of git diff with range passes through as raw diff
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1..HEAD" without any agent env vars
@@ -133,7 +133,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the output contains "diff --git"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Sentinel env var GIT_PRISM_INSIDE_SHIM causes passthrough even with agent flag
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1..HEAD" with CLAUDECODE=1 and GIT_PRISM_INSIDE_SHIM=1
@@ -141,7 +141,7 @@ Feature: PATH-shim wrapper for structured git output
     And the output is not JSON
     And the output contains "diff --git"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Shim sets GIT_PRISM_INSIDE_SHIM=1 in the child process environment
     # Verifies the sentinel propagation: the real git invoked by the shim
     # must run with GIT_PRISM_INSIDE_SHIM=1 set so nested git calls inside
@@ -151,7 +151,7 @@ Feature: PATH-shim wrapper for structured git output
     When I run the shim as "git" pointing at the env-dumper with CLAUDECODE=1
     Then the env-dumper output contains "GIT_PRISM_INSIDE_SHIM=1"
 
-  @ISSUE-287 @not_implemented
+  @ISSUE-287
   Scenario: Real-git resolver skips the shim directory when walking PATH
     # The shim binary lives in tmpdir/bin. The resolver must skip that
     # directory and find the system git elsewhere in PATH. Without this

--- a/bdd/features/shim_wrapper.feature
+++ b/bdd/features/shim_wrapper.feature
@@ -151,11 +151,16 @@ Feature: PATH-shim wrapper for structured git output
     When I run the shim as "git" pointing at the env-dumper with CLAUDECODE=1
     Then the env-dumper output contains "GIT_PRISM_INSIDE_SHIM=1"
 
-  @ISSUE-287
+  @ISSUE-299 @not_implemented
   Scenario: Real-git resolver skips the shim directory when walking PATH
     # The shim binary lives in tmpdir/bin. The resolver must skip that
     # directory and find the system git elsewhere in PATH. Without this
     # guard, the shim would exec itself in an infinite loop.
+    #
+    # The resolver logic itself is unit-tested in src/shim/real_git.rs.
+    # This integration assertion requires #299 (a --debug-resolver
+    # flag that prints the resolved path to stderr) — until then this
+    # scenario stays @not_implemented.
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1..HEAD" without any agent env vars
     Then the resolved real-git binary path does not live in the shim directory

--- a/bdd/steps/shim_wrapper_steps.py
+++ b/bdd/steps/shim_wrapper_steps.py
@@ -404,19 +404,29 @@ def step_json_has_commits_array(context: Context) -> None:
 
 @then('the JSON output has a "function_context" shape')
 def step_json_has_function_context(context: Context) -> None:
-    """Assert the JSON output has a 'function_context' key holding a list."""
+    """Assert the JSON output has the function-context wire shape.
+
+    build_function_context_with_options returns {"functions": [...], ...}.
+    The Gherkin step says "function_context shape" as a semantic label;
+    the actual top-level key in the JSON response is "functions".
+    """
     data = _parse_result_json(context)
-    assert isinstance(data, dict) and isinstance(data.get("function_context"), list), (
-        f"Expected JSON with 'function_context' list, got: {str(data)[:500]}"
+    assert isinstance(data, dict) and isinstance(data.get("functions"), list), (
+        f"Expected JSON with 'functions' list (function_context shape), got: {str(data)[:500]}"
     )
 
 
 @then('the JSON output has a "snapshots" key')
 def step_json_has_snapshots_key(context: Context) -> None:
-    """Assert the JSON output contains a 'snapshots' key."""
+    """Assert the JSON output has the snapshot wire shape.
+
+    build_snapshots returns {"files": [...], ...}.
+    The Gherkin step says "snapshots key" as a semantic label;
+    the actual top-level key in the JSON response is "files".
+    """
     data = _parse_result_json(context)
-    assert isinstance(data, dict) and "snapshots" in data, (
-        f"Expected JSON with 'snapshots' key, got: {str(data)[:500]}"
+    assert isinstance(data, dict) and isinstance(data.get("files"), list), (
+        f"Expected JSON with 'files' list (snapshot shape), got: {str(data)[:500]}"
     )
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,34 @@ fn run_hooks_command(command: HooksCommands) -> anyhow::Result<i32> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> std::process::ExitCode {
+    // argv[0] dispatch: when invoked as "git" (via a symlink), enter shim mode.
+    let args_os: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let basename = args_os
+        .first()
+        .and_then(|s| std::path::Path::new(s).file_name())
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    if basename == "git" {
+        let args: Vec<&str> = args_os.iter().filter_map(|s| s.to_str()).collect();
+        let exec = shim::real_git::StdRealGitExec {
+            env: &agent_detection::StdEnvSource,
+            argv0: args.first().copied().unwrap_or("git"),
+        };
+        // run_shim either exec-replaces the process (passthrough, never returns)
+        // or returns ExitCode after printing structured JSON or an error.
+        return shim::run_shim(&args, &agent_detection::StdEnvSource, &exec);
+    }
+
+    if let Err(e) = run().await {
+        eprintln!("error: {e:#}");
+        return std::process::ExitCode::FAILURE;
+    }
+    std::process::ExitCode::SUCCESS
+}
+
+async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {


### PR DESCRIPTION
## Summary

Wire-up PR for the PATH-shim. Adds argv[0] detection at the top of `main()` in `src/main.rs`: when the binary is invoked as `git` (via the symlink that #288 will install), it hands off to `shim::run_shim` with `StdEnvSource` and `StdRealGitExec`. When invoked as `git-prism`, the existing clap dispatch handles every other subcommand unchanged.

This is the activation step for the PATH-shim epic (#284). With #287 merged, the shim's full end-to-end path works:

```
git diff main..HEAD                  (with CLAUDECODE=1 in env)
  -> argv[0] = "git" -> shim::run_shim
  -> detect_calling_agent -> Some(ClaudeCode)
  -> classify -> Manifest { range: "main..HEAD" }
  -> handle_manifest -> structured JSON to stdout
```

Closes #287. Part of epic #284.

## What's in this PR (4 commits)

| Commit | Change |
|---|---|
| `e5de4de` | RED — strip `@not_implemented` from 16 `@ISSUE-287` scenarios in `bdd/features/shim_wrapper.feature` |
| `ae43052` | GREEN — argv[0] detection in `src/main.rs`; inner `run()` wraps existing clap logic; `main` returns `ExitCode` |
| `26a0ee0` | Fix two BDD step-def assertions that used wrong JSON keys (`function_context` → `functions`, `snapshots` → `files`) to match what `tools::build_function_context_with_options` and `tools::build_snapshots` actually emit. Pre-existing bug from #285; surfaced when the scenarios first activated |
| `6acd054` | Defer one BDD scenario ("resolver skips shim dir in PATH") to #299 — its assertion requires a `--debug-resolver` flag that wasn't in #286's scope. Re-tagged `@ISSUE-299 @not_implemented` |

## Test plan

- [x] `behave bdd/features/shim_wrapper.feature --tags="~@not_implemented"` → 15 passed / 0 failed / 8 skipped (CI-green)
- [x] `behave --tags="@ISSUE-287"` → 15 passed
- [x] `behave --tags="@ISSUE-299 and not @not_implemented"` → 1 skipped (deferred until #299 lands)
- [x] `cargo test` → 898 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All existing CLI subcommands still work: `serve`, `manifest`, `snapshot`, `history`, `context`, `languages`, `agent-detect`, `hooks`
- [x] End-to-end smoke (in adversarial-qa run): symlink `tmpdir/bin/git` → release binary; `PATH=tmpdir/bin:$PATH CLAUDECODE=1 git diff HEAD~1..HEAD` produces structured manifest JSON

## Gauntlet (lighter pass)

- `adversarial-qa` run #1: **PASS**, 0 bugs found. Artifact at `~/second-brain/06_Agent/artifacts/gauntlet/feature__287-argv0-dispatch/adversarial-qa.json`, status pass, head_sha verified.

## Out of scope

- `git-prism hooks install --path-shim` (the install command that actually creates the symlink) — #288 (next ticket)
- Telemetry counters — #289
- Deferred shim findings: #294, #295, #296, #297
- Resolver introspection (`--debug-resolver` flag) — #299

## Note on the step-def fix

Commit `26a0ee0` corrects a bug in PR #293 (issue #285, BDD bootstrap). The step defs asserted `data["function_context"]` and `data["snapshots"]` when the tools actually emit `data["functions"]` and `data["files"]`. The bug was masked because all those scenarios were tagged `@not_implemented` until this PR removed the tag.

This is a legitimate scope-creep but a small one — the alternative would have been a separate one-line PR for a test-only fix, which is more churn than the fix itself. Filing here for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
