### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-06-01
+
 ### Fixed
 
 - **`git-prism shim install` now creates a stable symlink target on Homebrew installs.** Previously `canonicalize()` resolved the full symlink chain, baking the version-pinned Cellar path (`/opt/homebrew/Cellar/git-prism/<version>/bin/git-prism`) into the shim. Every `brew upgrade` moved the binary to a new Cellar directory and GC'd the old one, leaving the shim pointing at a deleted file. The install logic now detects a Homebrew Cellar layout by looking for a `Cellar` component in the canonical exe path and maps it to `<prefix>/bin/git-prism` — the stable symlink Homebrew maintains across upgrades. Non-Homebrew installs (cargo, source builds) are unaffected. `git-prism shim status` now includes an advisory warning when the current shim target contains a `Cellar` path component, prompting the user to re-run `git-prism shim install`. (#343)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "git-prism"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-prism"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 description = "Agent-optimized git data MCP server — structured change manifests and full file snapshots for LLM agents"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release for the Homebrew shim footgun fixed in #343 (PR #344).

## Included

- **#343** (PR #344) — `git-prism shim install` no longer bakes the version-pinned Homebrew Cellar path into the shim symlink. It now targets the stable `<prefix>/bin/git-prism` (validated by Cellar-layout shape), so the shim survives `brew upgrade`. `shim status` / `hooks status` warn when an existing shim is Cellar-pinned or dangling, advising reinstall.

## Release mechanics

- `Cargo.toml` + `Cargo.lock` bumped `0.9.1` → `0.9.2`.
- CHANGELOG `[Unreleased]` cut to `## [0.9.2] — 2026-06-01`.
- Backward-compatible bug fix → patch bump.

After merge: tag `v0.9.2` (triggers cargo-dist → GitHub Release + Homebrew tap), then `cargo publish` to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
