### PR TITLE
fix(shim): distinguish exit 126 (unexecutable) from 127 (not found) in passthrough

### DIFF
--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -67,8 +67,8 @@ impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
             cmd.args(argv.iter().skip(1)); // skip argv[0] ("git")
             cmd.env("GIT_PRISM_INSIDE_SHIM", "1");
             let err = cmd.exec(); // never returns on success
-            eprintln!("git-prism shim: exec failed: {err}");
-            ExitCode::from(127)
+            eprintln!("git-prism shim: exec of {} failed: {err}", real.display());
+            ExitCode::from(exec_failure_exit_code(&err))
         }
         #[cfg(not(unix))]
         {

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -90,6 +90,17 @@ impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
     }
 }
 
+/// Map an exec `io::Error` to the conventional shell exit code.
+///
+/// - 126: command found but not executable (`PermissionDenied`)
+/// - 127: command not found or other exec failure
+fn exec_failure_exit_code(err: &std::io::Error) -> u8 {
+    match err.kind() {
+        std::io::ErrorKind::PermissionDenied => 126,
+        _ => 127,
+    }
+}
+
 /// Walk `$PATH`, skip any candidate that resolves (via symlink) to the shim
 /// binary itself, and return the first `<entry>/git` that is executable.
 ///
@@ -314,6 +325,24 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[test]
+    fn it_maps_permission_denied_to_exit_126() {
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert_eq!(exec_failure_exit_code(&err), 126);
+    }
+
+    #[test]
+    fn it_maps_not_found_to_exit_127() {
+        let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        assert_eq!(exec_failure_exit_code(&err), 127);
+    }
+
+    #[test]
+    fn it_maps_other_errors_to_exit_127() {
+        let err = std::io::Error::from(std::io::ErrorKind::Other);
+        assert_eq!(exec_failure_exit_code(&err), 127);
+    }
+
     #[test]
     fn it_skips_non_executable_git_files() {
         let dir = TempDir::new().unwrap();

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -343,6 +343,7 @@ mod tests {
         assert_eq!(exec_failure_exit_code(&err), 127);
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_skips_non_executable_git_files() {
         let dir = TempDir::new().unwrap();

--- a/tests/shim_exit_codes.rs
+++ b/tests/shim_exit_codes.rs
@@ -1,0 +1,50 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #296): the shim must distinguish exit 126
+//! (real git found but not executable) from exit 127 (real git not found),
+//! per POSIX shell convention.
+//!
+//! This drives the built binary end-to-end via its argv[0] = "git" dispatch.
+
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// When the resolver finds a `git` entry that passes the executable check but
+/// the process-replacement call fails with `PermissionDenied` (e.g. a directory
+/// named `git`), the shim must exit 126, NOT 127.
+#[test]
+fn it_exits_126_when_real_git_is_found_but_unexecutable() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    let real_dir = tmp.path().join("realbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    std::fs::create_dir_all(&real_dir).unwrap();
+
+    // Symlink the shim binary in as `git` (argv[0] = "git" triggers shim mode).
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    // The "real git" is a *directory* named `git`: it passes the resolver's
+    // `is_executable` check (directories carry the exec bit) but launching it
+    // fails with EACCES / PermissionDenied — the found-but-unexecutable case.
+    std::fs::create_dir(real_dir.join("git")).unwrap();
+
+    let path = format!("{}:{}", shim_dir.display(), real_dir.display());
+
+    let status = Command::new(&shim_git)
+        // GIT_PRISM_INSIDE_SHIM=1 forces the passthrough path directly.
+        .env("GIT_PRISM_INSIDE_SHIM", "1")
+        .env("PATH", &path)
+        .arg("status")
+        .status()
+        .unwrap();
+
+    assert_eq!(
+        status.code(),
+        Some(126),
+        "found-but-unexecutable real git must yield exit 126, not 127"
+    );
+}


### PR DESCRIPTION
## What

`StdRealGitExec::passthrough` exited `127` for every `cmd.exec()` failure. 127 conventionally means "command not found"; 126 means "found but not executable" (ENOEXEC / `PermissionDenied`). This distinguishes them.

## How

- New pure helper `exec_failure_exit_code(&io::Error) -> u8`: `PermissionDenied → 126`, else `127`.
- Wired into `passthrough`; the error message now includes the resolved git binary path.
- The "could not find real git" path is unchanged (correctly 127 — not found).

## Tests

- 3 unit tests for the mapping (126 / NotFound→127 / Other→127).
- Integration test `tests/shim_exit_codes.rs::it_exits_126_when_real_git_is_found_but_unexecutable` drives the built shim end-to-end with a found-but-unexecutable git and asserts exit 126.

Streamlined review (small single-file shim fix): targeted adversarial-QA (PASS) + pr-reviewer.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)