### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-06-01
+
 ### Fixed
 
+- **Annotated tags now peel to their target commit during ref resolution.** `get_change_manifest`, `get_commit_history`, `get_file_snapshots`, and the shim's `git diff` / `git log` / `git show` interception previously failed on annotated-tag refs with the error `was supposed to be of kind commit, but was kind tag`. Ref resolution now peels tag objects to their target commit, so diffing or showing tagged releases (e.g. `v0.8.0..v0.9.0`) works. (#337)
 - **Shim now passes through scripted-output git invocations.** When `git show`, `git log`, or `git diff` is called with flags that request formatted text output (`--format=`, `--pretty=`, `--pretty`, `-s`, `--no-patch`, `--porcelain`, `--stat`, `-z`), the shim forwards the call to real git instead of returning a JSON manifest. This fixes `git show -s --format=%ct HEAD` silently returning a change-manifest JSON payload instead of the expected epoch integer. (#338)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "git-prism"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-prism"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Agent-optimized git data MCP server — structured change manifests and full file snapshots for LLM agents"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release cutting the two bug fixes that landed on main after v0.9.0.

## Included

- **#337** (PR #339) — annotated tags now peel to their target commit during ref resolution. Fixes `tag..tag` manifests/history/snapshots and shim `git diff`/`git log`/`git show` on annotated-tag refs (previously errored `was supposed to be of kind commit, but was kind tag`).
- **#338** (PR #340) — the shim passes through scripted-output git (`--format`/`--pretty`/`-s`/`--porcelain`/`--stat`/`-z` across show/log/diff/blame), and `git show <ref>` returns an enriched manifest (commit metadata + per-file diffstat).

## Release mechanics

- `Cargo.toml` + `Cargo.lock` bumped `0.9.0` → `0.9.1`.
- CHANGELOG `[Unreleased]` cut to `## [0.9.1] — 2026-06-01` (the #337 entry, missing from main, is added here).
- Backward-compatible (no breaking changes) → patch bump under Cargo 0.x semantics.

After merge: tag `v0.9.1` is pushed (triggers cargo-dist → GitHub Release + Homebrew tap), then `cargo publish` to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
