### PR TITLE
fix(shim): passthrough scripted-output git + enrich git show <ref> (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Shim now passes through scripted-output git invocations.** When `git show`, `git log`, or `git diff` is called with flags that request formatted text output (`--format=`, `--pretty=`, `--pretty`, `-s`, `--no-patch`, `--porcelain`, `--stat`, `-z`), the shim forwards the call to real git instead of returning a JSON manifest. This fixes `git show -s --format=%ct HEAD` silently returning a change-manifest JSON payload instead of the expected epoch integer. (#338)
+
+### Added
+
+- **Enriched `git show <ref>` response.** The shim's `git show <sha>` handler now returns a `ShowManifestResponse` with structured commit metadata (`commit.sha`, `commit.short_sha`, `commit.parents`, `commit.author`, `commit.committer`, `commit.subject`, `commit.body`) and a top-level `diffstat` object (`files_changed`, `insertions`, `deletions`). JSON-aware callers no longer need to parse git text output to get per-commit author, timestamp, or diffstat data. (#338)
+
 ## [0.9.0] — 2026-05-31
 
 ### Breaking Changes

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -260,6 +260,70 @@ impl RepoReader {
 
         Ok(DiffResult { files })
     }
+
+    /// Diff a root (parentless) commit against the empty tree by walking its
+    /// tree and reporting every blob as an `Added` file.
+    ///
+    /// This exists because `diff_commits` calls `peel_to_commit` on the base
+    /// ref, which fails for the well-known empty-tree SHA
+    /// (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) — that SHA is a tree
+    /// object, not a commit.
+    pub fn diff_root_commit(&self, head_ref: &str) -> Result<DiffResult, GitError> {
+        let _span = tracing::info_span!("git.diff_root_commit").entered();
+        let head_commit = self.peel_to_commit(head_ref)?;
+        let head_tree = head_commit.tree().map_err(obj_err)?;
+
+        let mut files: Vec<FileChange> = Vec::new();
+        self.walk_tree_as_additions(&head_tree, String::new(), &mut files)?;
+        Ok(DiffResult { files })
+    }
+
+    /// Recursively walk a tree object, emitting every blob as an `Added` file.
+    fn walk_tree_as_additions(
+        &self,
+        tree: &gix::Tree<'_>,
+        prefix: String,
+        files: &mut Vec<FileChange>,
+    ) -> Result<(), GitError> {
+        for entry_ref in tree.iter() {
+            let entry = entry_ref.map_err(obj_err)?;
+            let name = entry.filename().to_string();
+            let path = if prefix.is_empty() {
+                name.clone()
+            } else {
+                format!("{prefix}/{name}")
+            };
+            let mode = entry.mode();
+            if mode.is_tree() {
+                let obj = entry.object().map_err(obj_err)?;
+                let sub_tree = obj.try_into_tree().map_err(obj_err)?;
+                let sub_tree_ref = self
+                    .repo()
+                    .find_object(sub_tree.id)
+                    .map_err(obj_err)?
+                    .try_into_tree()
+                    .map_err(obj_err)?;
+                self.walk_tree_as_additions(&sub_tree_ref, path, files)?;
+            } else if mode.is_blob() {
+                let obj = entry.object().map_err(obj_err)?;
+                let is_binary = obj.data.contains(&0);
+                let lines = if is_binary { 0 } else { count_lines(&obj.data) };
+                files.push(FileChange {
+                    path,
+                    old_path: None,
+                    change_type: ChangeType::Added,
+                    change_scope: ChangeScope::Committed,
+                    is_binary,
+                    lines_added: lines,
+                    lines_removed: 0,
+                    size_before: 0,
+                    size_after: obj.data.len(),
+                    staged_blob_id: None,
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 fn obj_err(e: impl std::fmt::Display) -> GitError {

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -289,21 +289,18 @@ impl RepoReader {
             let entry = entry_ref.map_err(obj_err)?;
             let name = entry.filename().to_string();
             let path = if prefix.is_empty() {
-                name.clone()
+                name
             } else {
                 format!("{prefix}/{name}")
             };
             let mode = entry.mode();
             if mode.is_tree() {
-                let obj = entry.object().map_err(obj_err)?;
-                let sub_tree = obj.try_into_tree().map_err(obj_err)?;
-                let sub_tree_ref = self
-                    .repo()
-                    .find_object(sub_tree.id)
+                let sub_tree = entry
+                    .object()
                     .map_err(obj_err)?
                     .try_into_tree()
                     .map_err(obj_err)?;
-                self.walk_tree_as_additions(&sub_tree_ref, path, files)?;
+                self.walk_tree_as_additions(&sub_tree, path, files)?;
             } else if mode.is_blob() {
                 let obj = entry.object().map_err(obj_err)?;
                 let is_binary = obj.data.contains(&0);

--- a/src/shim/classify.rs
+++ b/src/shim/classify.rs
@@ -124,19 +124,8 @@ fn classify_show<'a>(rest: &[&'a str]) -> Classification<'a> {
 }
 
 /// Return `true` when the argv slice contains any flag that requests
-/// scripted/machine-readable text output from git.  When these flags are
-/// present the caller wants the raw git output — not a JSON manifest.
-///
-/// Flags covered:
-/// - `--format=<val>` and `--format` (pretty-print format string)
-/// - `--pretty=<val>` and `--pretty` (pretty-print preset or format string)
-/// - `-s` / `--no-patch` (suppress diff, often paired with `--format`)
-/// - `--porcelain` (machine-readable output for `status`, `blame`, etc.)
-/// - `--stat` (diffstat text output)
-/// - `-z` (NUL-terminated output)
-/// Return `true` when the argv slice contains any flag that requests
-/// scripted/machine-readable text output from git.  When these flags are
-/// present the caller wants the raw git output — not a JSON manifest.
+/// scripted/machine-readable text output from git (the caller wants raw git
+/// output, not a JSON manifest).
 ///
 /// Flags covered:
 /// - `--format=<val>` and `--format` (pretty-print format string)

--- a/src/shim/classify.rs
+++ b/src/shim/classify.rs
@@ -134,6 +134,28 @@ fn classify_show<'a>(rest: &[&'a str]) -> Classification<'a> {
 /// - `--porcelain` (machine-readable output for `status`, `blame`, etc.)
 /// - `--stat` (diffstat text output)
 /// - `-z` (NUL-terminated output)
+/// Return `true` when the argv slice contains any flag that requests
+/// scripted/machine-readable text output from git.  When these flags are
+/// present the caller wants the raw git output — not a JSON manifest.
+///
+/// Flags covered:
+/// - `--format=<val>` and `--format` (pretty-print format string)
+/// - `--pretty=<val>` and `--pretty` (pretty-print preset or format string)
+/// - `-s` / `--no-patch` (suppress diff, often paired with `--format`)
+/// - `--porcelain` (machine-readable output for `status`, `blame`, etc.)
+/// - `--stat` (diffstat text output)
+/// - `-z` (NUL-terminated output)
+///
+/// # SAFETY: `--` separator not honoured
+///
+/// git treats `--` as the end of flags and the start of pathspecs, so
+/// `git diff a..b -- --stat` passes `--stat` as a filename, not a flag.
+/// This scanner does not track `--` and would incorrectly treat that
+/// `--stat` as a scripted-output flag, causing passthrough when interception
+/// was correct.  This is a theoretical input (no real caller names a file
+/// `--stat`) and adding a runtime guard would complicate the hot path for
+/// no practical benefit.  If it becomes real, scan for `--` first and stop
+/// checking beyond it.
 fn has_scripted_output_flag(tokens: &[&str]) -> bool {
     tokens.iter().any(|tok| {
         tok.starts_with("--format=")

--- a/src/shim/classify.rs
+++ b/src/shim/classify.rs
@@ -160,6 +160,10 @@ fn has_scripted_output_flag(tokens: &[&str]) -> bool {
 }
 
 fn classify_blame<'a>(rest: &[&'a str]) -> Classification<'a> {
+    // Scripted-output flags (e.g. --porcelain) mean the caller wants raw text.
+    if has_scripted_output_flag(rest) {
+        return Classification::Passthrough;
+    }
     // First non-flag argument is the path.
     if let Some(path) = rest.iter().copied().find(|t| !t.starts_with('-')) {
         return Classification::BlameSnapshot { path };
@@ -655,6 +659,64 @@ mod tests {
     fn it_classifies_git_blame_with_flags_before_path() {
         assert_eq!(
             classify(&["git", "blame", "-w", "src/main.rs"]),
+            Classification::BlameSnapshot {
+                path: "src/main.rs"
+            }
+        );
+    }
+
+    // --- Item 9: additional scripted-output classifier tests ---
+
+    #[test]
+    fn it_passes_through_git_diff_with_format_flag_and_range() {
+        // git diff --format=%H main..HEAD
+        assert_eq!(
+            classify(&["git", "diff", "--format=%H", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_diff_with_s_flag_and_range() {
+        // git diff -s main..HEAD
+        assert_eq!(
+            classify(&["git", "diff", "-s", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_diff_with_z_flag_and_range() {
+        // git diff -z main..HEAD
+        assert_eq!(
+            classify(&["git", "diff", "-z", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_bare_s_flag() {
+        // git show -s abc1234 (bare -s, no --format)
+        assert_eq!(
+            classify(&["git", "show", "-s", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_blame_with_porcelain_flag() {
+        // git blame --porcelain src/main.rs — scripted output, must passthrough.
+        assert_eq!(
+            classify(&["git", "blame", "--porcelain", "src/main.rs"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_still_classifies_plain_git_blame_as_blame_snapshot() {
+        // Regression: plain git blame without scripted-output flags must still be intercepted.
+        assert_eq!(
+            classify(&["git", "blame", "src/main.rs"]),
             Classification::BlameSnapshot {
                 path: "src/main.rs"
             }

--- a/src/shim/classify.rs
+++ b/src/shim/classify.rs
@@ -81,6 +81,10 @@ fn classify_git<'a>(subcommand: &str, rest: &[&'a str]) -> Classification<'a> {
 }
 
 fn classify_log<'a>(rest: &[&'a str]) -> Classification<'a> {
+    // Scripted-output flags take priority — caller wants text, not JSON.
+    if has_scripted_output_flag(rest) {
+        return Classification::Passthrough;
+    }
     // Pickaxe check BEFORE ref-range check (mirrors Python order).
     if let Some(term) = pickaxe_term(rest) {
         let range = rest.iter().copied().find(|t| has_ref_range(t));
@@ -97,6 +101,10 @@ fn classify_log<'a>(rest: &[&'a str]) -> Classification<'a> {
 }
 
 fn classify_diff<'a>(rest: &[&'a str]) -> Classification<'a> {
+    // Scripted-output flags take priority — caller wants text, not JSON.
+    if has_scripted_output_flag(rest) {
+        return Classification::Passthrough;
+    }
     if let Some(range) = rest.iter().copied().find(|t| has_ref_range(t)) {
         return Classification::Manifest { range };
     }
@@ -104,11 +112,40 @@ fn classify_diff<'a>(rest: &[&'a str]) -> Classification<'a> {
 }
 
 fn classify_show<'a>(rest: &[&'a str]) -> Classification<'a> {
+    // Scripted-output flags mean the caller wants text, not JSON.
+    if has_scripted_output_flag(rest) {
+        return Classification::Passthrough;
+    }
     // First non-flag argument is the sha.
     if let Some(sha) = rest.iter().copied().find(|t| !t.starts_with('-')) {
         return Classification::ShowSnapshot { sha };
     }
     Classification::Passthrough
+}
+
+/// Return `true` when the argv slice contains any flag that requests
+/// scripted/machine-readable text output from git.  When these flags are
+/// present the caller wants the raw git output — not a JSON manifest.
+///
+/// Flags covered:
+/// - `--format=<val>` and `--format` (pretty-print format string)
+/// - `--pretty=<val>` and `--pretty` (pretty-print preset or format string)
+/// - `-s` / `--no-patch` (suppress diff, often paired with `--format`)
+/// - `--porcelain` (machine-readable output for `status`, `blame`, etc.)
+/// - `--stat` (diffstat text output)
+/// - `-z` (NUL-terminated output)
+fn has_scripted_output_flag(tokens: &[&str]) -> bool {
+    tokens.iter().any(|tok| {
+        tok.starts_with("--format=")
+            || tok.starts_with("--pretty=")
+            || *tok == "--format"
+            || *tok == "--pretty"
+            || *tok == "-s"
+            || *tok == "--no-patch"
+            || *tok == "--porcelain"
+            || *tok == "--stat"
+            || *tok == "-z"
+    })
 }
 
 fn classify_blame<'a>(rest: &[&'a str]) -> Classification<'a> {
@@ -461,10 +498,133 @@ mod tests {
     }
 
     #[test]
-    fn it_classifies_git_show_with_flags_before_sha() {
+    fn it_classifies_git_show_with_non_scripted_flag_before_sha() {
+        // Flags that don't request scripted output still route to ShowSnapshot.
+        // --name-only requests filenames only — not a scripted format override.
+        assert_eq!(
+            classify(&["git", "show", "--name-only", "abc1234"]),
+            Classification::ShowSnapshot { sha: "abc1234" }
+        );
+    }
+
+    // --- Scripted-output passthrough (issue #338) ---
+
+    #[test]
+    fn it_passes_through_git_show_with_format_flag() {
+        // The exact case from the bug report: git show -s --format=%ct HEAD
+        assert_eq!(
+            classify(&["git", "show", "-s", "--format=%ct", "HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_bare_format_flag() {
+        // git show --format <value> HEAD  (space-separated form)
+        assert_eq!(
+            classify(&["git", "show", "--format", "%ct", "HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_pretty_equals_flag() {
+        // git show --pretty=format:%H HEAD
+        assert_eq!(
+            classify(&["git", "show", "--pretty=format:%H", "HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_bare_pretty_flag() {
+        // git show --pretty HEAD  (bare --pretty with separate value)
+        assert_eq!(
+            classify(&["git", "show", "--pretty", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_porcelain_flag() {
+        // git show --porcelain HEAD
+        assert_eq!(
+            classify(&["git", "show", "--porcelain", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_stat_flag() {
+        // git show --stat HEAD  (diffstat text output)
         assert_eq!(
             classify(&["git", "show", "--stat", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_z_flag() {
+        // git show -z HEAD  (NUL-separated output)
+        assert_eq!(
+            classify(&["git", "show", "-z", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_log_with_format_flag() {
+        // git log --format=%ct main..HEAD  (scripted log output)
+        assert_eq!(
+            classify(&["git", "log", "--format=%ct", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_log_with_pretty_flag() {
+        // git log --pretty=oneline main..HEAD
+        assert_eq!(
+            classify(&["git", "log", "--pretty=oneline", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_diff_with_stat_flag() {
+        // git diff --stat main..HEAD
+        assert_eq!(
+            classify(&["git", "diff", "--stat", "main..HEAD"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_passes_through_git_show_with_no_patch_flag() {
+        // --no-patch is a synonym for -s; caller is requesting suppressed output
+        assert_eq!(
+            classify(&["git", "show", "--no-patch", "abc1234"]),
+            Classification::Passthrough
+        );
+    }
+
+    #[test]
+    fn it_still_classifies_plain_git_show_sha_as_snapshot() {
+        // Regression: plain git show without scripted-output flags must still be intercepted
+        assert_eq!(
+            classify(&["git", "show", "abc1234"]),
             Classification::ShowSnapshot { sha: "abc1234" }
+        );
+    }
+
+    #[test]
+    fn it_still_classifies_git_log_range_without_format_as_history() {
+        // Regression: git log with a range but no scripted-output flags must still be intercepted
+        assert_eq!(
+            classify(&["git", "log", "main..HEAD"]),
+            Classification::History {
+                range: "main..HEAD"
+            }
         );
     }
 

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -138,15 +138,18 @@ fn handle_show_snapshot<W: Write>(sha: &str, repo_path: &Path, out: &mut W) -> a
             .collect()
     } else {
         // Normal commit: diff against first parent via the manifest pipeline.
+        // Use the resolved commit SHA (not the raw `sha` input) so that
+        // annotated tags — where `sha` is e.g. "v1.0" and "v1.0^" is not a
+        // resolvable ref — still produce a valid parent ref.
         let manifest_options = ManifestOptions {
             include_patterns: vec![],
             exclude_patterns: vec![],
             include_function_analysis: false,
             max_response_tokens: None,
         };
-        let base_ref = format!("{sha}^");
+        let base_ref = format!("{}^", commit.sha);
         let manifest =
-            collect_all_manifest_pages(repo_path, &base_ref, sha, &manifest_options, 500)?;
+            collect_all_manifest_pages(repo_path, &base_ref, &commit.sha, &manifest_options, 500)?;
         manifest
             .files
             .into_iter()

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -12,6 +12,7 @@ use crate::git::reader::RepoReader;
 use crate::git::refs::RefRange;
 use crate::git::refs::parse_range;
 use crate::shim::classify::Classification;
+use crate::tools::size::estimate_response_tokens;
 use crate::tools::types::{
     CommitSignature, ShowCommitDetail, ShowDiffstat, ShowFileEntry, ShowManifestResponse,
 };
@@ -169,12 +170,13 @@ fn handle_show_snapshot<W: Write>(sha: &str, repo_path: &Path, out: &mut W) -> a
         deletions,
     };
 
-    let result = ShowManifestResponse {
+    let mut result = ShowManifestResponse {
         commit,
         diffstat,
         files,
         token_estimate: 0,
     };
+    result.token_estimate = estimate_response_tokens(&result);
     serde_json::to_writer_pretty(out, &result)?;
     Ok(())
 }
@@ -215,8 +217,8 @@ fn build_show_commit_detail(repo_path: &Path, sha: &str) -> anyhow::Result<ShowC
         .committer()
         .map_err(|e| anyhow::anyhow!("failed to read committer: {e}"))?;
 
-    let author = signature_to_commit_signature(&author_sig);
-    let committer = signature_to_commit_signature(&committer_sig);
+    let author = signature_to_commit_signature(&author_sig)?;
+    let committer = signature_to_commit_signature(&committer_sig)?;
 
     let raw_message = commit
         .message_raw()
@@ -241,23 +243,29 @@ fn build_show_commit_detail(repo_path: &Path, sha: &str) -> anyhow::Result<ShowC
 /// `SignatureRef.time` is a raw `&str` like `"1780329644 +0000"`.
 /// We call `sig.time()` (the decode method) to get `gix_date::Time` with
 /// typed `seconds: i64` and `offset: i32` fields.
-fn signature_to_commit_signature(sig: &gix::actor::SignatureRef<'_>) -> CommitSignature {
-    // sig.time() decodes the raw time string; fall back to epoch 0 on parse failure.
-    let gix_time = sig.time().unwrap_or_default();
+///
+/// Returns an error instead of silently substituting epoch 0 so callers
+/// see a real failure instead of corrupted `%ct`-equivalent data.
+fn signature_to_commit_signature(
+    sig: &gix::actor::SignatureRef<'_>,
+) -> anyhow::Result<CommitSignature> {
+    let gix_time = sig
+        .time()
+        .map_err(|e| anyhow::anyhow!("failed to parse commit time for {}: {e}", sig.email))?;
     let epoch = gix_time.seconds;
     let offset_seconds = gix_time.offset;
     let naive = chrono::DateTime::from_timestamp(epoch, 0)
-        .unwrap_or_default()
+        .ok_or_else(|| anyhow::anyhow!("commit timestamp {epoch} out of representable range"))?
         .naive_utc();
     let offset = chrono::FixedOffset::east_opt(offset_seconds)
-        .unwrap_or(chrono::FixedOffset::east_opt(0).unwrap());
+        .ok_or_else(|| anyhow::anyhow!("commit tz offset {offset_seconds}s out of range"))?;
     let dt = chrono::DateTime::<chrono::FixedOffset>::from_naive_utc_and_offset(naive, offset);
-    CommitSignature {
+    Ok(CommitSignature {
         name: sig.name.to_string(),
         email: sig.email.to_string(),
         date_iso: dt.to_rfc3339(),
         date_epoch: epoch,
-    }
+    })
 }
 
 /// Split a raw commit message into (subject, body).
@@ -483,45 +491,38 @@ mod tests {
         assert_eq!(code, ExitCode::SUCCESS);
 
         let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
-        // Enriched show response must include a top-level "commit" object.
         let commit = json
             .get("commit")
             .expect("expected 'commit' key in show output");
-        assert!(
-            commit.get("sha").and_then(|v| v.as_str()).is_some(),
-            "commit.sha must be present, got: {json}"
+        // Exact-value assertions (F7: strengthen weak shape checks).
+        assert_eq!(
+            commit["author"]["name"].as_str().unwrap(),
+            "Test",
+            "commit.author.name must be 'Test'"
         );
-        assert!(
-            commit.get("short_sha").and_then(|v| v.as_str()).is_some(),
-            "commit.short_sha must be present"
+        assert_eq!(
+            commit["author"]["email"].as_str().unwrap(),
+            "test@test.com",
+            "commit.author.email must be 'test@test.com'"
         );
-        assert!(
-            commit.get("subject").and_then(|v| v.as_str()).is_some(),
-            "commit.subject must be present"
-        );
-        let author = commit.get("author").expect("commit.author must be present");
-        assert!(
-            author.get("name").and_then(|v| v.as_str()).is_some(),
-            "commit.author.name must be present"
-        );
-        assert!(
-            author.get("email").and_then(|v| v.as_str()).is_some(),
-            "commit.author.email must be present"
-        );
-        assert!(
-            author.get("date_epoch").and_then(|v| v.as_i64()).is_some(),
-            "commit.author.date_epoch must be an integer"
-        );
-        // Diffstat must be present.
+        // The fixture adds world.txt in the second commit (1 file, 1 insertion).
         let diffstat = json
             .get("diffstat")
             .expect("expected 'diffstat' key in show output");
-        assert!(
-            diffstat
-                .get("files_changed")
-                .and_then(|v| v.as_u64())
-                .is_some(),
-            "diffstat.files_changed must be present"
+        assert_eq!(
+            diffstat["files_changed"].as_u64().unwrap(),
+            1,
+            "diffstat.files_changed must be 1"
+        );
+        assert_eq!(
+            diffstat["insertions"].as_u64().unwrap(),
+            1,
+            "diffstat.insertions must be 1"
+        );
+        assert_eq!(
+            diffstat["deletions"].as_u64().unwrap(),
+            0,
+            "diffstat.deletions must be 0"
         );
     }
 
@@ -602,14 +603,19 @@ mod tests {
         handle(&classification, &path, &mut out);
         let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
         let committer = &json["commit"]["committer"];
-        assert!(committer.get("name").and_then(|v| v.as_str()).is_some());
-        assert!(committer.get("email").and_then(|v| v.as_str()).is_some());
-        assert!(committer.get("date_iso").and_then(|v| v.as_str()).is_some());
+        // Exact-value assertions — the fixture sets user.name=Test, user.email=test@test.com.
+        assert_eq!(committer["name"].as_str().unwrap(), "Test");
+        assert_eq!(committer["email"].as_str().unwrap(), "test@test.com");
+        // date_iso must be parseable as RFC-3339.
+        let date_iso = committer["date_iso"]
+            .as_str()
+            .expect("date_iso must be a string");
+        chrono::DateTime::parse_from_rfc3339(date_iso)
+            .unwrap_or_else(|e| panic!("date_iso '{date_iso}' must parse as RFC-3339: {e}"));
+        // date_epoch must be a positive unix timestamp.
         assert!(
-            committer
-                .get("date_epoch")
-                .and_then(|v| v.as_i64())
-                .is_some()
+            committer["date_epoch"].as_i64().unwrap() > 0,
+            "date_epoch must be a positive unix timestamp"
         );
     }
 
@@ -642,6 +648,111 @@ mod tests {
         assert!(
             json.get("files").and_then(|f| f.as_array()).is_some(),
             "expected 'files' array in blame output, got: {json}"
+        );
+    }
+
+    // --- Item 5: split_commit_message unit tests ---
+
+    #[test]
+    fn split_commit_message_single_line_has_no_body() {
+        let (subject, body) = split_commit_message("fix: correct the thing");
+        assert_eq!(subject, "fix: correct the thing");
+        assert!(body.is_none());
+    }
+
+    #[test]
+    fn split_commit_message_subject_and_single_paragraph_body() {
+        let (subject, body) = split_commit_message("feat: add widget\n\nThis adds the widget.");
+        assert_eq!(subject, "feat: add widget");
+        assert_eq!(body.as_deref(), Some("This adds the widget."));
+    }
+
+    #[test]
+    fn split_commit_message_multi_paragraph_body_preserves_internal_blank_line() {
+        let msg = "feat: multi\n\nParagraph one.\n\nParagraph two.";
+        let (subject, body) = split_commit_message(msg);
+        assert_eq!(subject, "feat: multi");
+        let b = body.expect("body must be Some");
+        assert!(b.contains("Paragraph one."), "body must contain first para");
+        assert!(
+            b.contains("Paragraph two."),
+            "body must contain second para"
+        );
+    }
+
+    #[test]
+    fn split_commit_message_trailing_blank_lines_only_gives_no_body() {
+        let (subject, body) = split_commit_message("fix: thing\n\n  \n  ");
+        assert_eq!(subject, "fix: thing");
+        assert!(body.is_none(), "trailing blanks only must yield None body");
+    }
+
+    #[test]
+    fn split_commit_message_empty_string_gives_empty_subject_no_body() {
+        let (subject, body) = split_commit_message("");
+        assert_eq!(subject, "");
+        assert!(body.is_none());
+    }
+
+    #[test]
+    fn split_commit_message_trims_subject_whitespace() {
+        let (subject, _) = split_commit_message("  padded subject  \n\nbody");
+        assert_eq!(subject, "padded subject");
+    }
+
+    // --- Item 6: e2e show with multi-paragraph body ---
+
+    #[test]
+    fn it_handles_show_snapshot_multi_paragraph_body_is_present_and_not_in_subject() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_path_buf();
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&path)
+                .output()
+                .unwrap()
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@test.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(path.join("a.txt"), "a\n").unwrap();
+        run(&["add", "a.txt"]);
+        // Commit with subject + two body paragraphs via multiple -m flags.
+        run(&[
+            "commit",
+            "-m",
+            "feat: the subject",
+            "-m",
+            "First paragraph of body.",
+            "-m",
+            "Second paragraph of body.",
+        ]);
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        let code = handle(&classification, &path, &mut out);
+        assert_eq!(code, ExitCode::SUCCESS);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(
+            json["commit"]["subject"].as_str().unwrap(),
+            "feat: the subject",
+            "subject must not contain body paragraphs"
+        );
+        let body = json["commit"]["body"]
+            .as_str()
+            .expect("body must be non-null for multi-paragraph commit");
+        assert!(
+            body.contains("First paragraph"),
+            "body must contain first paragraph"
+        );
+        assert!(
+            body.contains("Second paragraph"),
+            "body must contain second paragraph"
+        );
+        assert!(
+            !body.contains("feat: the subject"),
+            "subject must not leak into body"
         );
     }
 

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -9,14 +9,14 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use crate::git::reader::RepoReader;
-use crate::git::refs::parse_range;
 use crate::git::refs::RefRange;
+use crate::git::refs::parse_range;
 use crate::shim::classify::Classification;
 use crate::tools::types::{CommitSignature, ShowCommitDetail, ShowDiffstat, ShowManifestResponse};
 use crate::tools::{
-    build_function_context_with_options, build_snapshots, collect_all_history_pages,
-    collect_all_manifest_pages, collect_all_worktree_manifest_pages, ContextOptions,
-    ManifestOptions, SnapshotOptions,
+    ContextOptions, ManifestOptions, SnapshotOptions, build_function_context_with_options,
+    build_snapshots, collect_all_history_pages, collect_all_manifest_pages,
+    collect_all_worktree_manifest_pages,
 };
 
 /// Dispatch a classified git command to the appropriate tool function and
@@ -590,10 +590,12 @@ mod tests {
         assert!(committer.get("name").and_then(|v| v.as_str()).is_some());
         assert!(committer.get("email").and_then(|v| v.as_str()).is_some());
         assert!(committer.get("date_iso").and_then(|v| v.as_str()).is_some());
-        assert!(committer
-            .get("date_epoch")
-            .and_then(|v| v.as_i64())
-            .is_some());
+        assert!(
+            committer
+                .get("date_epoch")
+                .and_then(|v| v.as_i64())
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -12,7 +12,9 @@ use crate::git::reader::RepoReader;
 use crate::git::refs::RefRange;
 use crate::git::refs::parse_range;
 use crate::shim::classify::Classification;
-use crate::tools::types::{CommitSignature, ShowCommitDetail, ShowDiffstat, ShowManifestResponse};
+use crate::tools::types::{
+    CommitSignature, ShowCommitDetail, ShowDiffstat, ShowFileEntry, ShowManifestResponse,
+};
 use crate::tools::{
     ContextOptions, ManifestOptions, SnapshotOptions, build_function_context_with_options,
     build_snapshots, collect_all_history_pages, collect_all_manifest_pages,
@@ -119,50 +121,50 @@ fn handle_function_context<W: Write>(
 }
 
 fn handle_show_snapshot<W: Write>(sha: &str, repo_path: &Path, out: &mut W) -> anyhow::Result<()> {
-    // `git show <sha>` maps to get_file_snapshots with range `<sha>^..<sha>`.
-    let base = format!("{sha}^");
-    let range_str = format!("{base}..{sha}");
-    let (base_ref, head_ref) = match parse_range(&range_str) {
-        RefRange::CommitRange { base, head } => (base.to_string(), head.to_string()),
-        RefRange::WorktreeCompare { .. } => unreachable!("range_str always has .."),
-    };
-    let options = SnapshotOptions {
-        include_before: true,
-        include_after: true,
-        max_file_size_bytes: 100_000,
-        line_range: None,
-        include_diff_hunks: false,
-    };
-    let snapshot = build_snapshots(repo_path, &base_ref, &head_ref, &[], &options)?;
     let commit = build_show_commit_detail(repo_path, sha)?;
 
-    let files_changed = snapshot.files.len();
-    let insertions = snapshot
-        .files
-        .iter()
-        .map(|f| f.after.as_ref().map_or(0, |c| c.line_count))
-        .sum::<usize>()
-        .saturating_sub(
-            snapshot
-                .files
-                .iter()
-                .map(|f| f.before.as_ref().map_or(0, |c| c.line_count))
-                .sum::<usize>(),
-        );
-    let deletions = snapshot
-        .files
-        .iter()
-        .map(|f| f.before.as_ref().map_or(0, |c| c.line_count))
-        .sum::<usize>()
-        .saturating_sub(
-            snapshot
-                .files
-                .iter()
-                .map(|f| f.after.as_ref().map_or(0, |c| c.line_count))
-                .sum::<usize>(),
-        );
+    let files: Vec<ShowFileEntry> = if commit.parents.is_empty() {
+        // Root commit: no parent, so `<sha>^` doesn't resolve.  Walk the
+        // commit tree directly and report every blob as Added.
+        let reader =
+            RepoReader::open(repo_path).map_err(|e| anyhow::anyhow!("failed to open repo: {e}"))?;
+        let diff = reader
+            .diff_root_commit(sha)
+            .map_err(|e| anyhow::anyhow!("failed to diff root commit: {e}"))?;
+        diff.files
+            .into_iter()
+            .map(file_change_to_show_entry)
+            .collect()
+    } else {
+        // Normal commit: diff against first parent via the manifest pipeline.
+        let manifest_options = ManifestOptions {
+            include_patterns: vec![],
+            exclude_patterns: vec![],
+            include_function_analysis: false,
+            max_response_tokens: None,
+        };
+        let base_ref = format!("{sha}^");
+        let manifest =
+            collect_all_manifest_pages(repo_path, &base_ref, sha, &manifest_options, 500)?;
+        manifest
+            .files
+            .into_iter()
+            .map(|f| ShowFileEntry {
+                path: f.path,
+                old_path: f.old_path,
+                change_type: f.change_type,
+                additions: f.lines_added,
+                deletions: f.lines_removed,
+                is_binary: f.is_binary,
+            })
+            .collect()
+    };
+
+    // Derive diffstat directly from per-file counts — no net-delta arithmetic.
+    let insertions: usize = files.iter().map(|f| f.additions).sum();
+    let deletions: usize = files.iter().map(|f| f.deletions).sum();
     let diffstat = ShowDiffstat {
-        files_changed,
+        files_changed: files.len(),
         insertions,
         deletions,
     };
@@ -170,11 +172,24 @@ fn handle_show_snapshot<W: Write>(sha: &str, repo_path: &Path, out: &mut W) -> a
     let result = ShowManifestResponse {
         commit,
         diffstat,
-        files: snapshot.files,
-        token_estimate: snapshot.token_estimate,
+        files,
+        token_estimate: 0,
     };
     serde_json::to_writer_pretty(out, &result)?;
     Ok(())
+}
+
+/// Map a raw `FileChange` (from `diff_root_commit`) to the show-specific
+/// `ShowFileEntry` shape.
+fn file_change_to_show_entry(f: crate::git::diff::FileChange) -> ShowFileEntry {
+    ShowFileEntry {
+        path: f.path,
+        old_path: f.old_path,
+        change_type: f.change_type,
+        additions: f.lines_added,
+        deletions: f.lines_removed,
+        is_binary: f.is_binary,
+    }
 }
 
 /// Extract structured commit metadata for `sha` using gix (no shell out).

--- a/src/shim/handlers.rs
+++ b/src/shim/handlers.rs
@@ -8,13 +8,15 @@ use std::io::Write;
 use std::path::Path;
 use std::process::ExitCode;
 
-use crate::git::refs::RefRange;
+use crate::git::reader::RepoReader;
 use crate::git::refs::parse_range;
+use crate::git::refs::RefRange;
 use crate::shim::classify::Classification;
+use crate::tools::types::{CommitSignature, ShowCommitDetail, ShowDiffstat, ShowManifestResponse};
 use crate::tools::{
-    ContextOptions, ManifestOptions, SnapshotOptions, build_function_context_with_options,
-    build_snapshots, collect_all_history_pages, collect_all_manifest_pages,
-    collect_all_worktree_manifest_pages,
+    build_function_context_with_options, build_snapshots, collect_all_history_pages,
+    collect_all_manifest_pages, collect_all_worktree_manifest_pages, ContextOptions,
+    ManifestOptions, SnapshotOptions,
 };
 
 /// Dispatch a classified git command to the appropriate tool function and
@@ -131,9 +133,134 @@ fn handle_show_snapshot<W: Write>(sha: &str, repo_path: &Path, out: &mut W) -> a
         line_range: None,
         include_diff_hunks: false,
     };
-    let result = build_snapshots(repo_path, &base_ref, &head_ref, &[], &options)?;
+    let snapshot = build_snapshots(repo_path, &base_ref, &head_ref, &[], &options)?;
+    let commit = build_show_commit_detail(repo_path, sha)?;
+
+    let files_changed = snapshot.files.len();
+    let insertions = snapshot
+        .files
+        .iter()
+        .map(|f| f.after.as_ref().map_or(0, |c| c.line_count))
+        .sum::<usize>()
+        .saturating_sub(
+            snapshot
+                .files
+                .iter()
+                .map(|f| f.before.as_ref().map_or(0, |c| c.line_count))
+                .sum::<usize>(),
+        );
+    let deletions = snapshot
+        .files
+        .iter()
+        .map(|f| f.before.as_ref().map_or(0, |c| c.line_count))
+        .sum::<usize>()
+        .saturating_sub(
+            snapshot
+                .files
+                .iter()
+                .map(|f| f.after.as_ref().map_or(0, |c| c.line_count))
+                .sum::<usize>(),
+        );
+    let diffstat = ShowDiffstat {
+        files_changed,
+        insertions,
+        deletions,
+    };
+
+    let result = ShowManifestResponse {
+        commit,
+        diffstat,
+        files: snapshot.files,
+        token_estimate: snapshot.token_estimate,
+    };
     serde_json::to_writer_pretty(out, &result)?;
     Ok(())
+}
+
+/// Extract structured commit metadata for `sha` using gix (no shell out).
+fn build_show_commit_detail(repo_path: &Path, sha: &str) -> anyhow::Result<ShowCommitDetail> {
+    let reader =
+        RepoReader::open(repo_path).map_err(|e| anyhow::anyhow!("failed to open repo: {e}"))?;
+    let commit = reader
+        .peel_to_commit(sha)
+        .map_err(|e| anyhow::anyhow!("failed to resolve commit {sha}: {e}"))?;
+
+    let full_sha = commit.id().to_string();
+    let short_sha = full_sha.chars().take(8).collect::<String>();
+
+    let parents = commit
+        .parent_ids()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>();
+
+    let author_sig = commit
+        .author()
+        .map_err(|e| anyhow::anyhow!("failed to read author: {e}"))?;
+    let committer_sig = commit
+        .committer()
+        .map_err(|e| anyhow::anyhow!("failed to read committer: {e}"))?;
+
+    let author = signature_to_commit_signature(&author_sig);
+    let committer = signature_to_commit_signature(&committer_sig);
+
+    let raw_message = commit
+        .message_raw()
+        .map_err(|e| anyhow::anyhow!("failed to read message: {e}"))?;
+    let message = std::str::from_utf8(raw_message.as_ref())
+        .map_err(|e| anyhow::anyhow!("commit message not UTF-8: {e}"))?;
+    let (subject, body) = split_commit_message(message);
+
+    Ok(ShowCommitDetail {
+        sha: full_sha,
+        short_sha,
+        parents,
+        author,
+        committer,
+        subject,
+        body,
+    })
+}
+
+/// Convert a gix `SignatureRef` into our serialisable `CommitSignature`.
+///
+/// `SignatureRef.time` is a raw `&str` like `"1780329644 +0000"`.
+/// We call `sig.time()` (the decode method) to get `gix_date::Time` with
+/// typed `seconds: i64` and `offset: i32` fields.
+fn signature_to_commit_signature(sig: &gix::actor::SignatureRef<'_>) -> CommitSignature {
+    // sig.time() decodes the raw time string; fall back to epoch 0 on parse failure.
+    let gix_time = sig.time().unwrap_or_default();
+    let epoch = gix_time.seconds;
+    let offset_seconds = gix_time.offset;
+    let naive = chrono::DateTime::from_timestamp(epoch, 0)
+        .unwrap_or_default()
+        .naive_utc();
+    let offset = chrono::FixedOffset::east_opt(offset_seconds)
+        .unwrap_or(chrono::FixedOffset::east_opt(0).unwrap());
+    let dt = chrono::DateTime::<chrono::FixedOffset>::from_naive_utc_and_offset(naive, offset);
+    CommitSignature {
+        name: sig.name.to_string(),
+        email: sig.email.to_string(),
+        date_iso: dt.to_rfc3339(),
+        date_epoch: epoch,
+    }
+}
+
+/// Split a raw commit message into (subject, body).
+///
+/// The subject is the first non-empty line. The body is everything after the
+/// first blank line following the subject, trimmed. Returns `None` for body
+/// when the message has no body paragraph.
+fn split_commit_message(message: &str) -> (String, Option<String>) {
+    let mut lines = message.lines();
+    let subject = lines.next().unwrap_or("").trim().to_string();
+    // Skip blank lines separating subject from body
+    let body_lines: Vec<&str> = lines.skip_while(|l| l.trim().is_empty()).collect();
+    let body = if body_lines.is_empty() {
+        None
+    } else {
+        Some(body_lines.join("\n").trim().to_string())
+    };
+    (subject, body)
 }
 
 /// Handle `gh pr diff <N>` by resolving the PR's base..head ref range via the
@@ -328,6 +455,160 @@ mod tests {
         assert!(
             json.get("files").and_then(|f| f.as_array()).is_some(),
             "expected 'files' array in show output, got: {json}"
+        );
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_and_returns_commit_metadata() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        let code = handle(&classification, &path, &mut out);
+        assert_eq!(code, ExitCode::SUCCESS);
+
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        // Enriched show response must include a top-level "commit" object.
+        let commit = json
+            .get("commit")
+            .expect("expected 'commit' key in show output");
+        assert!(
+            commit.get("sha").and_then(|v| v.as_str()).is_some(),
+            "commit.sha must be present, got: {json}"
+        );
+        assert!(
+            commit.get("short_sha").and_then(|v| v.as_str()).is_some(),
+            "commit.short_sha must be present"
+        );
+        assert!(
+            commit.get("subject").and_then(|v| v.as_str()).is_some(),
+            "commit.subject must be present"
+        );
+        let author = commit.get("author").expect("commit.author must be present");
+        assert!(
+            author.get("name").and_then(|v| v.as_str()).is_some(),
+            "commit.author.name must be present"
+        );
+        assert!(
+            author.get("email").and_then(|v| v.as_str()).is_some(),
+            "commit.author.email must be present"
+        );
+        assert!(
+            author.get("date_epoch").and_then(|v| v.as_i64()).is_some(),
+            "commit.author.date_epoch must be an integer"
+        );
+        // Diffstat must be present.
+        let diffstat = json
+            .get("diffstat")
+            .expect("expected 'diffstat' key in show output");
+        assert!(
+            diffstat
+                .get("files_changed")
+                .and_then(|v| v.as_u64())
+                .is_some(),
+            "diffstat.files_changed must be present"
+        );
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_commit_sha_is_full_40_chars() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let commit_sha = json["commit"]["sha"].as_str().unwrap();
+        assert_eq!(commit_sha.len(), 40, "sha must be 40 hex chars");
+        let short_sha = json["commit"]["short_sha"].as_str().unwrap();
+        assert_eq!(short_sha.len(), 8, "short_sha must be 8 hex chars");
+        assert!(
+            commit_sha.starts_with(short_sha),
+            "short_sha must be a prefix of sha"
+        );
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_subject_matches_commit_message() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        // The fixture commits "second commit" as HEAD.
+        assert_eq!(json["commit"]["subject"].as_str().unwrap(), "second commit");
+        // Single-line message — body must be absent (null).
+        assert!(
+            json["commit"]["body"].is_null(),
+            "single-line commit must have null body"
+        );
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_parents_array_has_one_entry_for_normal_commit() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let parents = json["commit"]["parents"].as_array().unwrap();
+        assert_eq!(
+            parents.len(),
+            1,
+            "non-root commit must have exactly one parent"
+        );
+        assert_eq!(
+            parents[0].as_str().unwrap().len(),
+            40,
+            "parent sha must be 40 chars"
+        );
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_author_epoch_is_positive_integer() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let epoch = json["commit"]["author"]["date_epoch"].as_i64().unwrap();
+        assert!(epoch > 0, "date_epoch must be a positive unix timestamp");
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_committer_fields_present() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let committer = &json["commit"]["committer"];
+        assert!(committer.get("name").and_then(|v| v.as_str()).is_some());
+        assert!(committer.get("email").and_then(|v| v.as_str()).is_some());
+        assert!(committer.get("date_iso").and_then(|v| v.as_str()).is_some());
+        assert!(committer
+            .get("date_epoch")
+            .and_then(|v| v.as_i64())
+            .is_some());
+    }
+
+    #[test]
+    fn it_handles_show_snapshot_diffstat_files_changed_matches_files_array() {
+        let (_dir, path) = init_repo_with_two_commits();
+        let sha = head_sha(&path);
+        let classification = Classification::ShowSnapshot { sha: &sha };
+        let mut out = Vec::new();
+        handle(&classification, &path, &mut out);
+        let json: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let files_changed = json["diffstat"]["files_changed"].as_u64().unwrap();
+        let files_count = json["files"].as_array().unwrap().len() as u64;
+        assert_eq!(
+            files_changed, files_count,
+            "diffstat.files_changed must equal files array length"
         );
     }
 

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -452,6 +452,56 @@ pub struct FunctionContextResponse {
     pub pagination: PaginationInfo,
 }
 
+// --- ShowManifest types (git show <ref> enriched response) ---
+
+/// Author or committer identity with timestamp fields.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CommitSignature {
+    pub name: String,
+    pub email: String,
+    /// ISO-8601 timestamp (e.g. `"2026-01-01T00:00:00+00:00"`).
+    pub date_iso: String,
+    /// Unix epoch seconds — the scalar that `git show -s --format=%ct` returns.
+    pub date_epoch: i64,
+}
+
+/// Per-commit metadata emitted by the enriched `git show <ref>` handler.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ShowCommitDetail {
+    pub sha: String,
+    /// First 8 hex characters of the SHA.
+    pub short_sha: String,
+    /// Parent SHAs (empty for root commits, two entries for merge commits).
+    pub parents: Vec<String>,
+    pub author: CommitSignature,
+    pub committer: CommitSignature,
+    /// First line of the commit message.
+    pub subject: String,
+    /// Remainder of the commit message after the subject line, if any.
+    /// `None` when the message has no body.
+    pub body: Option<String>,
+}
+
+/// Top-level diff statistics for the commit.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ShowDiffstat {
+    pub files_changed: usize,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+/// Enriched response for `git show <ref>`.
+///
+/// Extends the raw `SnapshotResponse` with structured commit metadata and a
+/// diffstat so JSON-aware callers no longer need to parse git text output.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ShowManifestResponse {
+    pub commit: ShowCommitDetail,
+    pub diffstat: ShowDiffstat,
+    pub files: Vec<SnapshotFileEntry>,
+    pub token_estimate: usize,
+}
+
 // --- Tool options (for internal use) ---
 
 #[derive(Debug, Clone)]
@@ -988,11 +1038,9 @@ mod tests {
         assert_eq!(json["metadata"]["token_estimate"], 42);
         assert!(json["metadata"]["next_cursor"].is_null());
         // function_analysis_truncated skipped when empty
-        assert!(
-            json["metadata"]
-                .get("function_analysis_truncated")
-                .is_none()
-        );
+        assert!(json["metadata"]
+            .get("function_analysis_truncated")
+            .is_none());
         assert_eq!(json["functions"].as_array().unwrap().len(), 0);
         assert_eq!(json["pagination"]["total_items"], 0);
         assert_eq!(json["pagination"]["page_size"], 25);

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -490,15 +490,35 @@ pub struct ShowDiffstat {
     pub deletions: usize,
 }
 
+/// Per-file entry in the enriched `git show <ref>` response.
+///
+/// Carries the change-type and line-count fields that manifest entries have,
+/// named `additions`/`deletions` as the issue specification requires.
+/// Unlike `SnapshotFileEntry` this type does NOT include raw file content —
+/// callers that want content should follow up with `get_file_snapshots`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ShowFileEntry {
+    pub path: String,
+    /// Original path before a rename or copy. `None` for add/modify/delete.
+    pub old_path: Option<String>,
+    /// How this file was affected: `added`, `modified`, `deleted`, `renamed`, `copied`.
+    pub change_type: crate::git::diff::ChangeType,
+    /// Lines added in this file by this commit.
+    pub additions: usize,
+    /// Lines removed in this file by this commit.
+    pub deletions: usize,
+    pub is_binary: bool,
+}
+
 /// Enriched response for `git show <ref>`.
 ///
-/// Extends the raw `SnapshotResponse` with structured commit metadata and a
-/// diffstat so JSON-aware callers no longer need to parse git text output.
+/// Combines commit metadata, a real diffstat (insertions/deletions from the
+/// manifest, not a net-line-delta), and the list of files changed by the commit.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ShowManifestResponse {
     pub commit: ShowCommitDetail,
     pub diffstat: ShowDiffstat,
-    pub files: Vec<SnapshotFileEntry>,
+    pub files: Vec<ShowFileEntry>,
     pub token_estimate: usize,
 }
 

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -1126,4 +1126,88 @@ mod tests {
         );
         assert_eq!(json["function_analysis_truncated"][0], "some_fn");
     }
+
+    // --- Item 8: ShowFileEntry / ShowManifestResponse contract tests (Windows-safe) ---
+
+    #[test]
+    fn show_file_entry_renamed_serializes_change_type_snake_case_and_old_path() {
+        use crate::git::diff::ChangeType;
+        let entry = ShowFileEntry {
+            path: "new.txt".into(),
+            old_path: Some("old.txt".into()),
+            change_type: ChangeType::Renamed,
+            additions: 0,
+            deletions: 0,
+            is_binary: false,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["change_type"], "renamed");
+        assert_eq!(json["path"], "new.txt");
+        assert_eq!(json["old_path"], "old.txt");
+    }
+
+    #[test]
+    fn show_file_entry_added_serializes_with_null_old_path() {
+        use crate::git::diff::ChangeType;
+        let entry = ShowFileEntry {
+            path: "new.txt".into(),
+            old_path: None,
+            change_type: ChangeType::Added,
+            additions: 3,
+            deletions: 0,
+            is_binary: false,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["change_type"], "added");
+        assert!(
+            json["old_path"].is_null(),
+            "old_path must be null for Added"
+        );
+        assert_eq!(json["additions"], 3);
+        assert_eq!(json["deletions"], 0);
+    }
+
+    #[test]
+    fn show_diffstat_serializes_three_counts() {
+        let diffstat = ShowDiffstat {
+            files_changed: 2,
+            insertions: 10,
+            deletions: 5,
+        };
+        let json = serde_json::to_value(&diffstat).unwrap();
+        assert_eq!(json["files_changed"], 2);
+        assert_eq!(json["insertions"], 10);
+        assert_eq!(json["deletions"], 5);
+    }
+
+    #[test]
+    fn show_commit_detail_serializes_null_body_when_none_and_empty_parents() {
+        let detail = ShowCommitDetail {
+            sha: "a".repeat(40),
+            short_sha: "a".repeat(8),
+            parents: vec![],
+            author: CommitSignature {
+                name: "A".into(),
+                email: "a@a.com".into(),
+                date_iso: "2026-01-01T00:00:00+00:00".into(),
+                date_epoch: 1_000_000,
+            },
+            committer: CommitSignature {
+                name: "A".into(),
+                email: "a@a.com".into(),
+                date_iso: "2026-01-01T00:00:00+00:00".into(),
+                date_epoch: 1_000_000,
+            },
+            subject: "init".into(),
+            body: None,
+        };
+        let json = serde_json::to_value(&detail).unwrap();
+        assert!(json["body"].is_null(), "body must be null when None");
+        assert_eq!(
+            json["parents"].as_array().unwrap().len(),
+            0,
+            "parents must be empty array"
+        );
+        assert_eq!(json["subject"], "init");
+    }
 }

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -1038,9 +1038,11 @@ mod tests {
         assert_eq!(json["metadata"]["token_estimate"], 42);
         assert!(json["metadata"]["next_cursor"].is_null());
         // function_analysis_truncated skipped when empty
-        assert!(json["metadata"]
-            .get("function_analysis_truncated")
-            .is_none());
+        assert!(
+            json["metadata"]
+                .get("function_analysis_truncated")
+                .is_none()
+        );
         assert_eq!(json["functions"].as_array().unwrap().len(), 0);
         assert_eq!(json["pagination"]["total_items"], 0);
         assert_eq!(json["pagination"]["page_size"], 25);

--- a/tests/shim_show_diffstat_pentest.rs
+++ b/tests/shim_show_diffstat_pentest.rs
@@ -1,0 +1,326 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #338, gate 3): the enriched `git show <ref>` diffstat
+//! must report insertions/deletions that match real `git show --stat`.
+//!
+//! These drive the built binary end-to-end via argv[0] = "git" symlink dispatch,
+//! with an isolated agent env so the shim intercepts and emits structured JSON.
+//!
+//! BUG: `handle_show_snapshot` computes the diffstat as
+//!   insertions = sum(after.line_count) - sum(before.line_count)   (saturating)
+//!   deletions  = sum(before.line_count) - sum(after.line_count)   (saturating)
+//! across ALL files. This is a *net* line delta, not insertions/deletions.
+//! For any modification (lines changed but count unchanged) it reports 0/0,
+//! and across multiple files the cross-file sum cancels real edits.
+
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Run `git show <sha>` through the shim against `repo`, return parsed JSON.
+fn run_show(repo: &std::path::Path, sha: &str) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let git_link = shim_dir.join("git");
+    symlink(bin, &git_link).unwrap();
+
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", shim_dir.display(), real_path);
+
+    let out = Command::new(&git_link)
+        // AI_AGENT marker → detect_calling_agent returns Some → shim intercepts.
+        .env("AI_AGENT", "1")
+        // Point the shim at the fixture repo so it doesn't use the test cwd.
+        .env("GIT_PRISM_REPO", repo)
+        // Make sure no loop-break / CI override is set.
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["show", sha])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "expected structured JSON from intercepted `git show`, parse error: {e}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    })
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+}
+
+fn head_sha(repo: &std::path::Path) -> String {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+fn init_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-b", "main"]);
+    git(&path, &["config", "user.email", "t@t.com"]);
+    git(&path, &["config", "user.name", "T"]);
+    (dir, path)
+}
+
+/// The enriched `git show <ref>` must return the files the commit changed.
+/// The handler calls `build_snapshots(.., &[], ..)` with an EMPTY paths slice,
+/// and `build_snapshots` only emits entries for the paths it is given, so the
+/// `files` array is ALWAYS empty and `diffstat.files_changed` is ALWAYS 0 —
+/// the whole snapshot/diffstat half of the feature is dead.
+#[test]
+fn show_returns_nonempty_files_for_a_commit_that_changed_files() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("only.txt"), "alpha\nbeta\n").unwrap();
+    git(&path, &["add", "only.txt"]);
+    git(&path, &["commit", "-m", "first"]);
+    std::fs::write(path.join("only.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    git(&path, &["add", "only.txt"]);
+    git(&path, &["commit", "-m", "append a line"]);
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let files = json["files"].as_array().unwrap();
+    assert!(
+        !files.is_empty(),
+        "git show enrichment must return the changed file(s), got empty files array\n{json}"
+    );
+    let files_changed = json["diffstat"]["files_changed"].as_u64().unwrap();
+    assert_eq!(
+        files_changed, 1,
+        "diffstat.files_changed must be 1 (only.txt), got {files_changed}\n{json}"
+    );
+}
+
+/// A one-line modification: 3 lines before, 3 lines after.
+/// Real `git show --stat` reports "1 insertion(+), 1 deletion(-)".
+#[test]
+fn show_diffstat_matches_real_git_for_one_line_modification() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("f.txt"), "line1\nline2\nline3\n").unwrap();
+    git(&path, &["add", "f.txt"]);
+    git(&path, &["commit", "-m", "first"]);
+    std::fs::write(path.join("f.txt"), "line1\nCHANGED\nline3\n").unwrap();
+    git(&path, &["add", "f.txt"]);
+    git(&path, &["commit", "-m", "modify one line"]);
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let insertions = json["diffstat"]["insertions"].as_u64().unwrap();
+    let deletions = json["diffstat"]["deletions"].as_u64().unwrap();
+    assert_eq!(
+        insertions, 1,
+        "diffstat.insertions must match real git `1 insertion(+)`, got {insertions}\n{json}"
+    );
+    assert_eq!(
+        deletions, 1,
+        "diffstat.deletions must match real git `1 deletion(-)`, got {deletions}\n{json}"
+    );
+}
+
+/// Root commit has no parent, so `<sha>^` doesn't exist.
+/// The handler must fall back to the empty tree and still return the files.
+#[test]
+fn show_returns_files_for_root_commit() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("first.txt"), "hello\nworld\n").unwrap();
+    git(&path, &["add", "first.txt"]);
+    git(&path, &["commit", "-m", "root commit"]);
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    // Root commit: parents array must be empty.
+    let parents = json["commit"]["parents"].as_array().unwrap();
+    assert!(
+        parents.is_empty(),
+        "root commit must have 0 parents, got: {json}"
+    );
+
+    // Files must be non-empty — first.txt was added.
+    let files = json["files"].as_array().unwrap();
+    assert!(
+        !files.is_empty(),
+        "root commit must list added files, got: {json}"
+    );
+    assert_eq!(
+        json["diffstat"]["files_changed"].as_u64().unwrap(),
+        1,
+        "diffstat.files_changed must be 1 for root commit, got: {json}"
+    );
+    assert!(
+        json["diffstat"]["insertions"].as_u64().unwrap() > 0,
+        "root commit insertions must be > 0, got: {json}"
+    );
+}
+
+/// Per-file fields: change_type, additions, deletions, is_binary.
+/// Commit modifies one file, adds one file, deletes one file.
+#[test]
+fn show_files_carry_per_file_change_type_and_line_counts() {
+    let (_dir, path) = init_repo();
+
+    // Base: two files.
+    std::fs::write(path.join("keep.txt"), "a\nb\nc\n").unwrap();
+    std::fs::write(path.join("drop.txt"), "x\ny\n").unwrap();
+    git(&path, &["add", "keep.txt", "drop.txt"]);
+    git(&path, &["commit", "-m", "base"]);
+
+    // HEAD: modify keep.txt (1 line changed), add new.txt (2 lines), delete drop.txt.
+    std::fs::write(path.join("keep.txt"), "a\nCHANGED\nc\n").unwrap();
+    std::fs::write(path.join("new.txt"), "p\nq\n").unwrap();
+    std::fs::remove_file(path.join("drop.txt")).unwrap();
+    git(&path, &["add", "keep.txt", "new.txt"]);
+    git(&path, &["rm", "drop.txt"]);
+    git(
+        &path,
+        &["commit", "-m", "modify keep, add new, delete drop"],
+    );
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let files = json["files"].as_array().unwrap();
+    assert_eq!(files.len(), 3, "expected 3 file entries, got: {json}");
+
+    // Find each file entry by path.
+    let find = |name: &str| {
+        files
+            .iter()
+            .find(|f| f["path"].as_str() == Some(name))
+            .unwrap_or_else(|| panic!("missing file entry for {name} in: {json}"))
+    };
+
+    let keep = find("keep.txt");
+    assert_eq!(keep["change_type"].as_str().unwrap(), "modified");
+    assert_eq!(
+        keep["additions"].as_u64().unwrap(),
+        1,
+        "keep.txt: 1 line added"
+    );
+    assert_eq!(
+        keep["deletions"].as_u64().unwrap(),
+        1,
+        "keep.txt: 1 line removed"
+    );
+    assert_eq!(keep["is_binary"].as_bool().unwrap(), false);
+
+    let new_f = find("new.txt");
+    assert_eq!(new_f["change_type"].as_str().unwrap(), "added");
+    assert_eq!(
+        new_f["additions"].as_u64().unwrap(),
+        2,
+        "new.txt: 2 lines added"
+    );
+    assert_eq!(
+        new_f["deletions"].as_u64().unwrap(),
+        0,
+        "new.txt: 0 deletions"
+    );
+
+    let drop = find("drop.txt");
+    assert_eq!(drop["change_type"].as_str().unwrap(), "deleted");
+    assert_eq!(
+        drop["additions"].as_u64().unwrap(),
+        0,
+        "drop.txt: 0 additions"
+    );
+    assert_eq!(
+        drop["deletions"].as_u64().unwrap(),
+        2,
+        "drop.txt: 2 lines deleted"
+    );
+}
+
+/// Merge commit has two parents. The handler must not crash and must still
+/// return both commit metadata (parents.len() == 2) and the files array.
+#[test]
+fn show_merge_commit_has_two_parents() {
+    let (_dir, path) = init_repo();
+
+    // Base commit on main.
+    std::fs::write(path.join("base.txt"), "base\n").unwrap();
+    git(&path, &["add", "base.txt"]);
+    git(&path, &["commit", "-m", "base"]);
+
+    // Feature branch adds feature.txt.
+    git(&path, &["checkout", "-b", "feature"]);
+    std::fs::write(path.join("feature.txt"), "feature\n").unwrap();
+    git(&path, &["add", "feature.txt"]);
+    git(&path, &["commit", "-m", "add feature"]);
+
+    // Back to main, merge feature (creates merge commit).
+    git(&path, &["checkout", "main"]);
+    git(
+        &path,
+        &["merge", "--no-ff", "feature", "-m", "merge feature"],
+    );
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let parents = json["commit"]["parents"].as_array().unwrap();
+    assert_eq!(
+        parents.len(),
+        2,
+        "merge commit must have 2 parents, got: {json}"
+    );
+
+    // files array must be present (even if empty for a clean merge).
+    assert!(
+        json["files"].as_array().is_some(),
+        "files key must be present for merge commit, got: {json}"
+    );
+    assert!(
+        json["diffstat"]["files_changed"].as_u64().is_some(),
+        "diffstat.files_changed must be present for merge commit, got: {json}"
+    );
+}
+
+/// A multi-file commit: file A modified (+5/-5, count unchanged) plus file B
+/// added (+3). Real `git show --stat` reports "8 insertions(+), 5 deletions(-)".
+/// The handler's cross-file net sum cancels A's edits entirely.
+#[test]
+fn show_diffstat_matches_real_git_for_mixed_multi_file_commit() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("a.txt"), "1\n2\n3\n4\n5\n").unwrap();
+    git(&path, &["add", "a.txt"]);
+    git(&path, &["commit", "-m", "base"]);
+
+    // Modify all 5 lines of a.txt (same line count) and add b.txt with 3 lines.
+    std::fs::write(path.join("a.txt"), "A\nB\nC\nD\nE\n").unwrap();
+    std::fs::write(path.join("b.txt"), "x\ny\nz\n").unwrap();
+    git(&path, &["add", "a.txt", "b.txt"]);
+    git(&path, &["commit", "-m", "modify a, add b"]);
+
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let insertions = json["diffstat"]["insertions"].as_u64().unwrap();
+    let deletions = json["diffstat"]["deletions"].as_u64().unwrap();
+    assert_eq!(
+        insertions, 8,
+        "diffstat.insertions must be 8 (5 modified in a.txt + 3 added in b.txt), got {insertions}\n{json}"
+    );
+    assert_eq!(
+        deletions, 5,
+        "diffstat.deletions must be 5 (5 lines replaced in a.txt), got {deletions}\n{json}"
+    );
+}

--- a/tests/shim_show_diffstat_pentest.rs
+++ b/tests/shim_show_diffstat_pentest.rs
@@ -286,14 +286,26 @@ fn show_merge_commit_has_two_parents() {
         "merge commit must have 2 parents, got: {json}"
     );
 
-    // files array must be present (even if empty for a clean merge).
-    assert!(
-        json["files"].as_array().is_some(),
-        "files key must be present for merge commit, got: {json}"
+    // First-parent diff brings in feature.txt (1 file, 1 insertion).
+    assert_eq!(
+        json["diffstat"]["files_changed"].as_u64().unwrap(),
+        1,
+        "merge first-parent diff must show 1 file changed (feature.txt)\n{json}"
     );
+    assert_eq!(
+        json["diffstat"]["insertions"].as_u64().unwrap(),
+        1,
+        "merge first-parent diff must show 1 insertion (feature.txt: 1 line)\n{json}"
+    );
+    assert_eq!(
+        json["diffstat"]["deletions"].as_u64().unwrap(),
+        0,
+        "merge first-parent diff must show 0 deletions\n{json}"
+    );
+    let files = json["files"].as_array().unwrap();
     assert!(
-        json["diffstat"]["files_changed"].as_u64().is_some(),
-        "diffstat.files_changed must be present for merge commit, got: {json}"
+        files.iter().any(|f| f["path"] == "feature.txt"),
+        "feature.txt must appear in merge first-parent diff\n{json}"
     );
 }
 

--- a/tests/shim_show_diffstat_pentest.rs
+++ b/tests/shim_show_diffstat_pentest.rs
@@ -220,7 +220,10 @@ fn show_files_carry_per_file_change_type_and_line_counts() {
         1,
         "keep.txt: 1 line removed"
     );
-    assert_eq!(keep["is_binary"].as_bool().unwrap(), false);
+    assert!(
+        !keep["is_binary"].as_bool().unwrap(),
+        "keep.txt must not be binary"
+    );
 
     let new_f = find("new.txt");
     assert_eq!(new_f["change_type"].as_str().unwrap(), "added");

--- a/tests/shim_show_newsurface_pentest.rs
+++ b/tests/shim_show_newsurface_pentest.rs
@@ -1,0 +1,256 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #338, gate 3, run 2): attack the NEW `git show <ref>`
+//! enrichment surface — root commits, merge commits, renames, copies, binaries.
+//!
+//! Drives the built binary end-to-end via argv[0] = "git" symlink dispatch with
+//! an isolated agent env so the shim intercepts and emits structured JSON.
+
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn run_show(repo: &std::path::Path, sha: &str) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let git_link = shim_dir.join("git");
+    symlink(bin, &git_link).unwrap();
+
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", shim_dir.display(), real_path);
+
+    let out = Command::new(&git_link)
+        .env("AI_AGENT", "1")
+        .env("GIT_PRISM_REPO", repo)
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["show", sha])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "expected structured JSON, parse error: {e}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    })
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap()
+}
+
+fn head_sha(repo: &std::path::Path) -> String {
+    String::from_utf8(git(repo, &["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+fn init_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-b", "main"]);
+    git(&path, &["config", "user.email", "t@t.com"]);
+    git(&path, &["config", "user.name", "T"]);
+    (dir, path)
+}
+
+/// ROOT COMMIT: parentless, all files Added, insertions match real git.
+/// Real `git show --stat` on the root reports "5 insertions(+)" across 2 files.
+#[test]
+fn show_root_commit_reports_all_additions() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("root1.txt"), "a\nb\nc\n").unwrap();
+    std::fs::write(path.join("root2.txt"), "x\ny\n").unwrap();
+    git(&path, &["add", "root1.txt", "root2.txt"]);
+    git(&path, &["commit", "-m", "root commit"]);
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    assert_eq!(
+        json["commit"]["parents"].as_array().unwrap().len(),
+        0,
+        "root commit must have empty parents\n{json}"
+    );
+    let files = json["files"].as_array().unwrap();
+    assert_eq!(files.len(), 2, "root commit must list 2 files\n{json}");
+    for f in files {
+        assert_eq!(
+            f["change_type"], "added",
+            "every root-commit file must be `added`\n{json}"
+        );
+    }
+    assert_eq!(
+        json["diffstat"]["insertions"].as_u64().unwrap(),
+        5,
+        "root diffstat insertions must be 5\n{json}"
+    );
+    assert_eq!(
+        json["diffstat"]["deletions"].as_u64().unwrap(),
+        0,
+        "root diffstat deletions must be 0\n{json}"
+    );
+    assert_eq!(json["diffstat"]["files_changed"].as_u64().unwrap(), 2);
+}
+
+/// RENAME: `git mv a -> b` with no content change. Real `git show -M` reports a
+/// single renamed file. The enriched response must mark change_type=renamed and
+/// old_path=Some(original), NOT report a delete+add pair.
+#[test]
+fn show_rename_reports_renamed_with_old_path() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("orig.txt"), "a\nb\nc\n").unwrap();
+    git(&path, &["add", "orig.txt"]);
+    git(&path, &["commit", "-m", "add orig"]);
+    git(&path, &["mv", "orig.txt", "renamed.txt"]);
+    git(&path, &["commit", "-m", "rename orig to renamed"]);
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let files = json["files"].as_array().unwrap();
+    assert_eq!(
+        files.len(),
+        1,
+        "a pure rename must surface as ONE renamed file, not a delete+add pair\n{json}"
+    );
+    let f = &files[0];
+    assert_eq!(
+        f["change_type"], "renamed",
+        "change_type must be `renamed`\n{json}"
+    );
+    assert_eq!(
+        f["path"], "renamed.txt",
+        "path must be the new name\n{json}"
+    );
+    assert_eq!(
+        f["old_path"], "orig.txt",
+        "old_path must be the original name\n{json}"
+    );
+}
+
+/// COPY: copy a file (content preserved). NOTE: plain `git show` — even with
+/// `-C` — classifies a same-commit copy with an untouched source as a CREATE
+/// (`added`), not a copy. Git only emits "copy" with `-C --find-copies-harder`
+/// AND when the source is also modified in the same commit. So the shim's
+/// classification of a pure copy as `added` MATCHES the ground-truth oracle.
+/// This test asserts parity with real git (added), documenting that `copied`
+/// is NOT expected here — the earlier `copied` expectation was over-aggressive.
+#[test]
+fn show_pure_copy_matches_real_git_added_classification() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("src.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    git(&path, &["add", "src.txt"]);
+    git(&path, &["commit", "-m", "add src"]);
+    std::fs::write(path.join("dup.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    git(&path, &["add", "dup.txt"]);
+    git(&path, &["commit", "-m", "copy src to dup"]);
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let files = json["files"].as_array().unwrap();
+    let dup = files
+        .iter()
+        .find(|f| f["path"] == "dup.txt")
+        .unwrap_or_else(|| panic!("dup.txt must appear in files\n{json}"));
+    // Real `git show HEAD` reports: `1 file changed, 3 insertions(+)` / create dup.txt
+    assert_eq!(
+        dup["change_type"], "added",
+        "pure copy is reported by real git as `added`; shim must match\n{json}"
+    );
+    assert_eq!(
+        json["diffstat"]["insertions"].as_u64().unwrap(),
+        3,
+        "diffstat must match real git (3 insertions)\n{json}"
+    );
+}
+
+/// MERGE COMMIT: 2 parents. The shim diffs `<sha>^..<sha>` (first parent). It
+/// must not crash and must not double-count. Real first-parent diff of the
+/// fixture reports `feat.txt | 1 +`.
+#[test]
+fn show_merge_commit_first_parent_diff_no_double_count() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("base.txt"), "base\n").unwrap();
+    git(&path, &["add", "base.txt"]);
+    git(&path, &["commit", "-m", "base"]);
+    git(&path, &["checkout", "-b", "feature"]);
+    std::fs::write(path.join("feat.txt"), "feature line\n").unwrap();
+    git(&path, &["add", "feat.txt"]);
+    git(&path, &["commit", "-m", "feature commit"]);
+    git(&path, &["checkout", "main"]);
+    std::fs::write(path.join("mainf.txt"), "mainline\n").unwrap();
+    git(&path, &["add", "mainf.txt"]);
+    git(&path, &["commit", "-m", "main commit"]);
+    git(
+        &path,
+        &["merge", "--no-ff", "feature", "-m", "merge feature"],
+    );
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    assert_eq!(
+        json["commit"]["parents"].as_array().unwrap().len(),
+        2,
+        "merge commit must report 2 parents\n{json}"
+    );
+    // First-parent diff brings in feat.txt only (1 insertion).
+    assert_eq!(
+        json["diffstat"]["insertions"].as_u64().unwrap(),
+        1,
+        "merge first-parent diff insertions must be 1 (feat.txt)\n{json}"
+    );
+    let files = json["files"].as_array().unwrap();
+    assert!(
+        files.iter().any(|f| f["path"] == "feat.txt"),
+        "feat.txt must appear in merge first-parent diff\n{json}"
+    );
+}
+
+/// BINARY FILE: is_binary must be true and additions/deletions sane (0 for a
+/// freshly added binary, matching git's `Bin 0 -> N bytes` semantics).
+#[test]
+fn show_binary_file_reports_is_binary_with_sane_counts() {
+    let (_dir, path) = init_repo();
+    std::fs::write(path.join("seed.txt"), "seed\n").unwrap();
+    git(&path, &["add", "seed.txt"]);
+    git(&path, &["commit", "-m", "seed"]);
+    std::fs::write(path.join("bin.dat"), [0u8, 1, 2, 3, 0xff, 0xfe]).unwrap();
+    git(&path, &["add", "bin.dat"]);
+    git(&path, &["commit", "-m", "add binary"]);
+    let sha = head_sha(&path);
+    let json = run_show(&path, &sha);
+
+    let files = json["files"].as_array().unwrap();
+    let bin = files
+        .iter()
+        .find(|f| f["path"] == "bin.dat")
+        .unwrap_or_else(|| panic!("bin.dat must appear\n{json}"));
+    assert_eq!(bin["is_binary"], true, "bin.dat must be is_binary\n{json}");
+    assert_eq!(
+        bin["additions"].as_u64().unwrap(),
+        0,
+        "binary additions must be 0 (git reports Bin, not line counts)\n{json}"
+    );
+    assert_eq!(
+        bin["deletions"].as_u64().unwrap(),
+        0,
+        "binary deletions must be 0\n{json}"
+    );
+    // Diffstat for a binary-only addition must be 0 insertions / 0 deletions.
+    assert_eq!(
+        json["diffstat"]["insertions"].as_u64().unwrap(),
+        0,
+        "{json}"
+    );
+    assert_eq!(json["diffstat"]["deletions"].as_u64().unwrap(), 0, "{json}");
+}


### PR DESCRIPTION
## Summary

Fixes #338. Two related fixes to the PATH shim, restoring its "strict superset of git" contract and making `git show` useful to structured consumers.

### 1. Scripted-output passthrough (the bug)

The shim returned change-manifest JSON for scripted format-string invocations — e.g. `git show -s --format=%ct HEAD` returned a JSON object instead of the bare epoch, silently breaking any script that parses git output (`git log --pretty=…`, `git diff --stat`, etc.).

The classifier now passes through to real git whenever a scripted-output flag is present: `--format`/`--pretty` (with or without value), `-s`/`--no-patch`, `--porcelain`, `--stat`, `-z`. The guard applies across `show`, `log`, `diff`, **and `blame`** (`git blame --porcelain` is scripted output a script parses, the same bug class). Plain agent-facing forms (`git show <ref>`, `git diff a..b`, `git blame <path>`) still intercept.

### 2. `git show <ref>` enrichment

Bare `git show <ref>` previously returned `{files: [], token_estimate: 0}` for every commit (it passed an empty paths slice to the snapshot builder). It now returns a real manifest via the change-manifest pipeline:

- `commit`: `sha`, `short_sha`, `parents` (merge-aware), `author`/`committer` (`name`, `email`, `date_iso`, `date_epoch`), `subject`, `body`.
- `files[]`: `path`, `old_path` (renames), `change_type` (A/M/D/R/C), `additions`, `deletions`, `is_binary`.
- top-level `diffstat`: `files_changed`, `insertions`, `deletions`.
- a computed `token_estimate` (no longer hardcoded).

Parentless **root commits** are handled via a new `diff_root_commit` (empty-tree base). Commit-time extraction is **fail-loud**: a malformed commit time propagates an error rather than silently emitting a `1970` timestamp.

### Builds on #337

This depends on the annotated-tag peel fix (#337, merged). Together, `git show <annotated-tag>` resolves the tag to its commit (#337) and returns the enriched manifest (#338) — verified byte-identical to `git show <target-sha>`. The parent ref is built from the peeled `commit.sha` so caret-parent resolution works for tag inputs.

## Tests

996 tests. Classifier passthrough coverage for every scripted flag across show/log/diff/blame; `split_commit_message` unit tests; an end-to-end multi-paragraph-body test; type-serialization unit tests (guard the JSON contract on Windows, where the unix-only e2e tests are skipped); and adversarial-QA regression suites covering root/merge/rename/binary/copy commits and the annotated-tag synergy.

No MCP tool surface changed — `ShowManifestResponse` is a shim-only response shape, not a registered MCP tool.

## Verification

```
cargo fmt --check        # clean
cargo clippy --all-targets -- -D warnings   # 0 errors
cargo test               # 996 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
