### PR TITLE
fix(shim): cfg-guard unix-only shim code so the crate compiles on Windows

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1376,6 +1376,7 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
+    #[cfg(unix)]
     fn install_path_shim_creates_symlink_in_expected_location() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1391,6 +1392,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn install_path_shim_is_idempotent() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1407,6 +1409,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn install_path_shim_replaces_stale_symlink() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1435,6 +1438,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn path_shim_status_returns_installed_after_install() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1453,6 +1457,7 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
+    #[cfg(unix)]
     fn uninstall_path_shim_removes_symlink() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1466,6 +1471,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn uninstall_path_shim_removes_empty_bin_directory() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1490,6 +1496,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn path_shim_status_returns_not_installed_after_uninstall() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1516,6 +1523,7 @@ mod tests {
     ///
     /// This is a data-loss bug.
     #[test]
+    #[cfg(unix)]
     fn adversarial_uninstall_path_shim_must_not_delete_unrelated_regular_file() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -1551,6 +1559,7 @@ mod tests {
     /// Expected: error out unless --force is passed, or at minimum refuse
     /// to overwrite anything that isn't a symlink.
     #[test]
+    #[cfg(unix)]
     fn adversarial_install_path_shim_must_not_overwrite_regular_file_without_force() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -3,7 +3,9 @@
 //! Abstracts "find the real git binary and exec it" behind a trait so the
 //! shim's decision logic can be unit-tested with a fake implementation.
 
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 use crate::agent_detection::EnvSource;
@@ -179,6 +181,7 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    #[cfg(unix)]
     use std::fs;
 
     #[cfg(unix)]
@@ -205,6 +208,7 @@ mod tests {
         p
     }
 
+    #[cfg(unix)]
     fn env_with_path(path_val: &str) -> MapEnv {
         MapEnv(HashMap::from([("PATH".to_string(), path_val.to_string())]))
     }

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -50,21 +50,30 @@ pub(crate) struct StdRealGitExec<'e, E: EnvSource> {
 
 impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
     fn passthrough(&self, argv: &[&str]) -> ExitCode {
-        let real = match resolve_real_git(self.argv0, self.env) {
-            Some(p) => p,
-            None => {
-                eprintln!("git-prism shim: could not find real git binary");
-                return ExitCode::from(127);
-            }
-        };
+        #[cfg(unix)]
+        {
+            let real = match resolve_real_git(self.argv0, self.env) {
+                Some(p) => p,
+                None => {
+                    eprintln!("git-prism shim: could not find real git binary");
+                    return ExitCode::from(127);
+                }
+            };
 
-        use std::os::unix::process::CommandExt;
-        let mut cmd = std::process::Command::new(&real);
-        cmd.args(argv.iter().skip(1)); // skip argv[0] ("git")
-        cmd.env("GIT_PRISM_INSIDE_SHIM", "1");
-        let err = cmd.exec(); // never returns on success
-        eprintln!("git-prism shim: exec failed: {err}");
-        ExitCode::from(127)
+            use std::os::unix::process::CommandExt as _;
+            let mut cmd = std::process::Command::new(&real);
+            cmd.args(argv.iter().skip(1)); // skip argv[0] ("git")
+            cmd.env("GIT_PRISM_INSIDE_SHIM", "1");
+            let err = cmd.exec(); // never returns on success
+            eprintln!("git-prism shim: exec failed: {err}");
+            ExitCode::from(127)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = argv;
+            eprintln!("git-prism shim: passthrough is not supported on non-Unix platforms");
+            ExitCode::from(127)
+        }
     }
 
     fn capture(&self, argv: &[&str]) -> Result<usize, CaptureError> {
@@ -85,6 +94,9 @@ impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
 /// Falls back to `/usr/bin/git`, `/usr/local/bin/git`, `/opt/homebrew/bin/git`
 /// if nothing is found in `$PATH`.  Returns `None` only when no git binary
 /// exists anywhere.
+///
+/// On non-Unix platforms this always returns `None` — the shim is unix-only.
+#[cfg(unix)]
 pub(crate) fn resolve_real_git(argv0: &str, env: &dyn EnvSource) -> Option<PathBuf> {
     let shim_path = shim_canonical_path(argv0);
 
@@ -132,8 +144,15 @@ pub(crate) fn resolve_real_git(argv0: &str, env: &dyn EnvSource) -> Option<PathB
     None
 }
 
+/// Non-Unix stub: the shim is unix-only so real-git resolution is not available.
+#[cfg(not(unix))]
+pub(crate) fn resolve_real_git(_argv0: &str, _env: &dyn EnvSource) -> Option<PathBuf> {
+    None
+}
+
 /// Return the canonicalized path of the shim binary (`argv0`), or `None`
 /// when canonicalization fails (e.g. relative paths, missing binary).
+#[cfg(unix)]
 fn shim_canonical_path(argv0: &str) -> Option<PathBuf> {
     Path::new(argv0).canonicalize().ok()
 }
@@ -141,6 +160,7 @@ fn shim_canonical_path(argv0: &str) -> Option<PathBuf> {
 /// Return `true` if `a` and `b` refer to the same directory after
 /// canonicalization.  Falls back to a direct comparison when either
 /// canonicalization fails.
+#[cfg(unix)]
 fn canonical_eq(a: &Path, b: &Path) -> bool {
     let ca = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
     let cb = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
@@ -148,6 +168,7 @@ fn canonical_eq(a: &Path, b: &Path) -> bool {
 }
 
 /// Return `true` when `path` exists and is executable by the current user.
+#[cfg(unix)]
 fn is_executable(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     path.metadata()
@@ -159,8 +180,8 @@ fn is_executable(path: &Path) -> bool {
 mod tests {
     use std::collections::HashMap;
     use std::fs;
-    use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(unix)]
     use tempfile::TempDir;
 
     use super::*;
@@ -173,7 +194,9 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn make_executable_file(dir: &Path, name: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
         let p = dir.join(name);
         fs::write(&p, b"#!/bin/sh\n").unwrap();
         let mut perms = fs::metadata(&p).unwrap().permissions();
@@ -186,6 +209,7 @@ mod tests {
         MapEnv(HashMap::from([("PATH".to_string(), path_val.to_string())]))
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_skips_shim_directory_and_finds_git_in_next_path_entry() {
         let shim_dir = TempDir::new().unwrap();
@@ -210,6 +234,7 @@ mod tests {
         assert_eq!(result, Some(expected));
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_uses_fallback_chain_when_path_has_no_git() {
         // Use an empty PATH so $PATH search finds nothing.
@@ -218,6 +243,7 @@ mod tests {
         let _ = resolve_real_git("/nonexistent/git-prism", &env);
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_returns_none_when_no_git_found_anywhere() {
         // No PATH key at all.
@@ -227,6 +253,7 @@ mod tests {
         let _ = resolve_real_git("/nonexistent/path/git-prism", &env);
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_finds_git_in_path_when_shim_dir_is_absent() {
         let real_dir = TempDir::new().unwrap();
@@ -239,6 +266,7 @@ mod tests {
         assert_eq!(result, Some(expected));
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_skips_symlink_to_shim_binary_in_different_path_entry() {
         // Homebrew install pattern:
@@ -281,6 +309,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_skips_non_executable_git_files() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## What

The shim's unix-only code (`std::os::unix::process::CommandExt`, `cmd.exec()`, `PermissionsExt`, `os::unix::fs::symlink`, `set_mode`) in `src/shim/real_git.rs` was never `#[cfg(unix)]`-guarded, so `cargo test` failed to **compile** on windows-latest (E0433/E0599). windows-latest has been red since the shim landed (#298+).

The shim is unix-only **by design** (Windows argv[0] dispatch was out of scope for epic #284). This makes the crate compile cleanly on Windows as a no-op rather than breaking the build.

## How

- `StdRealGitExec::passthrough`: unix arm uses `CommandExt`/`.exec()`; `#[cfg(not(unix))]` arm returns 127 cleanly.
- `resolve_real_git`: `#[cfg(not(unix))]` stub returns `None`.
- `is_executable`/`shim_canonical_path`/`canonical_eq` and unix-only tests gated `#[cfg(unix)]`.
- Imports/test helpers used only on unix (`Path`, `std::fs`, `env_with_path`) cfg-split so the not(unix) build is warning-clean.

No unix behavior change (929 tests pass, clippy/fmt clean). Adversarial-QA: PASS.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)