### PR TITLE
fix(hooks): print 'Created symlink' confirmation on install --path-shim

### DIFF
--- a/bdd/features/shim_wrapper.feature
+++ b/bdd/features/shim_wrapper.feature
@@ -188,6 +188,13 @@ Feature: PATH-shim wrapper for structured git output
     And the output contains "PATH"
     And the output contains ".local/share/git-prism/bin"
 
+  @ISSUE-302
+  Scenario: hooks install --path-shim prints the symlink path
+    Given an isolated HOME directory
+    When I run "git-prism hooks install --path-shim" with the isolated HOME
+    Then the exit code is 0
+    And the output contains "Created symlink:"
+
   @ISSUE-288
   Scenario: hooks install --path-shim is idempotent
     Given an isolated HOME directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,10 +186,10 @@ fn run_hooks_command(command: HooksCommands) -> anyhow::Result<i32> {
             }
             if path_shim {
                 let symlink_path = hooks::install_path_shim(&home, force)?;
+                println!("Created symlink: {}", symlink_path.display());
                 println!(
                     "Add this to your shell init (~/.zshrc or ~/.bashrc):\n  export PATH=\"$HOME/.local/share/git-prism/bin:$PATH\""
                 );
-                let _ = symlink_path;
             }
             Ok(0)
         }


### PR DESCRIPTION
## What

`git-prism hooks install --path-shim` silently created the symlink without telling the user where. `src/main.rs` computed `symlink_path` then discarded it with `let _ = symlink_path;`.

## How

Print `Created symlink: <path>` before the PATH-export instruction; drop the `let _` discard.

## Tests

New `@ISSUE-302` BDD scenario asserts the install output contains `Created symlink:` — driven against the built binary in an isolated HOME. Mutation-verified (removing the println turns the scenario RED).

Streamlined review (small fix): adversarial-QA PASS + pr-reviewer. Rebased onto the #314 Windows fix.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)