### PR TITLE
fix(shim): Windows passthrough via spawn+wait (#322)

### DIFF
--- a/bdd/features/shim_parity.feature
+++ b/bdd/features/shim_parity.feature
@@ -48,7 +48,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
 
   Rule: Windows passthrough preserves real-git exit code and output
 
-    @ISSUE-322 @not_implemented @windows
+    @ISSUE-322 @windows
     Scenario: Successful git command exit code and stdout match real git on Windows
       Given a fixture git repository with two commits
       When the shim runs "git status" without agent env vars
@@ -56,7 +56,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
       Then the shim exit code matches the real git exit code
       And the shim stdout matches the real git stdout
 
-    @ISSUE-322 @not_implemented @windows
+    @ISSUE-322 @windows
     Scenario: Failed git command exit code and stderr match real git on Windows
       Given a fixture git repository with two commits
       When the shim runs "git not-a-real-subcommand" without agent env vars

--- a/src/shim/real_git.rs
+++ b/src/shim/real_git.rs
@@ -76,9 +76,33 @@ impl<E: EnvSource> RealGitExec for StdRealGitExec<'_, E> {
         }
         #[cfg(not(unix))]
         {
-            let _ = argv;
-            eprintln!("git-prism shim: passthrough is not supported on non-Unix platforms");
-            ExitCode::from(127)
+            let real = match resolve_real_git(self.argv0, self.env) {
+                Some(p) => p,
+                None => {
+                    eprintln!("git-prism shim: could not find real git binary");
+                    return ExitCode::from(127);
+                }
+            };
+
+            if self.env.get("GIT_PRISM_DEBUG_RESOLVER").is_some() {
+                eprintln!("git-prism shim: resolved real git to {}", real.display());
+            }
+
+            let status = std::process::Command::new(&real)
+                .args(argv.iter().skip(1))
+                .env("GIT_PRISM_INSIDE_SHIM", "1")
+                .status();
+
+            match status {
+                Ok(s) => {
+                    let code = s.code().unwrap_or(1);
+                    ExitCode::from(code as u8)
+                }
+                Err(err) => {
+                    eprintln!("git-prism shim: spawn of {} failed: {err}", real.display());
+                    ExitCode::from(exec_failure_exit_code(&err))
+                }
+            }
         }
     }
 
@@ -161,9 +185,45 @@ pub(crate) fn resolve_real_git(argv0: &str, env: &dyn EnvSource) -> Option<PathB
     None
 }
 
-/// Non-Unix stub: the shim is unix-only so real-git resolution is not available.
+/// Walk `%PATH%` on Windows, skip any candidate that resolves to the shim
+/// binary itself, and return the first `<entry>\git.exe` that exists.
+///
+/// Returns `None` only when no git binary is found anywhere on PATH.
 #[cfg(not(unix))]
-pub(crate) fn resolve_real_git(_argv0: &str, _env: &dyn EnvSource) -> Option<PathBuf> {
+pub(crate) fn resolve_real_git(argv0: &str, env: &dyn EnvSource) -> Option<PathBuf> {
+    use std::path::Path;
+
+    let shim_canonical = std::path::PathBuf::from(argv0)
+        .canonicalize()
+        .ok()
+        .or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.canonicalize().ok())
+        });
+
+    if let Some(path_var) = env.get("PATH") {
+        for entry in path_var.split(';') {
+            if entry.is_empty() {
+                continue;
+            }
+            // On Windows git may be "git.exe" or "git" (cmd.exe resolves extensions).
+            // Try both; prefer the .exe form.
+            for name in &["git.exe", "git"] {
+                let candidate = Path::new(entry).join(name);
+                if !candidate.exists() {
+                    continue;
+                }
+                // Skip if this candidate resolves to the shim itself.
+                if let Some(shim) = &shim_canonical {
+                    if candidate.canonicalize().ok().as_ref() == Some(shim) {
+                        continue;
+                    }
+                }
+                return Some(candidate);
+            }
+        }
+    }
     None
 }
 


### PR DESCRIPTION
## What

Makes the PATH shim function on Windows. Epic #328 (shim parity → sunset the redirect hook).

The shim's passthrough used `execvp` on unix; the `#[cfg(not(unix))]` arm was a stub that exited 127 unconditionally — so the shim was non-functional on Windows. This replaces that arm with **spawn+wait**: `std::process::Command::new(real_git).args(...).status()` then `exit(status.code())`, inheriting stdout/stderr and forwarding the real exit code. Also adds a `#[cfg(not(unix))]` `resolve_real_git()` PATH walker (`;`-separated, tries `git.exe` then `git`, skips the shim symlink to avoid self-recursion). **The unix execvp path is byte-for-byte unchanged.**

## Tests

- 2 `@ISSUE-322` scenarios (`@windows`-tagged) assert passthrough exit-code + stdout/stderr parity. They **pass on unix** (execvp passthrough already works) — `windows-latest` CI is their authoritative RED→GREEN gate, since the Windows-specific spawn+wait path is unreachable on unix. This is documented in the feature file's PLATFORM NOTE.
- Cross-platform unit tests for exit-code mapping (`exec_failure_exit_code` → 126/127).

## Verification

- Local: `cargo test`/`clippy --all-targets`/`fmt` clean; `behave --tags="@ISSUE-322"` passes on unix.
- **Windows typecheck**: adversarial-QA cross-compiled `real_git.rs` to `x86_64-pc-windows-gnu` (isolated crate, 0 errors), confirming the `#[cfg(not(unix))]` arms + test module compile on the Windows target. Final runtime verification is the `windows-latest` CI job below.

## Gauntlet

adversarial-QA PASS (0 reachable bugs); rust-purist ship-worthy.

### Non-blocking INFO (deferred, theoretical)
- `passthrough()` non-unix arm casts `i32`→`u8` for the exit code. Unreachable in practice (git exits 0–255); a `// SAFETY:` comment documenting the invariant would be the ideal polish.
- The bare-`git` (no `.exe`) PATH fallback won't spawn via `Command` on Windows (no `PATHEXT` resolution), but `git.exe` is tried first, so this only ever yields a clear spawn error — harmless.

## Notes

- `@ISSUE-323/325/326` remain `@not_implemented` (excluded from CI). Only `@ISSUE-322` activated.
- Rebased onto current main (post-#324).

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)