### PR TITLE
fix(git): peel annotated tags to commits in ref resolution (#337)

### DIFF
--- a/src/git/reader.rs
+++ b/src/git/reader.rs
@@ -89,10 +89,7 @@ impl RepoReader {
             .lookup_entry_by_path(file_path)
             .map_err(|e| GitError::ReadObject(e.to_string()))?
             .ok_or_else(|| {
-                GitError::ReadObject(format!(
-                    "file '{}' not found at ref '{}'",
-                    file_path, refspec
-                ))
+                GitError::ReadObject(format!("file '{file_path}' not found at ref '{refspec}'"))
             })?;
 
         let blob = entry
@@ -238,7 +235,7 @@ impl RepoReader {
             .repo
             .rev_parse_single(refspec)
             // Raw gix error omitted — see OpenRepo for rationale.
-            .map_err(|_| Self::resolve_ref_with_fallback(self, refspec))?;
+            .map_err(|_| self.resolve_ref_with_fallback(refspec))?;
 
         let object = rev
             .object()
@@ -999,14 +996,14 @@ mod tests {
             .unwrap()
             .trim()
             .to_string();
-        let out = git(
+        let tag_result = git(
             &path,
             &["tag", "-a", "treetag", "-m", "points at a tree", &tree_sha],
         );
         assert!(
-            out.status.success(),
+            tag_result.status.success(),
             "fixture setup failed (could not tag a tree): {}",
-            String::from_utf8_lossy(&out.stderr)
+            String::from_utf8_lossy(&tag_result.stderr)
         );
 
         let reader = RepoReader::open(&path).unwrap();
@@ -1031,14 +1028,14 @@ mod tests {
             .unwrap()
             .trim()
             .to_string();
-        let out = git(
+        let tag_result = git(
             &path,
             &["tag", "-a", "blobtag", "-m", "points at a blob", &blob_sha],
         );
         assert!(
-            out.status.success(),
+            tag_result.status.success(),
             "fixture setup failed (could not tag a blob): {}",
-            String::from_utf8_lossy(&out.stderr)
+            String::from_utf8_lossy(&tag_result.stderr)
         );
 
         let reader = RepoReader::open(&path).unwrap();

--- a/src/git/reader.rs
+++ b/src/git/reader.rs
@@ -245,7 +245,7 @@ impl RepoReader {
             .map_err(|e| GitError::ReadObject(e.to_string()))?;
 
         object
-            .try_into_commit()
+            .peel_to_commit()
             .map_err(|e| GitError::ReadObject(e.to_string()))
     }
 
@@ -892,5 +892,66 @@ mod tests {
 
         drop(local_dir);
         drop(remote_dir);
+    }
+
+    #[test]
+    fn it_peels_annotated_tag_to_commit() {
+        let (_dir, path) = create_test_repo();
+
+        Command::new("git")
+            .args(["tag", "-a", "v1.0", "-m", "release v1.0"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let reader = RepoReader::open(&path).unwrap();
+        let result = reader.resolve_commit("v1.0");
+        assert!(
+            result.is_ok(),
+            "peel_to_commit failed for annotated tag: {:?}",
+            result.err()
+        );
+        let commit = result.unwrap();
+        assert_eq!(
+            commit.message, "initial commit",
+            "annotated tag should resolve to the tagged commit"
+        );
+    }
+
+    #[test]
+    fn it_resolves_lightweight_tag_to_commit() {
+        let (_dir, path) = create_test_repo();
+
+        Command::new("git")
+            .args(["tag", "v0.1"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let reader = RepoReader::open(&path).unwrap();
+        let commit = reader.resolve_commit("v0.1").unwrap();
+        assert_eq!(
+            commit.message, "initial commit",
+            "lightweight tag should also resolve to the tagged commit"
+        );
+    }
+
+    #[test]
+    fn annotated_tag_and_branch_resolve_to_same_commit_sha() {
+        let (_dir, path) = create_test_repo();
+
+        Command::new("git")
+            .args(["tag", "-a", "v1.0", "-m", "release v1.0"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let reader = RepoReader::open(&path).unwrap();
+        let via_tag = reader.resolve_commit("v1.0").unwrap();
+        let via_branch = reader.resolve_commit("main").unwrap();
+        assert_eq!(
+            via_tag.sha, via_branch.sha,
+            "annotated tag and branch should resolve to the same commit SHA"
+        );
     }
 }

--- a/src/git/reader.rs
+++ b/src/git/reader.rs
@@ -954,4 +954,181 @@ mod tests {
             "annotated tag and branch should resolve to the same commit SHA"
         );
     }
+
+    // ===== ADVERSARIAL QA PROBES (issue #337 pen-test) =====
+
+    fn git(path: &std::path::Path, args: &[&str]) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap()
+    }
+
+    /// A tag pointing at ANOTHER annotated tag (`git tag -a v2 v1`). gix's
+    /// peel_to_commit must follow the full chain tag -> tag -> commit.
+    #[test]
+    fn qa_nested_annotated_tag_chain_resolves_to_commit() {
+        let (_dir, path) = create_test_repo();
+        git(&path, &["tag", "-a", "v1", "-m", "first tag"]);
+        git(&path, &["tag", "-a", "v2", "-m", "tag of a tag", "v1"]);
+
+        let reader = RepoReader::open(&path).unwrap();
+        let via_chain = reader.resolve_commit("v2");
+        assert!(
+            via_chain.is_ok(),
+            "nested annotated tag (tag->tag->commit) failed to peel: {:?}",
+            via_chain.err()
+        );
+        let head = reader.resolve_commit("HEAD").unwrap();
+        assert_eq!(
+            via_chain.unwrap().sha,
+            head.sha,
+            "nested annotated tag must resolve to the underlying commit"
+        );
+    }
+
+    /// An annotated tag whose target is a TREE (not a commit). peel_to_commit
+    /// cannot reach a commit, so it must return a clean GitError::ReadObject —
+    /// NOT panic and NOT silently succeed.
+    #[test]
+    fn qa_annotated_tag_pointing_at_tree_errors_cleanly() {
+        let (_dir, path) = create_test_repo();
+        // Resolve HEAD's tree SHA, then create an annotated tag pointing at it.
+        let tree_sha = String::from_utf8(git(&path, &["rev-parse", "HEAD^{tree}"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        let out = git(
+            &path,
+            &["tag", "-a", "treetag", "-m", "points at a tree", &tree_sha],
+        );
+        assert!(
+            out.status.success(),
+            "fixture setup failed (could not tag a tree): {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let reader = RepoReader::open(&path).unwrap();
+        // Must not panic; must be an Err.
+        let result = reader.resolve_commit("treetag");
+        assert!(
+            result.is_err(),
+            "annotated tag pointing at a tree must NOT resolve to a commit, got: {:?}",
+            result.ok()
+        );
+        assert!(
+            matches!(result.unwrap_err(), GitError::ReadObject(_)),
+            "tag->tree peel failure must surface as GitError::ReadObject"
+        );
+    }
+
+    /// An annotated tag whose target is a BLOB. Same contract: clean error.
+    #[test]
+    fn qa_annotated_tag_pointing_at_blob_errors_cleanly() {
+        let (_dir, path) = create_test_repo();
+        let blob_sha = String::from_utf8(git(&path, &["rev-parse", "HEAD:README.md"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        let out = git(
+            &path,
+            &["tag", "-a", "blobtag", "-m", "points at a blob", &blob_sha],
+        );
+        assert!(
+            out.status.success(),
+            "fixture setup failed (could not tag a blob): {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let reader = RepoReader::open(&path).unwrap();
+        let result = reader.resolve_commit("blobtag");
+        assert!(
+            result.is_err(),
+            "annotated tag pointing at a blob must NOT resolve to a commit, got: {:?}",
+            result.ok()
+        );
+        assert!(
+            matches!(result.unwrap_err(), GitError::ReadObject(_)),
+            "tag->blob peel failure must surface as GitError::ReadObject"
+        );
+    }
+
+    /// Regression guard: a raw full SHA must still resolve to itself after the
+    /// peel change (peel_to_commit on an already-commit object is a no-op).
+    #[test]
+    fn qa_raw_full_sha_still_resolves_unchanged() {
+        let (_dir, path) = create_test_repo();
+        let full_sha = String::from_utf8(git(&path, &["rev-parse", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        let reader = RepoReader::open(&path).unwrap();
+        let by_sha = reader.resolve_commit(&full_sha).unwrap();
+        assert_eq!(by_sha.sha, full_sha, "raw full SHA must resolve to itself");
+        assert_eq!(by_sha.message, "initial commit");
+    }
+
+    /// tag..tag manifest (annotated) must equal the equivalent commit..commit
+    /// manifest and be non-empty. This is the real-world reviewer use case:
+    /// `git-prism manifest v_old..v_new` over annotated release tags.
+    #[test]
+    fn qa_annotated_tag_range_manifest_matches_commit_range_and_is_nonempty() {
+        let (_dir, path) = create_test_repo();
+        // base = initial commit (tagged v_old)
+        git(&path, &["tag", "-a", "v_old", "-m", "old release"]);
+        let base_sha = String::from_utf8(git(&path, &["rev-parse", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        // add a second commit, tag it v_new
+        std::fs::write(path.join("feature.rs"), "fn added() {}\n").unwrap();
+        git(&path, &["add", "feature.rs"]);
+        git(&path, &["commit", "-m", "add feature"]);
+        git(&path, &["tag", "-a", "v_new", "-m", "new release"]);
+        let head_sha = String::from_utf8(git(&path, &["rev-parse", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+
+        let reader = RepoReader::open(&path).unwrap();
+
+        let via_tags = reader.diff_commits("v_old", "v_new").unwrap();
+        let via_commits = reader.diff_commits(&base_sha, &head_sha).unwrap();
+
+        let tag_files: Vec<String> = via_tags.files.iter().map(|f| f.path.clone()).collect();
+        let commit_files: Vec<String> = via_commits.files.iter().map(|f| f.path.clone()).collect();
+
+        assert!(
+            !tag_files.is_empty(),
+            "annotated tag..tag diff must be non-empty (expected feature.rs)"
+        );
+        assert_eq!(
+            tag_files, commit_files,
+            "annotated tag range must produce the same file set as the commit range"
+        );
+        assert!(
+            tag_files.iter().any(|p| p == "feature.rs"),
+            "expected feature.rs in tag-range diff, got: {tag_files:?}"
+        );
+    }
+
+    /// Mixed range: annotated tag .. branch must resolve both ends and produce
+    /// the correct diff (regression that peel didn't break non-tag end).
+    #[test]
+    fn qa_mixed_annotated_tag_dotdot_branch_range() {
+        let (_dir, path) = create_test_repo();
+        git(&path, &["tag", "-a", "v_old", "-m", "old release"]);
+        std::fs::write(path.join("feature.rs"), "fn added() {}\n").unwrap();
+        git(&path, &["add", "feature.rs"]);
+        git(&path, &["commit", "-m", "add feature"]);
+
+        let reader = RepoReader::open(&path).unwrap();
+        let via_mixed = reader.diff_commits("v_old", "main").unwrap();
+        let files: Vec<String> = via_mixed.files.iter().map(|f| f.path.clone()).collect();
+        assert!(
+            files.iter().any(|p| p == "feature.rs"),
+            "mixed tag..branch range must include feature.rs, got: {files:?}"
+        );
+    }
 }

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -365,4 +365,34 @@ mod tests {
             "expected 'functions' key in function_context output, got: {json}"
         );
     }
+
+    #[test]
+    fn it_handles_show_snapshot_for_annotated_tag_without_error() {
+        // Before the peel fix, `git show <annotated-tag>` would panic or exit
+        // non-zero because peel_to_commit failed with "was kind tag". This test
+        // confirms the handler completes successfully (exit SUCCESS, valid JSON
+        // with a "files" array) after the fix.
+        let (_dir, path) = init_repo_with_two_commits();
+
+        Command::new("git")
+            .args(["tag", "-a", "v1.0", "-m", "release v1.0"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let classification = Classification::ShowSnapshot { sha: "v1.0" };
+        let mut out = Vec::new();
+        let code = handle(&classification, &path, &mut out);
+        assert_eq!(
+            code,
+            ExitCode::SUCCESS,
+            "handle should exit SUCCESS for annotated tag, got non-zero"
+        );
+
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(
+            json.get("files").and_then(|f| f.as_array()).is_some(),
+            "expected 'files' array in show output for annotated tag, got: {json}"
+        );
+    }
 }

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -455,4 +455,60 @@ mod tests {
             "annotated-tag show must produce the same files as target-sha show"
         );
     }
+
+    /// The `Classification::Manifest` path peels BOTH ends of a range.  This
+    /// test creates two annotated tags on consecutive commits and asserts that
+    /// the manifest over `v0.1..v0.2` returns a non-empty `files` array that
+    /// contains the file added in the second commit.  A "was kind tag" peel
+    /// failure would surface here as either an error exit or an empty file list.
+    #[test]
+    fn qa_manifest_over_annotated_tag_range_returns_changed_files() {
+        let (dir, path) = init_repo_with_two_commits();
+
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&path)
+                .output()
+                .unwrap()
+        };
+
+        // v0.1 tags the first commit (HEAD~1 after init_repo_with_two_commits)
+        git(&["tag", "-a", "v0.1", "-m", "v0.1 release", "HEAD~1"]);
+        // v0.2 tags the current HEAD (second commit, which added world.txt)
+        git(&["tag", "-a", "v0.2", "-m", "v0.2 release", "HEAD"]);
+
+        let classification = Classification::Manifest {
+            range: "v0.1..v0.2",
+        };
+        let mut out = Vec::new();
+        let code = handle(&classification, &path, &mut out);
+        assert_eq!(
+            code,
+            ExitCode::SUCCESS,
+            "manifest over annotated tag range must exit SUCCESS"
+        );
+
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let files = json
+            .get("files")
+            .and_then(|f| f.as_array())
+            .expect("expected 'files' array in manifest output");
+
+        assert!(
+            !files.is_empty(),
+            "manifest over v0.1..v0.2 must be non-empty (expected world.txt)"
+        );
+
+        let paths: Vec<&str> = files
+            .iter()
+            .filter_map(|f| f.get("path").and_then(|p| p.as_str()))
+            .collect();
+        assert!(
+            paths.contains(&"world.txt"),
+            "expected world.txt in manifest files, got: {paths:?}"
+        );
+
+        drop(dir);
+    }
 }

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -395,4 +395,64 @@ mod tests {
             "expected 'files' array in show output for annotated tag, got: {json}"
         );
     }
+
+    // ===== ADVERSARIAL QA PROBES (issue #337 pen-test) =====
+
+    // SUSPICIOUS (pre-existing, NOT a #337 regression): `git show <ref>` via the
+    // shim always returns files: [] because handle_show_snapshot calls
+    // build_snapshots with an empty `paths` slice (&[]). build_snapshots only
+    // processes files explicitly listed in `paths`; it never enumerates the
+    // changed files of the range. This is true for annotated tags, lightweight
+    // tags, AND raw SHAs identically — the empty `&[]` predates this PR
+    // (origin/main:src/shim/handlers.rs:134). The peel change is therefore
+    // correct and unaffected here; the dev's
+    // it_handles_show_snapshot_for_annotated_tag_without_error test passes only
+    // because the snapshot is empty for everything, which masks whether the
+    // peel actually surfaces the right commit's content. Reported as SUSPICIOUS,
+    // not blocked, because it is out of scope for the #337 peel fix.
+
+    /// Regression guard within #337 scope: `git show <annotated-tag>` and
+    /// `git show <target-sha>` produce IDENTICAL output (both empty today, but
+    /// must not diverge — peeling must map the tag to the same range the SHA
+    /// produces). This stays green and protects the equivalence the peel change
+    /// is supposed to guarantee.
+    #[test]
+    fn qa_show_annotated_tag_output_equals_target_sha_output() {
+        let (_dir, path) = init_repo_with_two_commits();
+        Command::new("git")
+            .args(["tag", "-a", "v1.0", "-m", "release v1.0"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        let target_sha = head_sha(&path);
+
+        let mut out_tag = Vec::new();
+        assert_eq!(
+            handle(
+                &Classification::ShowSnapshot { sha: "v1.0" },
+                &path,
+                &mut out_tag
+            ),
+            ExitCode::SUCCESS
+        );
+        let mut out_sha = Vec::new();
+        assert_eq!(
+            handle(
+                &Classification::ShowSnapshot { sha: &target_sha },
+                &path,
+                &mut out_sha
+            ),
+            ExitCode::SUCCESS
+        );
+
+        let json_tag: serde_json::Value = serde_json::from_slice(&out_tag).unwrap();
+        let json_sha: serde_json::Value = serde_json::from_slice(&out_sha).unwrap();
+        // Compare the `files` arrays (metadata.base_ref/head_ref legitimately
+        // differ: "v1.0^"/"v1.0" vs "<sha>^"/"<sha>"; generated_at also differs).
+        assert_eq!(
+            json_tag.get("files"),
+            json_sha.get("files"),
+            "annotated-tag show must produce the same files as target-sha show"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #337. `get_change_manifest`, `get_commit_history`, `get_file_snapshots`, and the PATH shim's `git diff`/`git log`/`git show` interception all failed when a ref was an **annotated tag** — so git-prism couldn't analyze its own tagged releases (e.g. `v0.8.0..v0.9.0`).

## Root cause

`RepoReader::peel_to_commit` (`src/git/reader.rs`) resolved a ref and then called `object.try_into_commit()`. For an annotated tag, `rev_parse_single` resolves to the **tag object**, and `try_into_commit()` errors:

```
git error: failed to read object: <oid> was supposed to be of kind commit, but was kind tag.
```

Lightweight tags, branches, and raw SHAs were unaffected (they resolve directly to commits).

## Fix

One-line root fix: `try_into_commit()` → `peel_to_commit()`, which follows the tag → … → commit chain before converting. It's a no-op for objects that are already commits, so branches/SHAs/lightweight tags behave exactly as before. The `GitError::ReadObject` error contract is preserved verbatim for genuinely unresolvable refs (e.g. a tag pointing at a tree/blob still errors cleanly — no panic, no silent empty result).

Because both the MCP tools and the PATH shim funnel through `peel_to_commit`, this single change fixes every surface.

## Tests

- `it_peels_annotated_tag_to_commit` (RED→GREEN) + triangulation (lightweight tag, tag/branch SHA equivalence).
- Adversarial-QA probes: nested annotated-tag chains (`tag -a v2 v1`), tag→tree and tag→blob clean-error contracts, raw-SHA regression guard, annotated `tag..tag` range equals the commit..commit range and is non-empty, mixed tag..branch range.
- A manifest-path test exercising peel-through-the-shim with non-empty output.

## Out of scope / follow-up

The shim's bare `git show <ref>` returns an empty `files` array (it passes an empty `paths` slice to `build_snapshots`) — this predates this PR and affects all ref types equally, so it is **not** a peel regression. It is fixed in the parallel PR for #338 (which rewrites `git show` to use the manifest pipeline).

## Verification

```
cargo fmt --check        # clean
cargo clippy --all-targets -- -D warnings   # 0 errors
cargo test               # 939 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
