### PR TITLE
feat(shim): GIT_PRISM_DEBUG_RESOLVER stderr emission; activate final @ISSUE-299 scenario

### DIFF
--- a/bdd/features/shim_wrapper.feature
+++ b/bdd/features/shim_wrapper.feature
@@ -151,7 +151,7 @@ Feature: PATH-shim wrapper for structured git output
     When I run the shim as "git" pointing at the env-dumper with CLAUDECODE=1
     Then the env-dumper output contains "GIT_PRISM_INSIDE_SHIM=1"
 
-  @ISSUE-299 @not_implemented
+  @ISSUE-299
   Scenario: Real-git resolver skips the shim directory when walking PATH
     # The shim binary lives in tmpdir/bin. The resolver must skip that
     # directory and find the system git elsewhere in PATH. Without this

--- a/bdd/steps/shim_wrapper_steps.py
+++ b/bdd/steps/shim_wrapper_steps.py
@@ -248,8 +248,16 @@ def step_run_shim_with_both_flags(context: Context, command: str) -> None:
 
 @when('I run the shim as "{command}" without any agent env vars')
 def step_run_shim_no_agent_vars(context: Context, command: str) -> None:
-    """Invoke the shim with no agent env vars set (non-agent invocation)."""
-    _run_shim(context, _parse_shim_command(command), extra_env=None)
+    """Invoke the shim with no agent env vars set (non-agent invocation).
+
+    Always sets GIT_PRISM_DEBUG_RESOLVER=1 so the shim emits the resolved
+    real-git path to stderr, enabling the resolver-path assertions.
+    """
+    _run_shim(
+        context,
+        _parse_shim_command(command),
+        extra_env={"GIT_PRISM_DEBUG_RESOLVER": "1"},
+    )
 
 
 @when('I run the shim as "git" pointing at the env-dumper with CLAUDECODE=1')
@@ -479,15 +487,26 @@ def step_env_dumper_contains_sentinel(context: Context) -> None:
 def step_real_git_not_in_shim_dir(context: Context) -> None:
     """Assert the shim resolved real git to a path outside the shim directory.
 
-    NOTE: This assertion is a placeholder.  Verifying the resolved binary path
-    requires instrumentation that does not yet exist in the shim implementation.
-    Issue #286 should add a --debug-resolver flag that prints the resolved real-git
-    path to stderr; update this step when that lands.
+    Reads the 'resolved real git to <path>' line emitted by GIT_PRISM_DEBUG_RESOLVER
+    and asserts the resolved path is not inside context.shim_dir.
     """
-    raise AssertionError(
-        "real-git resolver introspection requires #286 instrumentation — "
-        "assertion deferred.  Add --debug-resolver to the shim (#286) that "
-        "prints the resolved real-git path to stderr, then update this step."
+    stderr = context.result.stderr
+    prefix = "git-prism shim: resolved real git to "
+    resolved_path = None
+    for line in stderr.splitlines():
+        if line.startswith(prefix):
+            resolved_path = Path(line[len(prefix):].strip())
+            break
+
+    assert resolved_path is not None, (
+        f"Expected 'resolved real git to <path>' in shim stderr but found none.\n"
+        f"stderr: {stderr}"
+    )
+
+    shim_dir = context.shim_dir
+    assert not str(resolved_path).startswith(str(shim_dir)), (
+        f"Resolved real git '{resolved_path}' lives inside the shim directory '{shim_dir}'. "
+        "The resolver must skip the shim dir and find git elsewhere."
     )
 
 

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -62,6 +62,10 @@ impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
                 }
             };
 
+            if self.env.get("GIT_PRISM_DEBUG_RESOLVER").is_some() {
+                eprintln!("git-prism shim: resolved real git to {}", real.display());
+            }
+
             use std::os::unix::process::CommandExt as _;
             let mut cmd = std::process::Command::new(&real);
             cmd.args(argv.iter().skip(1)); // skip argv[0] ("git")
@@ -163,11 +167,19 @@ pub(crate) fn resolve_real_git(_argv0: &str, _env: &dyn EnvSource) -> Option<Pat
     None
 }
 
-/// Return the canonicalized path of the shim binary (`argv0`), or `None`
-/// when canonicalization fails (e.g. relative paths, missing binary).
+/// Return the canonicalized path of the shim binary.
+///
+/// Tries `argv0` first (works when the shim is invoked with a full path).
+/// Falls back to `std::env::current_exe()` which the OS always resolves
+/// correctly, even when `argv0` is a bare name like `"git"` (e.g. when
+/// the kernel sets argv[0] from a PATH lookup).
 #[cfg(unix)]
 fn shim_canonical_path(argv0: &str) -> Option<PathBuf> {
-    Path::new(argv0).canonicalize().ok()
+    Path::new(argv0).canonicalize().ok().or_else(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+    })
 }
 
 /// Return `true` if `a` and `b` refer to the same directory after


### PR DESCRIPTION
## What

Adds `GIT_PRISM_DEBUG_RESOLVER` — when set, the shim prints `resolved real git to <path>` to stderr before exec, so the BDD scenario *"Real-git resolver skips the shim directory when walking PATH"* can assert the resolved path is outside the shim dir. Clears the **last** `@not_implemented` scenario in the PATH-shim epic.

## How

- `src/shim/real_git.rs`:
  - `passthrough` emits the resolved path to stderr when `GIT_PRISM_DEBUG_RESOLVER` is set (inside the `#[cfg(unix)]` arm, before exec; no behavior change otherwise).
  - `shim_canonical_path` falls back to `std::env::current_exe()` when `argv0` is a bare name. **Load-bearing for loop-prevention**: invoked via a bare `git` symlink, `argv0 == "git"` doesn't canonicalize, so without the fallback the resolver would return the shim's own symlink as "real git" and infinite-loop. Adversarial-QA proved this via mutation.
- BDD: `@ISSUE-299` scenario activated (RED commit removes `@not_implemented`; GREEN implements); the step parses the stderr line.

RED (`8d23b2e`) precedes GREEN (`585d3d6`). Adversarial-QA PASS, mutation-verified.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)