### PR TITLE
fix(shim): use stable path for shim target so it survives brew upgrade (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`git-prism shim install` now creates a stable symlink target on Homebrew installs.** Previously `canonicalize()` resolved the full symlink chain, baking the version-pinned Cellar path (`/opt/homebrew/Cellar/git-prism/<version>/bin/git-prism`) into the shim. Every `brew upgrade` moved the binary to a new Cellar directory and GC'd the old one, leaving the shim pointing at a deleted file. The install logic now detects a Homebrew Cellar layout by looking for a `Cellar` component in the canonical exe path and maps it to `<prefix>/bin/git-prism` — the stable symlink Homebrew maintains across upgrades. Non-Homebrew installs (cargo, source builds) are unaffected. `git-prism shim status` now includes an advisory warning when the current shim target contains a `Cellar` path component, prompting the user to re-run `git-prism shim install`. (#343)
+
 ## [0.9.1] — 2026-06-01
 
 ### Fixed

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -403,7 +403,7 @@ fn path_contains_cellar_component(path: &Path) -> bool {
 }
 
 /// The advisory message shown when a shim target is a version-pinned Cellar path.
-const CELLAR_STALENESS_ADVISORY: &str = "shim points at a version-pinned Homebrew Cellar path; \
+pub(crate) const CELLAR_STALENESS_ADVISORY: &str = "shim points at a version-pinned Homebrew Cellar path; \
      run `git-prism shim install` to update to a stable path \
      that survives `brew upgrade`";
 
@@ -738,10 +738,18 @@ mod tests {
         std::os::unix::fs::symlink(&cellar_exe, &link).unwrap();
 
         let status = path_shim_status(home);
-        assert!(
-            matches!(status, PathShimStatus::Installed { ref staleness_warning, .. } if staleness_warning.is_some()),
-            "expected Installed with a staleness warning for Cellar target; got {status:?}"
-        );
+        match status {
+            PathShimStatus::Installed {
+                staleness_warning: Some(ref w),
+                ..
+            } => {
+                assert_eq!(
+                    w, CELLAR_STALENESS_ADVISORY,
+                    "staleness warning must equal the canonical advisory string"
+                );
+            }
+            other => panic!("expected Installed with exact staleness warning; got {other:?}"),
+        }
     }
 
     #[test]
@@ -833,12 +841,16 @@ mod tests {
         std::fs::remove_file(&stable_exe).unwrap();
         std::os::unix::fs::symlink(&cellar_exe_110, &stable_exe).unwrap();
 
-        // The stable path still exists and now resolves to 1.1.0.
-        // Canonicalize both sides: on macOS /tmp is a symlink to /private/tmp,
-        // so TempDir paths need normalizing before comparison.
-        let resolved = std::fs::canonicalize(&stable_exe).unwrap();
+        // The install-time target (`target_before`) must re-resolve to the
+        // post-upgrade Cellar exe, proving a stable-path shim automatically
+        // follows `brew upgrade` without reinstalling.
+        // Canonicalize both sides: on macOS /tmp is a symlink to /private/tmp.
+        let resolved = std::fs::canonicalize(&target_before).unwrap();
         let expected = std::fs::canonicalize(&cellar_exe_110).unwrap();
-        assert_eq!(resolved, expected, "stable path should follow the upgrade");
+        assert_eq!(
+            resolved, expected,
+            "shim target chosen at install time must re-resolve to the post-upgrade version"
+        );
     }
 
     #[test]
@@ -875,6 +887,67 @@ mod tests {
         assert_eq!(
             result, cellar_exe,
             "should fall back to canonical exe when stable bin does not exist"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // stable_shim_target — positional boundary unit tests (hand-built paths,
+    // no canonicalize, so the arithmetic is tested directly)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn cellar_at_n_minus_6_via_libexec_is_not_rewritten() {
+        // Layout: <root>/Cellar/<formula>/<version>/libexec/bin/<bin>
+        // Cellar sits at n-6 (5 trailing components), NOT n-5.
+        // A trap <root>/bin/<bin> exists to catch a false rewrite.
+        let dir = tempfile::TempDir::new().unwrap();
+        let r = dir.path();
+        let cellar_exe = r.join("Cellar/git-prism/1.0.0/libexec/bin/git-prism");
+        std::fs::create_dir_all(cellar_exe.parent().unwrap()).unwrap();
+        std::fs::write(&cellar_exe, b"binary").unwrap();
+        let trap = r.join("bin/git-prism");
+        std::fs::create_dir_all(trap.parent().unwrap()).unwrap();
+        std::fs::write(&trap, b"trap").unwrap();
+
+        let result = stable_shim_target(&cellar_exe);
+        assert_eq!(
+            result, cellar_exe,
+            "Cellar at n-6 (libexec/bin layout) must not be rewritten; got {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn cellar_at_n_minus_5_with_sbin_not_bin_is_not_rewritten() {
+        // Layout: <root>/Cellar/<formula>/<version>/sbin/<bin>
+        // Cellar is at n-5 but "sbin" ≠ "bin" at n-2.
+        let dir = tempfile::TempDir::new().unwrap();
+        let r = dir.path();
+        let cellar_exe = r.join("Cellar/git-prism/1.0.0/sbin/git-prism");
+        std::fs::create_dir_all(cellar_exe.parent().unwrap()).unwrap();
+        std::fs::write(&cellar_exe, b"binary").unwrap();
+        let trap = r.join("bin/git-prism");
+        std::fs::create_dir_all(trap.parent().unwrap()).unwrap();
+        std::fs::write(&trap, b"trap").unwrap();
+
+        let result = stable_shim_target(&cellar_exe);
+        assert_eq!(
+            result, cellar_exe,
+            "sbin (not bin) at n-2 must not be rewritten; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn path_with_fewer_than_six_components_is_not_rewritten() {
+        // A path with exactly 5 components hits the n<6 guard.
+        // Hand-built as an absolute path so we control component count exactly.
+        // Layout: /a/Cellar/x/bin/git-prism — 5 components total.
+        let short = std::path::PathBuf::from("/a/Cellar/x/bin/git-prism");
+        let result = stable_shim_target(&short);
+        assert_eq!(
+            result, short,
+            "path with n<6 components must be returned unchanged; got {result:?}"
         );
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -176,9 +176,8 @@ pub enum PathShimStatus {
     /// Symlink exists and resolves to `target`.
     ///
     /// `staleness_warning` is `Some` when the target is version-pinned (contains
-    /// a `Cellar` path component) and will break after `brew upgrade`, or when
-    /// the target is a dangling symlink chain. In both cases the user should
-    /// re-run `git-prism shim install` to update the shim to a stable path.
+    /// a `Cellar` path component) and will break after `brew upgrade`. The user
+    /// should re-run `git-prism shim install` to update the shim to a stable path.
     Installed {
         target: PathBuf,
         staleness_warning: Option<String>,
@@ -206,17 +205,36 @@ fn path_shim_link(home: &Path) -> PathBuf {
 /// non-existent stable paths all fall back to the canonical exe path).
 ///
 /// Does NOT shell out to `brew`; the prefix is derived purely from path
-/// structure by locating the `Cellar` component.
+/// structure. The Homebrew Cellar shape is validated strictly: the suffix
+/// after `Cellar` must be exactly `<formula>/<version>/bin/<bin>` (four
+/// components), so a stray directory named `Cellar` in a non-Homebrew path
+/// is never mistaken for a Homebrew install.
 pub(crate) fn stable_shim_target(canonical_exe: &Path) -> PathBuf {
-    // Walk the components to find the index of "Cellar".
     // Expected layout: <prefix>/Cellar/<formula>/<version>/bin/<bin>
+    //
+    // Validate the full suffix shape rather than just finding the first
+    // `Cellar` component. `Cellar` must be exactly 4 components from the end,
+    // with "bin" as the second-to-last component. This prevents a stray
+    // directory named `Cellar` in a non-Homebrew path from being mistaken for
+    // a Homebrew install and silently repointing the shim at an unrelated binary.
     let components: Vec<_> = canonical_exe.components().collect();
-    let cellar_idx = components.iter().position(|c| c.as_os_str() == "Cellar");
+    let n = components.len();
 
-    let cellar_idx = match cellar_idx {
-        Some(i) => i,
-        None => return canonical_exe.to_path_buf(),
-    };
+    // Need at least: <root> Cellar <formula> <version> bin <bin> = 6 components.
+    if n < 6 {
+        return canonical_exe.to_path_buf();
+    }
+
+    // `Cellar` must sit at index n-5 (exactly 4 components follow it).
+    let cellar_idx = n - 5;
+    if components[cellar_idx].as_os_str() != "Cellar" {
+        return canonical_exe.to_path_buf();
+    }
+
+    // The second-to-last component must be "bin" (index n-2).
+    if components[n - 2].as_os_str() != "bin" {
+        return canonical_exe.to_path_buf();
+    }
 
     // The prefix is everything before "Cellar".
     let prefix: PathBuf = components[..cellar_idx].iter().collect();
@@ -384,6 +402,11 @@ fn path_contains_cellar_component(path: &Path) -> bool {
     path.components().any(|c| c.as_os_str() == "Cellar")
 }
 
+/// The advisory message shown when a shim target is a version-pinned Cellar path.
+const CELLAR_STALENESS_ADVISORY: &str = "shim points at a version-pinned Homebrew Cellar path; \
+     run `git-prism shim install` to update to a stable path \
+     that survives `brew upgrade`";
+
 /// Query the current state of the path-shim symlink without modifying anything.
 pub fn path_shim_status(home: &Path) -> PathShimStatus {
     let link = path_shim_link(home);
@@ -392,6 +415,12 @@ pub fn path_shim_status(home: &Path) -> PathShimStatus {
     }
     match std::fs::read_link(&link) {
         Ok(target) => {
+            // Check for a Cellar-pinned target BEFORE resolving existence.
+            // A dangling Cellar target (brew upgrade GC\'d the old version) is
+            // the primary scenario this fix addresses; the advisory must fire
+            // even when the target no longer exists on disk.
+            let cellar_pinned = path_contains_cellar_component(&target);
+
             let resolved = if target.is_absolute() {
                 target.clone()
             } else {
@@ -399,20 +428,27 @@ pub fn path_shim_status(home: &Path) -> PathShimStatus {
                     .map(|p| p.join(&target))
                     .unwrap_or_else(|| target.clone())
             };
+
             if resolved.exists() {
-                let staleness_warning = if path_contains_cellar_component(&target) {
-                    Some(
-                        "shim points at a version-pinned Homebrew Cellar path; \
-                         run `git-prism shim install` to update to a stable path \
-                         that survives `brew upgrade`"
-                            .to_string(),
-                    )
+                let staleness_warning = if cellar_pinned {
+                    Some(CELLAR_STALENESS_ADVISORY.to_string())
                 } else {
                     None
                 };
                 PathShimStatus::Installed {
                     target,
                     staleness_warning,
+                }
+            } else if cellar_pinned {
+                // Dangling Cellar target: the exact post-upgrade scenario.
+                // Surface as BrokenLink but include the reinstall advisory so
+                // the user knows the remedy, not just the broken path.
+                PathShimStatus::BrokenLink {
+                    reason: format!(
+                        "symlink target does not exist: {} — {}",
+                        target.display(),
+                        CELLAR_STALENESS_ADVISORY
+                    ),
                 }
             } else {
                 PathShimStatus::BrokenLink {
@@ -689,7 +725,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
 
-        // Create a fake Cellar target so the symlink isn't dangling.
+        // Create a fake Cellar target so the symlink is not dangling.
         let cellar_bin = home.join("Cellar/git-prism/1.0.0/bin");
         std::fs::create_dir_all(&cellar_bin).unwrap();
         let cellar_exe = cellar_bin.join("git-prism");
@@ -766,8 +802,8 @@ mod tests {
     #[cfg(unix)]
     fn stable_shim_target_survives_brew_upgrade() {
         // Simulate a brew upgrade: the stable bin symlink is repointed from
-        // 1.0.0 to 1.1.0. A shim that was installed targeting <prefix>/bin/git-prism
-        // (rather than the Cellar path) still resolves correctly after the upgrade.
+        // 1.0.0 to 1.1.0. A shim installed targeting <prefix>/bin/git-prism
+        // still resolves correctly after the upgrade.
         let dir = TempDir::new().unwrap();
         let prefix = dir.path();
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -174,7 +174,15 @@ pub const PATH_SHIM_LINK_NAME: &str = "git";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathShimStatus {
     /// Symlink exists and resolves to `target`.
-    Installed { target: PathBuf },
+    ///
+    /// `staleness_warning` is `Some` when the target is version-pinned (contains
+    /// a `Cellar` path component) and will break after `brew upgrade`, or when
+    /// the target is a dangling symlink chain. In both cases the user should
+    /// re-run `git-prism shim install` to update the shim to a stable path.
+    Installed {
+        target: PathBuf,
+        staleness_warning: Option<String>,
+    },
     /// Symlink does not exist.
     NotInstalled,
     /// Symlink exists but is broken or cannot be read.
@@ -184,6 +192,47 @@ pub enum PathShimStatus {
 /// Return the expected path to the shim symlink: `$HOME/.local/share/git-prism/bin/git`.
 fn path_shim_link(home: &Path) -> PathBuf {
     home.join(PATH_SHIM_REL_DIR).join(PATH_SHIM_LINK_NAME)
+}
+
+/// Given the canonicalized current-exe path, return a stable shim target.
+///
+/// If the path is inside a Homebrew Cellar
+/// (`<prefix>/Cellar/<formula>/<version>/bin/<bin>`) and the stable linked
+/// path `<prefix>/bin/<bin>` exists on disk, return that path — it survives
+/// `brew upgrade` because Homebrew keeps `<prefix>/bin/<bin>` pointing at
+/// the current Cellar version.
+///
+/// Otherwise return the input unchanged (cargo-install, source builds, and
+/// non-existent stable paths all fall back to the canonical exe path).
+///
+/// Does NOT shell out to `brew`; the prefix is derived purely from path
+/// structure by locating the `Cellar` component.
+pub(crate) fn stable_shim_target(canonical_exe: &Path) -> PathBuf {
+    // Walk the components to find the index of "Cellar".
+    // Expected layout: <prefix>/Cellar/<formula>/<version>/bin/<bin>
+    let components: Vec<_> = canonical_exe.components().collect();
+    let cellar_idx = components.iter().position(|c| c.as_os_str() == "Cellar");
+
+    let cellar_idx = match cellar_idx {
+        Some(i) => i,
+        None => return canonical_exe.to_path_buf(),
+    };
+
+    // The prefix is everything before "Cellar".
+    let prefix: PathBuf = components[..cellar_idx].iter().collect();
+
+    // The binary filename is the last component of the canonical exe.
+    let bin_name = match canonical_exe.file_name() {
+        Some(name) => name,
+        None => return canonical_exe.to_path_buf(),
+    };
+
+    let stable = prefix.join("bin").join(bin_name);
+    if stable.exists() {
+        stable
+    } else {
+        canonical_exe.to_path_buf()
+    }
 }
 
 /// Create `~/.local/share/git-prism/bin/git` as a symlink pointing at the
@@ -208,10 +257,16 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
             .with_context(|| format!("failed to chmod {}", shim_dir.display()))?;
     }
 
-    let current_exe = std::env::current_exe()
+    let canonical_exe = std::env::current_exe()
         .context("failed to resolve current executable path")?
         .canonicalize()
         .context("failed to canonicalize current executable path")?;
+
+    // Use a stable path that survives `brew upgrade`. For Homebrew installs the
+    // canonical exe is a version-pinned Cellar path that gets GC'd on upgrade;
+    // `stable_shim_target` maps it to `<prefix>/bin/<bin>` which Homebrew keeps
+    // up-to-date. For cargo-install / source builds the path is unchanged.
+    let target = stable_shim_target(&canonical_exe);
 
     let link = path_shim_link(home);
 
@@ -232,7 +287,7 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
         } else {
             match std::fs::read_link(&link) {
                 Ok(existing_target) => {
-                    if existing_target == current_exe {
+                    if existing_target == target {
                         return Ok(link);
                     }
                     std::fs::remove_file(&link).with_context(|| {
@@ -249,7 +304,7 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     }
 
     #[cfg(unix)]
-    std::os::unix::fs::symlink(&current_exe, &link)
+    std::os::unix::fs::symlink(&target, &link)
         .with_context(|| format!("failed to create symlink {}", link.display()))?;
 
     #[cfg(not(unix))]
@@ -323,6 +378,12 @@ pub fn uninstall_path_shim(home: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Return true if `path` contains a `Cellar` component, indicating it is a
+/// version-pinned Homebrew Cellar path that will break after `brew upgrade`.
+fn path_contains_cellar_component(path: &Path) -> bool {
+    path.components().any(|c| c.as_os_str() == "Cellar")
+}
+
 /// Query the current state of the path-shim symlink without modifying anything.
 pub fn path_shim_status(home: &Path) -> PathShimStatus {
     let link = path_shim_link(home);
@@ -339,7 +400,20 @@ pub fn path_shim_status(home: &Path) -> PathShimStatus {
                     .unwrap_or_else(|| target.clone())
             };
             if resolved.exists() {
-                PathShimStatus::Installed { target }
+                let staleness_warning = if path_contains_cellar_component(&target) {
+                    Some(
+                        "shim points at a version-pinned Homebrew Cellar path; \
+                         run `git-prism shim install` to update to a stable path \
+                         that survives `brew upgrade`"
+                            .to_string(),
+                    )
+                } else {
+                    None
+                };
+                PathShimStatus::Installed {
+                    target,
+                    staleness_warning,
+                }
             } else {
                 PathShimStatus::BrokenLink {
                     reason: format!("symlink target does not exist: {}", target.display()),
@@ -601,6 +675,171 @@ mod tests {
 
         let status = path_shim_status(home);
         assert_eq!(status, PathShimStatus::NotInstalled);
+    }
+
+    // -------------------------------------------------------------------------
+    // path_shim_status staleness warning
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn path_shim_status_warns_when_target_is_cellar_path() {
+        // A symlink pointing into a Cellar directory is version-pinned and will
+        // break after `brew upgrade`. The status must include a staleness advisory.
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        // Create a fake Cellar target so the symlink isn't dangling.
+        let cellar_bin = home.join("Cellar/git-prism/1.0.0/bin");
+        std::fs::create_dir_all(&cellar_bin).unwrap();
+        let cellar_exe = cellar_bin.join("git-prism");
+        std::fs::write(&cellar_exe, b"binary").unwrap();
+
+        // Install the shim pointing directly at the Cellar path.
+        let shim_dir = home.join(PATH_SHIM_REL_DIR);
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        let link = shim_dir.join(PATH_SHIM_LINK_NAME);
+        std::os::unix::fs::symlink(&cellar_exe, &link).unwrap();
+
+        let status = path_shim_status(home);
+        assert!(
+            matches!(status, PathShimStatus::Installed { ref staleness_warning, .. } if staleness_warning.is_some()),
+            "expected Installed with a staleness warning for Cellar target; got {status:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn path_shim_status_no_warning_for_stable_target() {
+        // A symlink pointing to a stable (non-Cellar) path needs no advisory.
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        let stable_bin = home.join("bin");
+        std::fs::create_dir_all(&stable_bin).unwrap();
+        let stable_exe = stable_bin.join("git-prism");
+        std::fs::write(&stable_exe, b"binary").unwrap();
+
+        let shim_dir = home.join(PATH_SHIM_REL_DIR);
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        let link = shim_dir.join(PATH_SHIM_LINK_NAME);
+        std::os::unix::fs::symlink(&stable_exe, &link).unwrap();
+
+        let status = path_shim_status(home);
+        assert!(
+            matches!(status, PathShimStatus::Installed { ref staleness_warning, .. } if staleness_warning.is_none()),
+            "expected Installed with no staleness warning for stable target; got {status:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // stable_shim_target
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn stable_shim_target_maps_homebrew_cellar_exe_to_prefix_bin() {
+        // Build a fake Homebrew layout:
+        //   <tmp>/Cellar/git-prism/1.0.0/bin/git-prism  (the canonical exe)
+        //   <tmp>/bin/git-prism                          (the stable linked path)
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path();
+
+        let cellar_bin = prefix.join("Cellar/git-prism/1.0.0/bin");
+        std::fs::create_dir_all(&cellar_bin).unwrap();
+        let cellar_exe = cellar_bin.join("git-prism");
+        std::fs::write(&cellar_exe, b"fake binary").unwrap();
+
+        let stable_bin = prefix.join("bin");
+        std::fs::create_dir_all(&stable_bin).unwrap();
+        let stable_exe = stable_bin.join("git-prism");
+        std::fs::write(&stable_exe, b"fake binary").unwrap();
+
+        let result = stable_shim_target(&cellar_exe);
+        assert_eq!(
+            result, stable_exe,
+            "Homebrew Cellar exe should map to <prefix>/bin/<binary>"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn stable_shim_target_survives_brew_upgrade() {
+        // Simulate a brew upgrade: the stable bin symlink is repointed from
+        // 1.0.0 to 1.1.0. A shim that was installed targeting <prefix>/bin/git-prism
+        // (rather than the Cellar path) still resolves correctly after the upgrade.
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path();
+
+        // v1.0.0 layout
+        let cellar_bin_100 = prefix.join("Cellar/git-prism/1.0.0/bin");
+        std::fs::create_dir_all(&cellar_bin_100).unwrap();
+        let cellar_exe_100 = cellar_bin_100.join("git-prism");
+        std::fs::write(&cellar_exe_100, b"v1.0.0 binary").unwrap();
+
+        // v1.1.0 layout (post-upgrade)
+        let cellar_bin_110 = prefix.join("Cellar/git-prism/1.1.0/bin");
+        std::fs::create_dir_all(&cellar_bin_110).unwrap();
+        let cellar_exe_110 = cellar_bin_110.join("git-prism");
+        std::fs::write(&cellar_exe_110, b"v1.1.0 binary").unwrap();
+
+        // stable <prefix>/bin/git-prism initially points at 1.0.0
+        let stable_bin = prefix.join("bin");
+        std::fs::create_dir_all(&stable_bin).unwrap();
+        let stable_exe = stable_bin.join("git-prism");
+        std::os::unix::fs::symlink(&cellar_exe_100, &stable_exe).unwrap();
+
+        // Before upgrade: stable_shim_target on 1.0.0 returns the stable path
+        let target_before = stable_shim_target(&cellar_exe_100);
+        assert_eq!(target_before, stable_exe);
+
+        // Simulate brew upgrade: repoint stable symlink to 1.1.0
+        std::fs::remove_file(&stable_exe).unwrap();
+        std::os::unix::fs::symlink(&cellar_exe_110, &stable_exe).unwrap();
+
+        // The stable path still exists and now resolves to 1.1.0.
+        // Canonicalize both sides: on macOS /tmp is a symlink to /private/tmp,
+        // so TempDir paths need normalizing before comparison.
+        let resolved = std::fs::canonicalize(&stable_exe).unwrap();
+        let expected = std::fs::canonicalize(&cellar_exe_110).unwrap();
+        assert_eq!(resolved, expected, "stable path should follow the upgrade");
+    }
+
+    #[test]
+    fn stable_shim_target_returns_input_for_non_homebrew_path() {
+        // A cargo-install path has no Cellar component — must be returned unchanged.
+        let dir = TempDir::new().unwrap();
+        let cargo_bin = dir.path().join(".cargo/bin");
+        std::fs::create_dir_all(&cargo_bin).unwrap();
+        let exe = cargo_bin.join("git-prism");
+        std::fs::write(&exe, b"binary").unwrap();
+
+        let result = stable_shim_target(&exe);
+        assert_eq!(
+            result, exe,
+            "non-Homebrew path should be returned unchanged"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn stable_shim_target_falls_back_when_stable_bin_does_not_exist() {
+        // Cellar layout exists but <prefix>/bin/git-prism does NOT exist.
+        // Must fall back to the canonical Cellar path rather than pointing at a phantom.
+        let dir = TempDir::new().unwrap();
+        let prefix = dir.path();
+
+        let cellar_bin = prefix.join("Cellar/git-prism/1.0.0/bin");
+        std::fs::create_dir_all(&cellar_bin).unwrap();
+        let cellar_exe = cellar_bin.join("git-prism");
+        std::fs::write(&cellar_exe, b"binary").unwrap();
+
+        // Intentionally do NOT create <prefix>/bin/git-prism
+        let result = stable_shim_target(&cellar_exe);
+        assert_eq!(
+            result, cellar_exe,
+            "should fall back to canonical exe when stable bin does not exist"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,8 +237,14 @@ fn run_hooks_command(command: HooksCommands) -> anyhow::Result<i32> {
             }
             let shim_status = hooks::path_shim_status(&home);
             match shim_status {
-                hooks::PathShimStatus::Installed { target, .. } => {
+                hooks::PathShimStatus::Installed {
+                    target,
+                    staleness_warning,
+                } => {
                     println!("path-shim: installed @ {}", target.display());
+                    if let Some(w) = staleness_warning {
+                        println!("warning: {w}");
+                    }
                 }
                 hooks::PathShimStatus::NotInstalled => {
                     println!("path-shim: not installed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn run_hooks_command(command: HooksCommands) -> anyhow::Result<i32> {
             }
             let shim_status = hooks::path_shim_status(&home);
             match shim_status {
-                hooks::PathShimStatus::Installed { target } => {
+                hooks::PathShimStatus::Installed { target, .. } => {
                     println!("path-shim: installed @ {}", target.display());
                 }
                 hooks::PathShimStatus::NotInstalled => {

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -173,13 +173,19 @@ pub fn run_status(home: &std::path::Path) -> Result<()> {
     let shim_dir = home.join(hooks::PATH_SHIM_REL_DIR);
     let shim_dir_str = shim_dir.to_string_lossy();
     match hooks::path_shim_status(home) {
-        hooks::PathShimStatus::Installed { target } => {
+        hooks::PathShimStatus::Installed {
+            target,
+            staleness_warning,
+        } => {
             println!(
                 "shim: installed at {} -> {}",
                 shim_dir.join(hooks::PATH_SHIM_LINK_NAME).display(),
                 target.display()
             );
             println!("shim directory: {shim_dir_str}");
+            if let Some(warning) = staleness_warning {
+                println!("warning: {warning}");
+            }
         }
         hooks::PathShimStatus::NotInstalled => {
             println!("shim: not installed");

--- a/tests/shim_stable_path_pentest.rs
+++ b/tests/shim_stable_path_pentest.rs
@@ -221,3 +221,184 @@ fn genuine_homebrew_cellar_layout_rewrites_to_stable_bin() {
         target.display()
     );
 }
+
+// ---------------------------------------------------------------------------
+// RUN 2 — re-attack the positional shape validation (Cellar at n-5, bin at n-2)
+// ---------------------------------------------------------------------------
+
+/// RUN2 C1: an extra path segment (`libexec/bin`) between the Cellar
+/// `<version>` and the binary. Real layout some formulae use:
+/// `<prefix>/Cellar/<formula>/<version>/libexec/bin/<bin>` — here Cellar sits
+/// at n-6, NOT n-5, so the strict positional check must NOT treat it as the
+/// canonical 4-component shape and must return the path unchanged (it would be
+/// wrong to point at `<prefix>/bin/<bin>` when the real exe lives under
+/// libexec). Confirms the check is anchored to n-5, not "Cellar somewhere with
+/// bin near the end".
+#[test]
+fn cellar_with_extra_libexec_segment_must_not_rewrite() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    // 5 components after Cellar: formula/version/libexec/bin/<bin>
+    let real_exe = copy_binary_to(&r.join("Cellar/git-prism/1.0.0/libexec/bin/git-prism"));
+
+    // Unrelated <r>/bin/git-prism exists (the trap).
+    let unrelated = r.join("bin/git-prism");
+    fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+    fs::write(&unrelated, b"#!/bin/sh\necho WRONG\n").unwrap();
+    fs::set_permissions(&unrelated, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&real_exe, home.path());
+
+    let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_real = fs::canonicalize(&real_exe).unwrap();
+    let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
+    assert_ne!(
+        canon_target,
+        canon_unrelated,
+        "a libexec/bin Cellar layout (5 trailing components) was rewritten to \
+         <prefix>/bin/<bin>; target={}",
+        target.display()
+    );
+    assert_eq!(
+        canon_target,
+        canon_real,
+        "libexec/bin layout must be left unchanged; target={}",
+        target.display()
+    );
+}
+
+/// RUN2 C2: Cellar IS at n-5, but the second-to-last segment is NOT `bin`
+/// (`.../Cellar/<formula>/<version>/sbin/<bin>`). The strict check requires
+/// `bin` at n-2, so this must be returned unchanged.
+#[test]
+fn cellar_at_n_minus_5_but_not_bin_at_n_minus_2_must_not_rewrite() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    // Cellar at n-5, but "sbin" (not "bin") at n-2.
+    let real_exe = copy_binary_to(&r.join("Cellar/git-prism/1.0.0/sbin/git-prism"));
+
+    // Trap: <r>/bin/git-prism exists.
+    let unrelated = r.join("bin/git-prism");
+    fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+    fs::write(&unrelated, b"#!/bin/sh\necho WRONG\n").unwrap();
+    fs::set_permissions(&unrelated, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&real_exe, home.path());
+
+    let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
+    assert_ne!(
+        canon_target,
+        canon_unrelated,
+        "a Cellar layout with `sbin` (not `bin`) at n-2 was rewritten; target={}",
+        target.display()
+    );
+}
+
+/// RUN2 C3: filename preservation under rewrite. A genuinely Homebrew-shaped
+/// exe with a NON-default binary name (`git-prism2`) must rewrite to
+/// `<prefix>/bin/git-prism2`, NOT a hardcoded `git-prism`. Proves the derived
+/// stable path uses the exe's own file_name().
+#[test]
+fn rewrite_preserves_non_default_binary_filename() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    let cellar_exe = copy_binary_to(&r.join("Cellar/git-prism/1.0.0/bin/git-prism2"));
+
+    // Stable <r>/bin/git-prism2 exists (matching filename). Also plant a
+    // <r>/bin/git-prism decoy to catch any hardcoded-name behavior.
+    let stable = r.join("bin/git-prism2");
+    fs::create_dir_all(stable.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&cellar_exe, &stable).unwrap();
+    let decoy = r.join("bin/git-prism");
+    fs::write(&decoy, b"#!/bin/sh\necho DECOY\n").unwrap();
+    fs::set_permissions(&decoy, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&cellar_exe, home.path());
+
+    assert_eq!(
+        target.file_name().and_then(|s| s.to_str()),
+        Some("git-prism2"),
+        "rewritten target must keep the exe's own filename (git-prism2), not a \
+         hardcoded name; target={}",
+        target.display()
+    );
+    assert_eq!(
+        fs::canonicalize(&target).unwrap(),
+        fs::canonicalize(&stable).unwrap(),
+        "should rewrite to <prefix>/bin/git-prism2; target={}",
+        target.display()
+    );
+}
+
+/// RUN2 C4: a genuine Homebrew Cellar exe whose `<prefix>/bin/<bin>` does NOT
+/// exist must fall back to the canonical Cellar path (no phantom target).
+#[test]
+fn genuine_cellar_without_stable_bin_falls_back_to_canonical() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    let cellar_exe = copy_binary_to(&r.join("Cellar/git-prism/1.0.0/bin/git-prism"));
+    // Intentionally do NOT create <r>/bin/git-prism.
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&cellar_exe, home.path());
+
+    assert_eq!(
+        fs::canonicalize(&target).unwrap(),
+        fs::canonicalize(&cellar_exe).unwrap(),
+        "missing <prefix>/bin/<bin> must fall back to the canonical Cellar exe; \
+         target={}",
+        target.display()
+    );
+}
+
+/// RUN2 C5: a plain cargo-install path (no Cellar component anywhere) is left
+/// unchanged even when a sibling `<root>/bin/git-prism` exists.
+#[test]
+fn cargo_install_path_left_unchanged() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    let cargo_exe = copy_binary_to(&r.join(".cargo/bin/git-prism"));
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&cargo_exe, home.path());
+
+    assert_eq!(
+        fs::canonicalize(&target).unwrap(),
+        fs::canonicalize(&cargo_exe).unwrap(),
+        "cargo-install path (no Cellar) must be unchanged; target={}",
+        target.display()
+    );
+}
+
+/// RUN2 C6 (dangling control): a dangling NON-Cellar target must NOT get the
+/// Cellar reinstall advisory — only genuine Cellar staleness should.
+#[test]
+fn dangling_non_cellar_target_gets_no_cellar_advisory() {
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_git-prism"));
+    let home = TempDir::new().unwrap();
+    let h = home.path();
+
+    let shim_dir = h.join(".local/share/git-prism/bin");
+    fs::create_dir_all(&shim_dir).unwrap();
+    let link = shim_dir.join("git");
+    // Dangling target with NO Cellar component.
+    let dangling = h.join(".cargo/bin/git-prism");
+    std::os::unix::fs::symlink(&dangling, &link).unwrap();
+
+    let stdout = run_status(&bin, h);
+    assert!(
+        !stdout.to_lowercase().contains("brew upgrade")
+            && !stdout.contains("git-prism shim install"),
+        "a dangling non-Cellar target must not emit a Homebrew/Cellar advisory; \
+         got: {stdout:?}"
+    );
+}

--- a/tests/shim_stable_path_pentest.rs
+++ b/tests/shim_stable_path_pentest.rs
@@ -1,0 +1,223 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #343, gate 3): stable shim target derivation.
+//!
+//! `stable_shim_target` rewrites a Homebrew-Cellar exe path
+//! (`<prefix>/Cellar/<formula>/<version>/bin/<bin>`) to the stable
+//! `<prefix>/bin/<bin>` so the shim survives `brew upgrade`. These tests drive
+//! the REAL binary end-to-end: we copy the built `git-prism` into a synthetic
+//! on-disk layout, run `<copy> shim install` with an isolated HOME, and inspect
+//! the symlink target it produces. Because `install_path_shim` resolves the
+//! target from `std::env::current_exe()`, running a relocated copy is the only
+//! black-box way to exercise the Cellar-detection branch.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+const CLEAN_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+/// Copy the built test binary to `dest`, preserving the exec bit. Creates parent
+/// dirs as needed. Returns `dest`.
+fn copy_binary_to(dest: &Path) -> PathBuf {
+    let src = env!("CARGO_BIN_EXE_git-prism");
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    fs::copy(src, dest).unwrap();
+    let mut perms = fs::metadata(dest).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(dest, perms).unwrap();
+    dest.to_path_buf()
+}
+
+/// Run `<exe> shim install` with an isolated HOME, declining the PATH prompt.
+/// Returns the symlink target that was created (read_link of the shim).
+fn install_and_read_target(exe: &Path, home: &Path) -> PathBuf {
+    let out = Command::new(exe)
+        .env("HOME", home)
+        .env("PATH", CLEAN_PATH)
+        .env("SHELL", "/bin/zsh")
+        .args(["shim", "install"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(b"n\n").unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "shim install failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let link = home.join(".local/share/git-prism/bin/git");
+    fs::read_link(&link).unwrap()
+}
+
+/// PENTEST A1 (the headline attack): a NON-Homebrew install whose path merely
+/// contains a directory literally named `Cellar` above the binary — e.g. a
+/// project dir, an encrypted-volume mount, a user who named a folder `Cellar`.
+/// The derivation latches onto the first `Cellar` component and computes
+/// `<before-Cellar>/bin/<bin>`. If that sibling exists (a `bin/` dir next to a
+/// `Cellar/` dir is utterly ordinary), the shim is silently retargeted to an
+/// UNRELATED binary instead of the one the user actually ran. That breaks the
+/// install (`git` shim points at the wrong program) with no warning.
+#[test]
+fn cellar_dir_in_non_homebrew_path_must_not_retarget_to_unrelated_bin() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    // The actual binary the user runs, nested below a stray `Cellar` dir.
+    //   <r>/Cellar/work/git-prism      <- real exe (current_exe())
+    let real_exe = copy_binary_to(&r.join("Cellar/work/git-prism"));
+
+    // A DIFFERENT, unrelated program sitting at the computed <prefix>/bin/<bin>.
+    //   <r>/bin/git-prism              <- not what the user ran
+    let unrelated = r.join("bin/git-prism");
+    fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+    fs::write(&unrelated, b"#!/bin/sh\necho WRONG BINARY\n").unwrap();
+    fs::set_permissions(&unrelated, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&real_exe, home.path());
+
+    // Correct behavior: this is not a Homebrew Cellar layout, so the shim must
+    // point at the binary the user actually ran, NOT the unrelated <r>/bin one.
+    let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_real = fs::canonicalize(&real_exe).unwrap();
+    let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
+
+    assert_ne!(
+        canon_target,
+        canon_unrelated,
+        "shim was retargeted to an UNRELATED binary because of a stray `Cellar` \
+         directory in a non-Homebrew path; target={}",
+        target.display()
+    );
+    assert_eq!(
+        canon_target,
+        canon_real,
+        "shim must point at the binary the user actually ran; target={}",
+        target.display()
+    );
+}
+
+/// PENTEST A2: the derivation does not validate the Homebrew shape
+/// (`Cellar/<formula>/<version>/bin/<bin>`). ANY path with a `Cellar` component
+/// and an existing `<before-Cellar>/bin/<bin>` is rewritten — even a degenerate
+/// `.../Cellar/git-prism` with zero intervening `<formula>/<version>/bin`
+/// segments. A real Cellar exe always has those segments.
+#[test]
+fn cellar_marker_without_formula_version_bin_shape_must_not_rewrite() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    // Degenerate: Cellar immediately followed by the binary.
+    let real_exe = copy_binary_to(&r.join("Cellar/git-prism"));
+
+    // Unrelated <r>/bin/git-prism exists.
+    let unrelated = r.join("bin/git-prism");
+    fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+    fs::write(&unrelated, b"#!/bin/sh\necho WRONG\n").unwrap();
+    fs::set_permissions(&unrelated, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&real_exe, home.path());
+
+    let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
+    assert_ne!(
+        canon_target,
+        canon_unrelated,
+        "a path that does not match Cellar/<formula>/<version>/bin/<bin> was \
+         still rewritten to <prefix>/bin/<bin>; target={}",
+        target.display()
+    );
+}
+
+/// Run `<exe> shim status` with an isolated HOME and capture stdout.
+fn run_status(exe: &Path, home: &Path) -> String {
+    let out = Command::new(exe)
+        .env("HOME", home)
+        .env("PATH", CLEAN_PATH)
+        .args(["shim", "status"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "shim status exited non-zero");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// PENTEST B1 (documented-contract probe): the `PathShimStatus::Installed`
+/// doc comment claims `staleness_warning` is `Some` when "the target is a
+/// dangling symlink chain". Plant a shim that points at a DANGLING Cellar path
+/// (the Cellar version was GC'd by `brew upgrade` — the exact scenario the fix
+/// targets) and assert `shim status` surfaces the Cellar staleness advisory.
+///
+/// If this fails, the documented dangling-Cellar branch is unreachable: the
+/// code only computes the warning inside `if resolved.exists()`, so a dangling
+/// Cellar target reports a generic "broken link" with no hint that re-running
+/// `git-prism shim install` (the documented remedy) would fix it.
+#[test]
+fn dangling_cellar_target_status_must_advise_reinstall() {
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_git-prism"));
+    let home = TempDir::new().unwrap();
+    let h = home.path();
+
+    // Plant a shim symlink pointing at a Cellar path that does NOT exist
+    // (post-`brew upgrade` GC of the old version).
+    let shim_dir = h.join(".local/share/git-prism/bin");
+    fs::create_dir_all(&shim_dir).unwrap();
+    let link = shim_dir.join("git");
+    let dangling_cellar = h.join("opt/homebrew/Cellar/git-prism/0.9.0/bin/git-prism");
+    std::os::unix::fs::symlink(&dangling_cellar, &link).unwrap();
+
+    let stdout = run_status(&bin, h);
+
+    // The documented remedy for a stale Cellar shim is to re-run
+    // `git-prism shim install`. A dangling Cellar chain should point the user
+    // at that fix, not just say "broken link". (The bare path echoed in a
+    // broken-link reason happens to contain "Cellar" but gives no remedy.)
+    assert!(
+        stdout.contains("git-prism shim install") || stdout.to_lowercase().contains("brew upgrade"),
+        "status on a dangling Cellar target gives no actionable remedy \
+         (re-run `git-prism shim install` / mentions of `brew upgrade`); \
+         the PathShimStatus::Installed doc claims the warning covers a \
+         dangling chain, but that branch is unreachable. Got: {stdout:?}"
+    );
+}
+
+/// CONTROL: a genuine Homebrew Cellar layout DOES get rewritten to the stable
+/// <prefix>/bin/<bin>. Confirms the feature works for the real case so a fix
+/// for A1/A2 cannot simply disable rewriting wholesale.
+#[test]
+fn genuine_homebrew_cellar_layout_rewrites_to_stable_bin() {
+    let root = TempDir::new().unwrap();
+    let r = root.path();
+
+    // Real-shaped Cellar exe: <r>/Cellar/git-prism/1.0.0/bin/git-prism
+    let cellar_exe = copy_binary_to(&r.join("Cellar/git-prism/1.0.0/bin/git-prism"));
+
+    // Stable <r>/bin/git-prism -> the Cellar exe (Homebrew opt link).
+    let stable = r.join("bin/git-prism");
+    fs::create_dir_all(stable.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&cellar_exe, &stable).unwrap();
+
+    let home = TempDir::new().unwrap();
+    let target = install_and_read_target(&cellar_exe, home.path());
+
+    assert_eq!(
+        fs::canonicalize(&target).unwrap(),
+        fs::canonicalize(&stable).unwrap(),
+        "genuine Homebrew Cellar exe should be rewritten to <prefix>/bin/<bin>; \
+         target={}",
+        target.display()
+    );
+}

--- a/tests/shim_stable_path_pentest.rs
+++ b/tests/shim_stable_path_pentest.rs
@@ -131,12 +131,19 @@ fn cellar_marker_without_formula_version_bin_shape_must_not_rewrite() {
     let target = install_and_read_target(&real_exe, home.path());
 
     let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_real = fs::canonicalize(&real_exe).unwrap();
     let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
     assert_ne!(
         canon_target,
         canon_unrelated,
         "a path that does not match Cellar/<formula>/<version>/bin/<bin> was \
          still rewritten to <prefix>/bin/<bin>; target={}",
+        target.display()
+    );
+    assert_eq!(
+        canon_target,
+        canon_real,
+        "degenerate Cellar path must point at the binary the user actually ran; target={}",
         target.display()
     );
 }
@@ -186,11 +193,16 @@ fn dangling_cellar_target_status_must_advise_reinstall() {
     // at that fix, not just say "broken link". (The bare path echoed in a
     // broken-link reason happens to contain "Cellar" but gives no remedy.)
     assert!(
-        stdout.contains("git-prism shim install") || stdout.to_lowercase().contains("brew upgrade"),
-        "status on a dangling Cellar target gives no actionable remedy \
-         (re-run `git-prism shim install` / mentions of `brew upgrade`); \
-         the PathShimStatus::Installed doc claims the warning covers a \
-         dangling chain, but that branch is unreachable. Got: {stdout:?}"
+        stdout.contains("git-prism shim install"),
+        "status on a dangling Cellar target must mention `git-prism shim install`; got: {stdout:?}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("brew upgrade"),
+        "status on a dangling Cellar target must mention `brew upgrade`; got: {stdout:?}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("broken link"),
+        "status on a dangling Cellar target must report as broken link; got: {stdout:?}"
     );
 }
 
@@ -290,11 +302,18 @@ fn cellar_at_n_minus_5_but_not_bin_at_n_minus_2_must_not_rewrite() {
     let target = install_and_read_target(&real_exe, home.path());
 
     let canon_target = fs::canonicalize(&target).unwrap_or(target.clone());
+    let canon_real = fs::canonicalize(&real_exe).unwrap();
     let canon_unrelated = fs::canonicalize(&unrelated).unwrap();
     assert_ne!(
         canon_target,
         canon_unrelated,
         "a Cellar layout with `sbin` (not `bin`) at n-2 was rewritten; target={}",
+        target.display()
+    );
+    assert_eq!(
+        canon_target,
+        canon_real,
+        "sbin layout must point at the binary the user actually ran; target={}",
         target.display()
     );
 }
@@ -400,5 +419,9 @@ fn dangling_non_cellar_target_gets_no_cellar_advisory() {
             && !stdout.contains("git-prism shim install"),
         "a dangling non-Cellar target must not emit a Homebrew/Cellar advisory; \
          got: {stdout:?}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("broken link"),
+        "a dangling non-Cellar target must still report as broken link; got: {stdout:?}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes #343. `git-prism shim install` baked the **version-pinned Homebrew Cellar path** into the shim symlink, so every `brew upgrade` left the shim pointing at a stale (eventually GC'd) Cellar directory.

## Root cause

`install_path_shim` used `std::env::current_exe()?.canonicalize()?`, and `canonicalize()` resolves the full symlink chain — turning `/opt/homebrew/bin/git-prism` into `…/Cellar/git-prism/<version>/bin/git-prism`. That version-pinned path was persisted as the shim target.

## Fix

New `stable_shim_target(canonical_exe)`: when the path matches the Homebrew Cellar shape — validated **positionally** (`Cellar` exactly 4 components from the end, `bin` second-to-last) — it rewrites to the stable `<prefix>/bin/<bin>` (which Homebrew keeps current across upgrades), and only if that target exists. Anything else (cargo installs, source builds, stray directories literally named `Cellar`) is returned unchanged. Derivation is pure `Path::components()` — no shelling out to `brew`.

`shim status` (and, for parity, the legacy `hooks status`) now warns when the stored shim target is version-pinned to a Cellar path or dangles, advising the user to re-run `git-prism shim install`.

## Tests

10 integration probes + boundary unit tests pinning the `n-5`/`n-2`/`n<6` positional arithmetic (with hand-built absolute paths, since `canonicalize()` would otherwise hide the boundary), an upgrade-survival test that resolves the *install-time* target after a simulated `brew upgrade`, filename-preservation, missing-stable-bin fallback, and status-advisory parity. 1015 tests pass; clippy/fmt clean.

## Scope

Source-only (`std::path`); no dependency or `Cargo.toml` changes. Ships in v0.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
