### PR TITLE
docs(shim): README section, CHANGELOG, ADR-0009 for PATH shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **PATH shim (experimental, Unix-only).** Installed as a `git` binary ahead of the real git on `PATH`, git-prism intercepts watch-list subcommands (`diff`/`log`/`show`/`blame`/pickaxe) that carry a ref range when an AI agent is detected, routing them to structured JSON; humans, CI, non-agents, and ref-range-less commands pass through to vanilla git untouched. Ships the Python classifier ported to `src/shim/classify.rs`, `argv[0]`-aware dispatch in `main` (#287), the shim core of `classify`/`real_git`/handlers (#286), and a `git-prism hooks install --path-shim` flag (plus matching `uninstall`/`status`) that creates the `~/.local/share/git-prism/bin/git` symlink and prints the `Created symlink:` line and PATH-export instructions (#288, #302). Agent detection reuses the env-var logic from #280. `GIT_PRISM_INSIDE_SHIM=1` forces passthrough and is set in child processes to break recursion through nested git calls. `GIT_PRISM_DEBUG_RESOLVER=1` prints the resolved real-git path to stderr (#299). (#284)
+- **Shim telemetry counters.** `shim_invocations_total` and `shim_classification_total` record how often the shim runs and how each command is classified (intercept vs passthrough). (#289)
 - **`git-prism agent-detect` subcommand.** Prints a JSON object indicating whether the current process is running on behalf of an AI coding agent, detected via environment variables only. Detection checks `AI_AGENT` (Vercel cross-tool convention), `AGENT` with an allowlisted value (`goose`, `amp`), and eight tool-specific markers (`CLAUDECODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `CODEX_SANDBOX`, `CLINE_ACTIVE`, `AUGMENT_AGENT`, `OPENCODE_CLIENT`, `TRAE_AI_SHELL_ID`). `CI=true` is a hard override that always returns `{"agent": null, "signal": null}`. Not exposed as an MCP tool — diagnostics/ops use only. (#278)
+
+### Fixed
+
+- **Shim passthrough distinguishes exit 126 from 127.** When delegating to the real git, the shim now returns `126` if the resolved binary exists but is not executable, and `127` if no git binary is found on `PATH`, matching POSIX shell conventions instead of collapsing both into one code. (#296)
+- **Windows builds compile cleanly.** The shim's `execvp`-based exec path is now gated behind `#[cfg(unix)]`, so the crate compiles as a no-op on Windows and `hooks install --path-shim` bails with "not supported on non-Unix platforms" rather than failing the build. (#314)
 
 ## [0.8.0] — 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ so you can confirm which `git` binary the shim is delegating to:
 
 ```bash
 GIT_PRISM_DEBUG_RESOLVER=1 git status
-# (stderr) git-prism: resolved real git -> /usr/bin/git
+# (stderr) git-prism shim: resolved real git to /usr/bin/git
 ```
 
 ### Coexisting with rtk

--- a/README.md
+++ b/README.md
@@ -78,6 +78,121 @@ git-prism hooks uninstall   # removes the hook file and settings.json entry
 git-prism hooks status      # shows whether the hook is installed and at which scope
 ```
 
+## PATH shim (experimental)
+
+> **Unix-only.** The shim relies on `execvp`-style process replacement that has no
+> clean Windows equivalent. `git-prism hooks install --path-shim` cleanly bails on
+> non-Unix platforms ("not supported on non-Unix platforms"), and the shim code
+> compiles as a no-op there. Everything below assumes macOS or Linux.
+
+### What it does and why
+
+The bundled redirect hook above only fires inside Claude Code's `PreToolUse`
+pipeline. Agents that shell out to `git` through other channels — a subprocess,
+a shell tool, a wrapper script — never hit it. The PATH shim closes that gap at
+the process level.
+
+When installed, `git-prism` is placed on your `PATH` as a binary literally named
+`git`, ahead of the real git. Every `git` invocation flows through git-prism
+first. The shim then decides, per command:
+
+- **AI agent + a watch-list subcommand with a ref range** → route to git-prism's
+  structured-JSON path (the same data the MCP tools return) instead of porcelain.
+  The watch list is `diff`, `log`, `show`, `blame`, and pickaxe forms
+  (`-S`/`-G`), but **only when a ref range is present** (e.g. `git diff main..HEAD`).
+- **Everything else** — humans, CI, non-agents, ref-range-less commands like
+  `git status` or a bare `git diff` — falls straight through to the real git
+  binary, unchanged.
+
+Agent detection reuses the env-var-only logic behind
+[`git-prism agent-detect`](#agent-detection): no agent signal (or `CI=true`)
+means vanilla git, always. The classifier and watch list live in
+[`src/shim/classify.rs`](src/shim/classify.rs); the real-git resolver that walks
+`PATH` (skipping the shim's own directory) lives in `src/shim/real_git.rs`.
+
+### Install
+
+```bash
+git-prism hooks install --path-shim
+```
+
+This creates a symlink at `~/.local/share/git-prism/bin/git` pointing at the
+git-prism binary and prints both the created path and the line to add to your
+shell profile:
+
+```
+Created symlink: /home/you/.local/share/git-prism/bin/git
+Add this to your shell profile (~/.bashrc, ~/.zshrc, ...):
+  export PATH="$HOME/.local/share/git-prism/bin:$PATH"
+```
+
+Add that `export` line to your shell profile so the shim directory precedes the
+real git on `PATH`, then open a new shell.
+
+### Smoke test
+
+```bash
+# 1. Install and wire up PATH
+git-prism hooks install --path-shim
+export PATH="$HOME/.local/share/git-prism/bin:$PATH"
+
+# 2. As a non-agent, you get vanilla git — passthrough
+git --version            # prints the real git version
+
+# 3. As an agent, a ref-range diff is intercepted and returns structured JSON
+AI_AGENT=smoke-test git diff HEAD~1..HEAD | head -c 80
+# => {"metadata":{ ... structured manifest ...
+
+# 4. A ref-range-less command always passes through, even for an agent
+AI_AGENT=smoke-test git status   # plain porcelain
+```
+
+### Escape hatch and loop prevention
+
+The shim sets `GIT_PRISM_INSIDE_SHIM=1` in every child process it spawns. When
+the shim sees that variable already set, it forces passthrough — so nested git
+calls (a `lefthook` pre-push hook, `cargo`'s internal git, a build script that
+shells out to git) never recurse back into the shim and loop. You can set it
+yourself to force vanilla git for one command:
+
+```bash
+GIT_PRISM_INSIDE_SHIM=1 git diff main..HEAD   # bypasses the shim
+```
+
+### Debugging
+
+Set `GIT_PRISM_DEBUG_RESOLVER=1` to print the resolved real-git path to stderr,
+so you can confirm which `git` binary the shim is delegating to:
+
+```bash
+GIT_PRISM_DEBUG_RESOLVER=1 git status
+# (stderr) git-prism: resolved real git -> /usr/bin/git
+```
+
+### Coexisting with rtk
+
+If you use [rtk](https://github.com/rtk-rs) (or any tool that also wraps `git`
+on `PATH`), the two wrappers will fight over the same command. Tell rtk to leave
+`git` alone by adding it to rtk's exclude list in
+`~/Library/Application Support/rtk/config.toml`:
+
+```toml
+exclude_commands = ["git"]
+```
+
+### Uninstall
+
+```bash
+git-prism hooks uninstall --path-shim   # removes the symlink
+git-prism hooks status                  # reflects path-shim presence/absence
+```
+
+After uninstalling, remove the `export PATH=...` line you added to your shell
+profile.
+
+A narrated end-to-end walkthrough of the shim lives at
+[`demo/path-shim.mp4`](demo/path-shim.mp4).
+
 ## Agent detection
 
 ```bash

--- a/bdd/features/shim_wrapper.feature
+++ b/bdd/features/shim_wrapper.feature
@@ -159,8 +159,7 @@ Feature: PATH-shim wrapper for structured git output
     #
     # The resolver logic itself is unit-tested in src/shim/real_git.rs.
     # This integration assertion requires #299 (a --debug-resolver
-    # flag that prints the resolved path to stderr) — until then this
-    # scenario stays @not_implemented.
+    # flag that prints the resolved path to stderr).
     Given a fixture git repository with two commits
     When I run the shim as "git diff HEAD~1..HEAD" without any agent env vars
     Then the resolved real-git binary path does not live in the shim directory

--- a/docs/decisions/0009-path-shim-architecture.md
+++ b/docs/decisions/0009-path-shim-architecture.md
@@ -1,0 +1,162 @@
+# ADR 0009: PATH Shim Architecture
+
+- **Status**: Implemented
+- **Date**: 2026-05-29
+- **Context**: Epic #284 — a PATH shim that intercepts agent `git` calls outside Claude Code's hook pipeline
+
+## Context
+
+The bundled redirect hook (see [ADR 0008](0008-redirect-hook-spike.md)) only fires
+inside Claude Code's `PreToolUse` pipeline. It catches `git diff/log/show/blame`
+that an agent issues through the Bash tool, but it is blind to git invoked by any
+other path: a subprocess the agent spawns, a shell wrapper, a build script, an
+MCP server of its own. Those calls reach the real git untouched and hand the agent
+porcelain output — exactly the token-wasteful diff text git-prism exists to replace.
+
+A PATH shim closes that gap at the process level. If `git-prism` sits on `PATH`
+under the name `git`, ahead of the real git, then *every* `git` invocation in that
+shell flows through git-prism first, regardless of who spawned it. git-prism then
+decides per command whether to intercept (return structured JSON) or pass through
+(exec the real git unchanged).
+
+This ADR records the architectural decisions for that work. The agent-detection
+foundation it depends on landed earlier in [PR #280](https://github.com/mikelane/git-prism/pull/280);
+the shim itself is the body of epic [#284](https://github.com/mikelane/git-prism/issues/284).
+
+## Decision
+
+### 1. `argv[0]`-aware dispatch in the same binary, not a separate binary
+
+The shim is the same `git-prism` binary. At startup, `main` inspects `argv[0]`: if
+the program was invoked under a name ending in `git` (the symlink), it enters shim
+mode; otherwise it dispatches the normal clap CLI (`serve`, `manifest`, `hooks`, …).
+
+**Rationale.** One binary means one build, one release artifact, one version to keep
+in sync. A separate `git-prism-git-shim` binary would double the cargo-dist matrix,
+require a second crates.io entry or a bundled-binary install step, and invite version
+skew between the shim and the tool whose JSON path it reuses. `argv[0]` dispatch is
+the classic Unix multi-call pattern (busybox, coreutils' `[`); it costs one string
+check at startup.
+
+**Consequences.**
+
+- (+) Single artifact; the shim always matches the installed git-prism exactly.
+- (+) The shim reuses the same git + tree-sitter code paths in-process — no IPC, no
+  second binary to locate.
+- (−) A trivial amount of shim-mode branching lives in the otherwise-CLI `main`.
+  Mitigated by keeping the shim logic in `src/shim/` and having `main` only dispatch.
+- (−) The install symlink must point at a real `git-prism`; a moved or deleted binary
+  breaks the shim. Acceptable — the same is true of any installed tool.
+
+### 2. PATH shim, not (only) a Claude Code hook rewrite
+
+The redirect hook stays; the shim is additive, not a replacement.
+
+**Rationale.** The hook and the shim cover disjoint blind spots. The hook sees the
+agent's *intent* (the literal Bash command text, before execution) and can soft-warn
+or rewrite it with full Claude Code context. The shim sees *every* git process, even
+ones the hook never observes, but only at exec time with no conversational context.
+Neither subsumes the other. A hook-only solution misses non-Bash-tool git; a
+shim-only solution loses the ability to advise the agent in-band.
+
+**Consequences.**
+
+- (+) Defense in depth: two independent interception points.
+- (+) The shim works for agents that aren't Claude Code at all, since detection is
+  env-var-based (see #280), not Claude-specific.
+- (−) Two mechanisms to document and reason about. Mitigated by this ADR and the
+  README sections drawing the boundary explicitly.
+
+### 3. `GIT_PRISM_INSIDE_SHIM` sentinel for loop-break, not an in-process guard
+
+The shim sets `GIT_PRISM_INSIDE_SHIM=1` in the environment of every child process it
+spawns. On entry, if that variable is already set, the shim immediately passes through
+to the real git.
+
+**Rationale.** Recursion here is *cross-process*, not in-process. When the shim execs
+the real git, that git may itself shell out (hooks, `lefthook`, `cargo`'s embedded
+git, a build script) — and because the shim is still first on `PATH`, those nested
+calls re-enter git-prism. An in-process recursion counter cannot see across that
+`exec`/`fork` boundary; only an inherited environment variable survives it. The
+sentinel is the standard wrapper-script technique (cf. `ccache`, `sccache`, editor
+`$EDITOR` re-entrancy guards).
+
+**Consequences.**
+
+- (+) Robust against arbitrarily deep nesting through unrelated tools.
+- (+) Doubles as a user-facing escape hatch: `GIT_PRISM_INSIDE_SHIM=1 git …` forces
+  vanilla git for one command.
+- (−) Relies on env inheritance; a child that scrubs its environment could, in theory,
+  loop. In practice nothing in the git toolchain scrubs `GIT_PRISM_*`, and the cost of
+  a missed sentinel is a loop the user would notice immediately, not silent corruption.
+
+### 4. Exact port of the Python classifier, not new ref-range logic
+
+The watch-list / ref-range classifier is a faithful port of the existing Python hook
+classifier into `src/shim/classify.rs`, not a fresh Rust design.
+
+**Rationale.** The two interception points must agree on what counts as an
+interceptable command, or an agent gets inconsistent behavior depending on which path
+its git call took. Porting the already-tested Python logic — same watch list, same
+ref-range detection — guarantees that agreement and lets us reuse the existing corpus
+of classification cases as Rust test fixtures. Inventing parallel logic would risk
+subtle divergence (a flag one side intercepts and the other passes through).
+
+**Consequences.**
+
+- (+) Behavioral parity between hook and shim by construction.
+- (+) Existing classification edge cases transfer directly into Rust unit tests.
+- (−) The two implementations must be kept in sync by hand; a change to one needs a
+  matching change to the other. Mitigated by shared test cases and a note in both
+  modules.
+
+### 5. Passthrough for ref-range-less forms, not intercepting all `git diff`
+
+The shim only intercepts watch-list subcommands when a **ref range** is present
+(`git diff main..HEAD`, `git log A..B`). A bare `git diff`, `git diff --staged`, or
+`git status` passes straight through.
+
+**Rationale.** git-prism's structured JSON answers "what changed between two refs."
+A bare `git diff` (working tree vs index) and interactive forms have no two-ref shape
+to map onto the manifest tools, and intercepting them would break the muscle-memory
+commands humans and agents rely on for quick local inspection. Restricting
+interception to ref-range forms targets exactly the PR-review / blast-radius use case
+the JSON path serves, and leaves everything else as plain git.
+
+**Consequences.**
+
+- (+) Zero surprise for the overwhelming majority of git usage — only the explicit
+  range forms change behavior.
+- (+) Matches the MCP tools' own contract, which is ref-range oriented.
+- (−) An agent that wants structured working-tree data via the shim doesn't get it
+  (it must use the MCP tool's working-tree mode instead). Accepted — the shim's job is
+  to catch the range-diff calls that leak past the hook, not to cover every mode.
+
+### 6. Keep the MCP server alongside the shim, not deprecate it
+
+The shim is an additional front door to the same data; the MCP server (`git-prism serve`)
+remains the primary, fully supported interface.
+
+**Rationale.** The MCP tools are richer than the shim can be: pagination, explicit
+budgets, `function_names` filtering, working-tree mode, the `review_change`
+orchestration. The shim necessarily speaks the fixed vocabulary of git's CLI surface
+and can only return what a given `git diff`/`log` shape maps onto. The shim is a
+convenience for git calls that escape the MCP path, not a superset of it. Deprecating
+MCP would lose capability and break every existing Claude Code registration.
+
+**Consequences.**
+
+- (+) Agents get the full MCP tool surface when they call git-prism directly, and a
+  graceful fallback when they shell out to git.
+- (+) No migration burden on existing users.
+- (−) Two surfaces returning overlapping-but-not-identical JSON shapes. Mitigated by
+  the shim reusing the same underlying manifest code, so the data is consistent even
+  where the envelope differs. The shim is labeled **experimental** in the README to
+  set expectations while its surface settles.
+
+## Status of dependent work
+
+Implementation landed across #280 (agent detection), #286 (shim core), #287 (`argv[0]`
+dispatch), #288 (`hooks install --path-shim`), #289 (telemetry counters), #296 (exit
+codes 126/127), #299 (`GIT_PRISM_DEBUG_RESOLVER`), #302 (`Created symlink:` line), and
+#314 (Windows `cfg` guards). The capstone demo (#291) records the end-to-end flow.


### PR DESCRIPTION
## What

Documentation for the PATH-shim epic (#284) — lands after all implementation issues merged so it reflects the actual shipped surface.

- **README.md** — new "PATH shim (experimental)" section: what/why, install + `Created symlink` / PATH-export output, the interception watch-list (links `src/shim/classify.rs`), `GIT_PRISM_INSIDE_SHIM=1` escape hatch + loop-break, `GIT_PRISM_DEBUG_RESOLVER=1`, rtk coexistence, uninstall/status, unix-only note, link to `demo/path-shim.mp4` (added by #291).
- **CHANGELOG.md** — `[Unreleased]` Added/Fixed entries for the shim, telemetry counters, exit-code 126/127, debug-resolver, and the Windows cfg-guard fix.
- **docs/decisions/0009-path-shim-architecture.md** — ADR with all six decisions + consequences.
- **bdd/features/shim_wrapper.feature** — removed one now-stale comment clause (comment-only; pr-reviewer LOW finding from #317).

Docs-only — adversarial QA / church / audits exempt per the docs-only exception. `it_matches_expected_tools` verified (no MCP tool drift).

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)