### PR TITLE
feat(shim): auto-PATH setup UX during shim install (#325)

### DIFF
--- a/bdd/features/shim_parity.feature
+++ b/bdd/features/shim_parity.feature
@@ -186,7 +186,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
 
   Rule: User consents to auto-PATH setup — rc file is updated idempotently
 
-    @ISSUE-325 @not_implemented
+    @ISSUE-325
     Scenario: Accepting PATH setup appends the export line to the shell rc
       Given an isolated HOME directory
       And the shim directory is not in PATH
@@ -196,7 +196,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
       And the rc file ".zshrc" under HOME contains the shim directory export line
       And the output contains "restart"
 
-    @ISSUE-325 @not_implemented
+    @ISSUE-325
     Scenario: Re-running install does not append the export line a second time
       Given an isolated HOME directory
       And the shim directory is not in PATH
@@ -207,7 +207,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
 
   Rule: User declines auto-PATH setup — rc file is not modified
 
-    @ISSUE-325 @not_implemented
+    @ISSUE-325
     Scenario: Declining PATH setup prints manual instructions and leaves rc unchanged
       Given an isolated HOME directory
       And the shim directory is not in PATH
@@ -219,7 +219,7 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
 
   Rule: Shim directory already in PATH — no prompt, no rc modification
 
-    @ISSUE-325 @not_implemented
+    @ISSUE-325
     Scenario: No PATH prompt when shim directory is already in PATH
       Given an isolated HOME directory
       And the shim directory is already in PATH

--- a/bdd/steps/shim_parity_steps.py
+++ b/bdd/steps/shim_parity_steps.py
@@ -479,6 +479,9 @@ def step_shim_install_consent(context: Context) -> None:
     """Run git-prism shim install, answering 'y' to the PATH setup prompt."""
     binary = _find_binary(context)
     env = _isolated_env(context)
+    # Pin SHELL to zsh so detect_rc_file always picks .zshrc, regardless of
+    # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
+    env["SHELL"] = "/bin/zsh"
     # If the shim dir was injected into PATH by a prior Given step, use that.
     if hasattr(context, "injected_path"):
         env["PATH"] = context.injected_path
@@ -502,6 +505,9 @@ def step_shim_install_consent_again(context: Context) -> None:
     """Run git-prism shim install a second time with 'y' consent (idempotency check)."""
     binary = _find_binary(context)
     env = _isolated_env(context)
+    # Pin SHELL to zsh so detect_rc_file always picks .zshrc, regardless of
+    # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
+    env["SHELL"] = "/bin/zsh"
     result = subprocess.run(  # noqa: S603
         [str(binary), "shim", "install"],
         input="y\n",

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -27,15 +27,27 @@ const SHIM_EXPORT_LINE: &str = r#"export PATH="$HOME/.local/share/git-prism/bin:
 /// in `PATH`. If not, prompts the user via stdin for consent to append the
 /// export line to their shell rc file.
 pub fn run_install(home: &std::path::Path, force: bool) -> Result<()> {
-    run_install_with_io(home, force, &mut io::stdin().lock(), &mut io::stdout())
+    let rc_path = detect_rc_file(home);
+    run_install_with_io(
+        home,
+        force,
+        &mut io::stdin().lock(),
+        &mut io::stdout(),
+        &rc_path,
+    )
 }
 
 /// Testable install implementation with injected I/O.
+///
+/// `rc_path` is the shell rc file to append the export line to when the user
+/// consents. Production callers pass `detect_rc_file(home)`; tests pass an
+/// explicit path so the result is independent of the runner's `$SHELL`.
 pub fn run_install_with_io(
     home: &std::path::Path,
     force: bool,
     stdin: &mut dyn BufRead,
     stdout: &mut dyn Write,
+    rc_path: &std::path::Path,
 ) -> Result<()> {
     let symlink_path = hooks::install_path_shim(home, force)?;
     writeln!(stdout, "Created symlink: {}", symlink_path.display())?;
@@ -48,7 +60,7 @@ pub fn run_install_with_io(
         return Ok(());
     }
 
-    offer_path_setup(home, stdin, stdout)?;
+    offer_path_setup(home, rc_path, stdin, stdout)?;
     Ok(())
 }
 
@@ -66,6 +78,7 @@ fn shim_dir_is_in_path(shim_dir: &str) -> bool {
 /// Prompt for PATH consent and act on the answer.
 fn offer_path_setup(
     home: &std::path::Path,
+    rc_path: &std::path::Path,
     stdin: &mut dyn BufRead,
     stdout: &mut dyn Write,
 ) -> Result<()> {
@@ -79,7 +92,7 @@ fn offer_path_setup(
     stdin.read_line(&mut answer)?;
 
     if answer.trim().eq_ignore_ascii_case("y") {
-        append_to_rc_idempotent(home, stdout)?;
+        append_to_rc_idempotent(home, rc_path, stdout)?;
     } else {
         print_manual_instructions(stdout)?;
     }
@@ -88,10 +101,13 @@ fn offer_path_setup(
 
 /// Append the export line to the shell rc file, unless it is already present.
 /// Detects presence by matching the full export line (line-wise, ignoring comments).
-fn append_to_rc_idempotent(home: &std::path::Path, stdout: &mut dyn Write) -> Result<()> {
-    let rc_path = detect_rc_file(home);
+fn append_to_rc_idempotent(
+    home: &std::path::Path,
+    rc_path: &std::path::Path,
+    stdout: &mut dyn Write,
+) -> Result<()> {
     let existing = if rc_path.exists() {
-        std::fs::read_to_string(&rc_path)?
+        std::fs::read_to_string(rc_path)?
     } else {
         String::new()
     };
@@ -106,7 +122,7 @@ fn append_to_rc_idempotent(home: &std::path::Path, stdout: &mut dyn Write) -> Re
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&rc_path)?;
+            .open(rc_path)?;
         writeln!(file, "\n{SHIM_EXPORT_LINE}")?;
     }
 
@@ -185,16 +201,20 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Install with consent, using an explicit `.zshrc` path so the test is
+    /// independent of the CI runner's `$SHELL`.
     fn install_with_consent(home: &std::path::Path) {
+        let rc = home.join(".zshrc");
         let mut stdin = Cursor::new("y\n");
         let mut stdout = Vec::new();
-        run_install_with_io(home, false, &mut stdin, &mut stdout).unwrap();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, &rc).unwrap();
     }
 
     fn install_with_decline(home: &std::path::Path) {
+        let rc = home.join(".zshrc");
         let mut stdin = Cursor::new("n\n");
         let mut stdout = Vec::new();
-        run_install_with_io(home, false, &mut stdin, &mut stdout).unwrap();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, &rc).unwrap();
     }
 
     #[test]
@@ -254,7 +274,7 @@ mod tests {
 
         let mut stdin = Cursor::new("y\n");
         let mut stdout = Vec::new();
-        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout).unwrap();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, &rc).unwrap();
 
         let out = String::from_utf8(stdout).unwrap();
         assert!(
@@ -279,9 +299,10 @@ mod tests {
     #[test]
     fn decline_output_contains_shim_dir_path() {
         let dir = TempDir::new().unwrap();
+        let rc = dir.path().join(".zshrc");
         let mut stdin = Cursor::new("n\n");
         let mut stdout = Vec::new();
-        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout).unwrap();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, &rc).unwrap();
 
         let out = String::from_utf8(stdout).unwrap();
         assert!(

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -5,22 +5,129 @@
 //! See ADR-0009 (`docs/decisions/0009-path-shim-architecture.md`) for design
 //! rationale.
 
+use std::io::{self, BufRead, Write};
+
 use anyhow::Result;
 
 use crate::hooks;
+
+/// The export line fragment used to detect existing entries and compute the shim dir.
+const SHIM_EXPORT_FRAGMENT: &str = ".local/share/git-prism/bin";
+
+/// The full export line written to shell rc files.
+const SHIM_EXPORT_LINE: &str = r#"export PATH="$HOME/.local/share/git-prism/bin:$PATH""#;
 
 /// Install the PATH shim symlink and print the result to stdout.
 ///
 /// Idempotent: if the symlink already exists and points at the current binary,
 /// this is a silent no-op. `force` allows overwriting a regular file at the
 /// target path.
+///
+/// After installing the symlink, checks whether the shim directory is already
+/// in `PATH`. If not, prompts the user via stdin for consent to append the
+/// export line to their shell rc file.
 pub fn run_install(home: &std::path::Path, force: bool) -> Result<()> {
+    run_install_with_io(home, force, &mut io::stdin().lock(), &mut io::stdout())
+}
+
+/// Testable install implementation with injected I/O.
+pub fn run_install_with_io(
+    home: &std::path::Path,
+    force: bool,
+    stdin: &mut dyn BufRead,
+    stdout: &mut dyn Write,
+) -> Result<()> {
     let symlink_path = hooks::install_path_shim(home, force)?;
-    println!("Created symlink: {}", symlink_path.display());
-    println!(
-        "Add this to your shell init (~/.zshrc or ~/.bashrc):\n  export PATH=\"$HOME/.local/share/git-prism/bin:$PATH\""
-    );
+    writeln!(stdout, "Created symlink: {}", symlink_path.display())?;
+
+    let shim_dir = home.join(SHIM_EXPORT_FRAGMENT);
+    let shim_dir_str = shim_dir.to_string_lossy().into_owned();
+
+    if shim_dir_is_in_path(&shim_dir_str) {
+        // Already on PATH — nothing to do.
+        return Ok(());
+    }
+
+    offer_path_setup(home, stdin, stdout)?;
     Ok(())
+}
+
+/// Return true if the shim directory string appears in the current `PATH` env var.
+fn shim_dir_is_in_path(shim_dir: &str) -> bool {
+    let path_env = std::env::var("PATH").unwrap_or_default();
+    path_env.split(':').any(|entry| entry == shim_dir)
+}
+
+/// Prompt for PATH consent and act on the answer.
+fn offer_path_setup(
+    home: &std::path::Path,
+    stdin: &mut dyn BufRead,
+    stdout: &mut dyn Write,
+) -> Result<()> {
+    writeln!(
+        stdout,
+        "\nThe shim directory is not in your PATH.\nAdd it automatically? [y/N] "
+    )?;
+    stdout.flush()?;
+
+    let mut answer = String::new();
+    stdin.read_line(&mut answer)?;
+
+    if answer.trim().eq_ignore_ascii_case("y") {
+        append_to_rc_idempotent(home, stdout)?;
+    } else {
+        print_manual_instructions(stdout)?;
+    }
+    Ok(())
+}
+
+/// Append the export line to the shell rc file, unless it is already present.
+fn append_to_rc_idempotent(home: &std::path::Path, stdout: &mut dyn Write) -> Result<()> {
+    let rc_path = detect_rc_file(home);
+    let existing = if rc_path.exists() {
+        std::fs::read_to_string(&rc_path)?
+    } else {
+        String::new()
+    };
+
+    if !existing.contains(SHIM_EXPORT_FRAGMENT) {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&rc_path)?;
+        writeln!(file, "\n{SHIM_EXPORT_LINE}")?;
+    }
+
+    let rc_display = rc_path
+        .strip_prefix(home)
+        .map(|p| format!("~/{}", p.display()))
+        .unwrap_or_else(|_| rc_path.display().to_string());
+
+    writeln!(
+        stdout,
+        "Added to {rc_display}. Please restart Claude Code so the new PATH takes effect in its shell snapshot."
+    )?;
+    Ok(())
+}
+
+/// Print manual PATH instructions to stdout.
+fn print_manual_instructions(stdout: &mut dyn Write) -> Result<()> {
+    writeln!(
+        stdout,
+        "To complete setup, add this line to your shell rc manually:\n  {SHIM_EXPORT_LINE}"
+    )?;
+    Ok(())
+}
+
+/// Determine the shell rc file based on `$SHELL`, defaulting to `.zshrc`.
+fn detect_rc_file(home: &std::path::Path) -> std::path::PathBuf {
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let rc_name = if shell.contains("bash") {
+        ".bashrc"
+    } else {
+        ".zshrc"
+    };
+    home.join(rc_name)
 }
 
 /// Remove the PATH shim symlink.
@@ -59,25 +166,38 @@ pub fn run_status(home: &std::path::Path) -> Result<()> {
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 mod tests {
+    use std::io::Cursor;
+
     use super::*;
     use tempfile::TempDir;
 
+    fn install_with_consent(home: &std::path::Path) {
+        let mut stdin = Cursor::new("y\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(home, false, &mut stdin, &mut stdout).unwrap();
+    }
+
+    fn install_with_decline(home: &std::path::Path) {
+        let mut stdin = Cursor::new("n\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(home, false, &mut stdin, &mut stdout).unwrap();
+    }
+
     #[test]
-    #[cfg(unix)]
     fn run_install_creates_symlink_under_home() {
         let dir = TempDir::new().unwrap();
-        run_install(dir.path(), false).unwrap();
+        install_with_decline(dir.path());
         let link = dir.path().join(".local/share/git-prism/bin/git");
         assert!(link.is_symlink(), "symlink must exist after shim install");
     }
 
     #[test]
-    #[cfg(unix)]
     fn run_install_is_idempotent() {
         let dir = TempDir::new().unwrap();
-        run_install(dir.path(), false).unwrap();
-        run_install(dir.path(), false).unwrap();
+        install_with_decline(dir.path());
+        install_with_decline(dir.path());
         let link = dir.path().join(".local/share/git-prism/bin/git");
         assert!(
             link.is_symlink(),
@@ -86,10 +206,82 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    fn consent_appends_export_line_to_rc_file() {
+        let dir = TempDir::new().unwrap();
+        let rc = dir.path().join(".zshrc");
+        std::fs::write(&rc, "# shell rc\n").unwrap();
+
+        install_with_consent(dir.path());
+
+        let content = std::fs::read_to_string(&rc).unwrap();
+        assert!(
+            content.contains(SHIM_EXPORT_FRAGMENT),
+            "rc file must contain the export fragment after consent"
+        );
+    }
+
+    #[test]
+    fn consent_appends_export_line_exactly_once_on_repeat() {
+        let dir = TempDir::new().unwrap();
+        let rc = dir.path().join(".zshrc");
+        std::fs::write(&rc, "# shell rc\n").unwrap();
+
+        install_with_consent(dir.path());
+        install_with_consent(dir.path());
+
+        let content = std::fs::read_to_string(&rc).unwrap();
+        let count = content.matches(SHIM_EXPORT_FRAGMENT).count();
+        assert_eq!(count, 1, "export fragment must appear exactly once");
+    }
+
+    #[test]
+    fn consent_output_contains_restart() {
+        let dir = TempDir::new().unwrap();
+        let rc = dir.path().join(".zshrc");
+        std::fs::write(&rc, "# shell rc\n").unwrap();
+
+        let mut stdin = Cursor::new("y\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout).unwrap();
+
+        let out = String::from_utf8(stdout).unwrap();
+        assert!(
+            out.contains("restart"),
+            "output must tell user to restart Claude Code; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn decline_leaves_rc_file_unchanged() {
+        let dir = TempDir::new().unwrap();
+        let rc = dir.path().join(".zshrc");
+        std::fs::write(&rc, "# shell rc\n").unwrap();
+        let original = std::fs::read_to_string(&rc).unwrap();
+
+        install_with_decline(dir.path());
+
+        let after = std::fs::read_to_string(&rc).unwrap();
+        assert_eq!(original, after, "rc file must be unchanged after decline");
+    }
+
+    #[test]
+    fn decline_output_contains_shim_dir_path() {
+        let dir = TempDir::new().unwrap();
+        let mut stdin = Cursor::new("n\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout).unwrap();
+
+        let out = String::from_utf8(stdout).unwrap();
+        assert!(
+            out.contains(SHIM_EXPORT_FRAGMENT),
+            "output must contain the shim dir path; got: {out:?}"
+        );
+    }
+
+    #[test]
     fn run_uninstall_removes_symlink() {
         let dir = TempDir::new().unwrap();
-        run_install(dir.path(), false).unwrap();
+        install_with_decline(dir.path());
         run_uninstall(dir.path()).unwrap();
         let link = dir.path().join(".local/share/git-prism/bin/git");
         assert!(!link.is_symlink() && !link.exists(), "symlink must be gone");
@@ -98,15 +290,13 @@ mod tests {
     #[test]
     fn run_status_reports_not_installed_when_absent() {
         let dir = TempDir::new().unwrap();
-        // Verifies no panic/error when shim is absent.
         run_status(dir.path()).unwrap();
     }
 
     #[test]
-    #[cfg(unix)]
     fn run_status_succeeds_after_install() {
         let dir = TempDir::new().unwrap();
-        run_install(dir.path(), false).unwrap();
+        install_with_decline(dir.path());
         run_status(dir.path()).unwrap();
     }
 }

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -53,9 +53,14 @@ pub fn run_install_with_io(
 }
 
 /// Return true if the shim directory string appears in the current `PATH` env var.
+/// Normalizes trailing slashes so a PATH entry like `/path/to/bin/` matches `/path/to/bin`.
 fn shim_dir_is_in_path(shim_dir: &str) -> bool {
     let path_env = std::env::var("PATH").unwrap_or_default();
-    path_env.split(':').any(|entry| entry == shim_dir)
+    let normalized_shim = shim_dir.trim_end_matches('/');
+    path_env.split(':').any(|entry| {
+        let normalized_entry = entry.trim_end_matches('/');
+        normalized_entry == normalized_shim
+    })
 }
 
 /// Prompt for PATH consent and act on the answer.
@@ -82,6 +87,7 @@ fn offer_path_setup(
 }
 
 /// Append the export line to the shell rc file, unless it is already present.
+/// Detects presence by matching the full export line (line-wise, ignoring comments).
 fn append_to_rc_idempotent(home: &std::path::Path, stdout: &mut dyn Write) -> Result<()> {
     let rc_path = detect_rc_file(home);
     let existing = if rc_path.exists() {
@@ -90,7 +96,13 @@ fn append_to_rc_idempotent(home: &std::path::Path, stdout: &mut dyn Write) -> Re
         String::new()
     };
 
-    if !existing.contains(SHIM_EXPORT_FRAGMENT) {
+    // Check if the full export line already exists (non-comment, trimmed match).
+    let export_line_already_present = existing.lines().any(|line| {
+        let trimmed = line.trim_start();
+        !trimmed.starts_with('#') && trimmed.trim() == SHIM_EXPORT_LINE.trim()
+    });
+
+    if !export_line_already_present {
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)

--- a/tests/shim_auto_path_pentest.rs
+++ b/tests/shim_auto_path_pentest.rs
@@ -1,0 +1,113 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #325, gate 3): auto-PATH setup UX.
+//!
+//! These drive the built binary end-to-end via `git-prism shim install`,
+//! injecting stdin and an isolated HOME. They probe the idempotency /
+//! consent logic in `src/shim_cmd.rs`.
+
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+/// Clean PATH that does NOT contain the isolated shim dir, so detection always
+/// reports "not in PATH" and the consent prompt fires.
+const CLEAN_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+fn count_real_export_lines(rc: &str) -> usize {
+    rc.lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with('#')
+                && t.contains(r#"export PATH="$HOME/.local/share/git-prism/bin:$PATH""#)
+        })
+        .count()
+}
+
+/// BUG: when the rc file merely MENTIONS the fragment `.local/share/git-prism/bin`
+/// in an unrelated line (a comment, a backup-dir path, a doc reference), the
+/// idempotency check `existing.contains(SHIM_EXPORT_FRAGMENT)` false-positives.
+/// On consent the export line is NOT appended, yet stdout claims
+/// "Added to ~/.zshrc. Please restart Claude Code...". The user is told setup
+/// succeeded while the rc has no working export — a silent failure plus a lie.
+#[test]
+fn consent_appends_export_even_when_fragment_appears_in_unrelated_line() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let home = TempDir::new().unwrap();
+    let rc = home.path().join(".zshrc");
+    // Unrelated line that contains the fragment as a substring.
+    std::fs::write(
+        &rc,
+        "# I once read about .local/share/git-prism/bin in the docs\n",
+    )
+    .unwrap();
+
+    let out = Command::new(bin)
+        .env("HOME", home.path())
+        .env("PATH", CLEAN_PATH)
+        .env("SHELL", "/bin/zsh")
+        .args(["shim", "install"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(b"y\n").unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let rc_after = std::fs::read_to_string(&rc).unwrap();
+
+    // The tool claims success...
+    assert!(
+        stdout.contains("Added to"),
+        "precondition: consent path prints the success message; got: {stdout}"
+    );
+    // ...but a real, working export line must actually be present.
+    assert_eq!(
+        count_real_export_lines(&rc_after),
+        1,
+        "consent must write exactly one real export line even when the \
+         fragment appears as an unrelated substring; rc was: {rc_after:?}"
+    );
+}
+
+/// SUSPICIOUS (false negative): a shim dir already on PATH but written with a
+/// trailing slash is not recognized as present (`entry == shim_dir` is exact).
+/// The tool re-prompts and offers to add a duplicate export line. Not data loss,
+/// but a UX defect: a user who already configured PATH (with a trailing slash)
+/// is told it's missing.
+#[test]
+fn trailing_slash_path_entry_is_recognized_as_already_present() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let home = TempDir::new().unwrap();
+    std::fs::write(home.path().join(".zshrc"), "# rc\n").unwrap();
+    let shim_dir = home.path().join(".local/share/git-prism/bin");
+
+    let path_with_trailing_slash = format!("{}/:{}", shim_dir.display(), CLEAN_PATH);
+
+    let out = Command::new(bin)
+        .env("HOME", home.path())
+        .env("PATH", path_with_trailing_slash)
+        .env("SHELL", "/bin/zsh")
+        .args(["shim", "install"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(b"n\n").unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("not in your PATH"),
+        "shim dir present with a trailing slash should count as already-in-PATH; \
+         got prompt: {stdout}"
+    );
+}


### PR DESCRIPTION
## What

Adds the auto-PATH-setup UX to `git-prism shim install`. Epic #328 (shim parity → sunset the redirect hook).

On `git-prism shim install`:
- **Shim dir already in PATH** → no prompt, no rc change.
- **Not in PATH** → prompt for consent:
  - **Consent** → idempotently append `export PATH="$HOME/.local/share/git-prism/bin:$PATH"` to the shell rc (`.zshrc`/`.bashrc` per `$SHELL`), and print a message telling the user to **restart Claude Code** (per ADR 0010 — the shell snapshot is frozen at launch, so the new PATH only takes effect on the next `claude` start).
  - **Decline** → no rc modification; print manual instructions including the shim dir path.

The install flow is split into a testable `run_install_with_io(..., &mut dyn BufRead, &mut dyn Write)` seam so consent and rc-writing are driven by injected stdin/stdout in tests.

## Tests — hermetic

4 `@ISSUE-325` scenarios go RED→GREEN; 10 unit tests. All hermetic — isolated tempdir HOME + a fixture rc + injected stdin (`Cursor`); **no test reads or writes the developer's real `~/.zshrc`/`~/.bashrc`** (verified: real rc SHA unchanged before/after).

## Gauntlet

adversarial-QA caught and we fixed two real bugs (runs 2, now PASS):
- **Idempotency substring false-positive** — the append guard matched the bare fragment `.local/share/git-prism/bin`, so an unrelated/commented rc line containing it caused a silent skip + a false "Added… restart" success message. Now matches the full export **line** line-wise, skipping comments.
- **Trailing-slash PATH false-negative** — a PATH entry `.../bin/` wasn't recognized as present → re-prompt/duplicate. Now normalizes trailing slashes on both sides (still exact-match, so `.../bin-backup` correctly does not match).

rust-purist clean. Two accepted LOW style nits (inline-prompt `write!` vs `writeln!`; a redundant double-`.trim()`) — cosmetic, not worth a re-verify cycle.

## Notes

- Scope is `git-prism shim install` only; the deprecated `hooks install --path-shim` path is unchanged.
- `@ISSUE-326` remains `@not_implemented` (the last unimplemented group). Windows compiles (auto-PATH logic is `fs`/`env`/`io` only; unix-only tests cfg-guarded).

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)