### PR TITLE
fix(shim): manage the gh symlink in install/status/uninstall + login-shell PATH UX (#347)

### DIFF
--- a/bdd/features/shim_parity.feature
+++ b/bdd/features/shim_parity.feature
@@ -190,20 +190,20 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
     Scenario: Accepting PATH setup appends the export line to the shell rc
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zshrc" under HOME
+      And a shell rc file exists at ".zprofile" under HOME
       When I run "git-prism shim install" and consent to PATH setup with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zshrc" under HOME contains the shim directory export line
+      And the rc file ".zprofile" under HOME contains the shim directory export line
       And the output contains "restart"
 
     @ISSUE-325
     Scenario: Re-running install does not append the export line a second time
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zshrc" under HOME
+      And a shell rc file exists at ".zprofile" under HOME
       When I run "git-prism shim install" and consent to PATH setup with the isolated HOME
       And I run "git-prism shim install" and consent to PATH setup with the isolated HOME again
-      Then the rc file ".zshrc" under HOME contains the shim export line exactly once
+      Then the rc file ".zprofile" under HOME contains the shim export line exactly once
 
   Rule: User declines auto-PATH setup — rc file is not modified
 
@@ -211,10 +211,10 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
     Scenario: Declining PATH setup prints manual instructions and leaves rc unchanged
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zshrc" under HOME
+      And a shell rc file exists at ".zprofile" under HOME
       When I run "git-prism shim install" and decline PATH setup with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zshrc" under HOME is unchanged
+      And the rc file ".zprofile" under HOME is unchanged
       And the output contains ".local/share/git-prism/bin"
 
   Rule: Shim directory already in PATH — no prompt, no rc modification
@@ -223,10 +223,10 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
     Scenario: No PATH prompt when shim directory is already in PATH
       Given an isolated HOME directory
       And the shim directory is already in PATH
-      And a shell rc file exists at ".zshrc" under HOME
+      And a shell rc file exists at ".zprofile" under HOME
       When I run "git-prism shim install" with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zshrc" under HOME is unchanged
+      And the rc file ".zprofile" under HOME is unchanged
 
   # ===========================================================================
   # @ISSUE-326 — redirect hook removal (hard removal, no deprecation phase)

--- a/bdd/steps/shim_parity_steps.py
+++ b/bdd/steps/shim_parity_steps.py
@@ -479,7 +479,7 @@ def step_shim_install_consent(context: Context) -> None:
     """Run git-prism shim install, answering 'y' to the PATH setup prompt."""
     binary = _find_binary(context)
     env = _isolated_env(context)
-    # Pin SHELL to zsh so detect_rc_file always picks .zshrc, regardless of
+    # Pin SHELL to zsh so detect_rc_file always picks .zprofile, regardless of
     # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
     env["SHELL"] = "/bin/zsh"
     # If the shim dir was injected into PATH by a prior Given step, use that.
@@ -505,7 +505,7 @@ def step_shim_install_consent_again(context: Context) -> None:
     """Run git-prism shim install a second time with 'y' consent (idempotency check)."""
     binary = _find_binary(context)
     env = _isolated_env(context)
-    # Pin SHELL to zsh so detect_rc_file always picks .zshrc, regardless of
+    # Pin SHELL to zsh so detect_rc_file always picks .zprofile, regardless of
     # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
     env["SHELL"] = "/bin/zsh"
     result = subprocess.run(  # noqa: S603

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -256,6 +256,86 @@ pub(crate) fn stable_shim_target(canonical_exe: &Path) -> PathBuf {
     }
 }
 
+/// Classify what kind of obstacle (if any) sits at `link` before an install.
+///
+/// Returns:
+/// - `Ok(None)` — path is absent, proceed with creation.
+/// - `Ok(Some(AlreadyOwned))` — symlink already points at `target`, skip.
+/// - `Ok(Some(NeedsReplacement))` — stale/broken git-prism symlink or `force`
+///   is true; safe to remove and recreate.
+/// - `Err(_)` — foreign regular file or foreign symlink without `force`.
+#[derive(Debug)]
+enum InstallObstacle {
+    AlreadyOwned,
+    NeedsReplacement,
+}
+
+fn classify_install_obstacle(
+    link: &Path,
+    target: &Path,
+    force: bool,
+) -> Result<Option<InstallObstacle>> {
+    if !link.exists() && !link.is_symlink() {
+        return Ok(None);
+    }
+
+    let meta = link
+        .symlink_metadata()
+        .with_context(|| format!("failed to stat {}", link.display()))?;
+
+    if !meta.file_type().is_symlink() {
+        // Regular file — only allow clobber with --force.
+        if !force {
+            anyhow::bail!(
+                "{} is a regular file, not a symlink; remove it manually or re-run with --force",
+                link.display()
+            );
+        }
+        return Ok(Some(InstallObstacle::NeedsReplacement));
+    }
+
+    // Symlink — inspect the target.
+    match std::fs::read_link(link) {
+        Ok(existing_target) => {
+            if existing_target == target {
+                // Already correct — idempotent skip.
+                return Ok(Some(InstallObstacle::AlreadyOwned));
+            }
+            // A symlink pointing at something else.
+            // If the target is dangling (canonicalize fails), it is safe to
+            // replace unconditionally — the target is gone regardless of who
+            // originally owned it.
+            // If the target is live but not ours, it is a foreign symlink:
+            // refuse without --force, matching how we treat regular files.
+            match existing_target.canonicalize() {
+                Ok(canonical) if canonical != *target => {
+                    if !force {
+                        anyhow::bail!(
+                            "{} is a symlink pointing at {} which is not the git-prism \
+                             shim target; remove it manually or re-run with --force",
+                            link.display(),
+                            existing_target.display()
+                        );
+                    }
+                    Ok(Some(InstallObstacle::NeedsReplacement))
+                }
+                Ok(_) => {
+                    // Canonical target matches — git-prism-owned, stale raw path.
+                    Ok(Some(InstallObstacle::NeedsReplacement))
+                }
+                Err(_) => {
+                    // Dangling symlink — target is gone, always safe to replace.
+                    Ok(Some(InstallObstacle::NeedsReplacement))
+                }
+            }
+        }
+        Err(_) => {
+            // Broken symlink — always safe to replace.
+            Ok(Some(InstallObstacle::NeedsReplacement))
+        }
+    }
+}
+
 /// Create shim symlinks under `~/.local/share/git-prism/bin/` for every name
 /// in [`PATH_SHIM_LINK_NAMES`] (`git` and `gh`), each pointing at the running
 /// `git-prism` binary.
@@ -264,9 +344,11 @@ pub(crate) fn stable_shim_target(canonical_exe: &Path) -> PathBuf {
 /// unchanged. Returns the path of the first symlink (`git`) so callers can
 /// report it.
 ///
-/// If a regular file (not a symlink) already exists at any target path, this
-/// function returns an error rather than overwriting it — unless `force` is
-/// `true`, in which case the file is removed and the symlink is created.
+/// If a regular file (not a symlink) or a foreign symlink already exists at
+/// any target path, this function returns an error rather than overwriting it
+/// — unless `force` is `true`. The pre-flight check runs for ALL names before
+/// any filesystem mutation, so a refusal on `gh` never leaves `git` partially
+/// installed.
 pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     let shim_dir = home.join(PATH_SHIM_REL_DIR);
     std::fs::create_dir_all(&shim_dir)
@@ -291,47 +373,32 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     // up-to-date. For cargo-install / source builds the path is unchanged.
     let target = stable_shim_target(&canonical_exe);
 
+    // Pre-flight: validate ALL names before mutating any.  A refusal on the
+    // second name must not leave the first name half-installed.
+    let obstacles: Vec<Option<InstallObstacle>> = PATH_SHIM_LINK_NAMES
+        .iter()
+        .map(|name| classify_install_obstacle(&path_shim_link(home, name), &target, force))
+        .collect::<Result<_>>()?;
+
+    // Apply mutations only after all pre-flight checks passed.
     let mut first_link: Option<PathBuf> = None;
 
-    for name in PATH_SHIM_LINK_NAMES {
+    for (name, obstacle) in PATH_SHIM_LINK_NAMES.iter().zip(obstacles) {
         let link = path_shim_link(home, name);
 
-        if link.exists() || link.is_symlink() {
-            let meta = link
-                .symlink_metadata()
-                .with_context(|| format!("failed to stat {}", link.display()))?;
-
-            if !meta.file_type().is_symlink() {
-                if !force {
-                    anyhow::bail!(
-                        "{} is a regular file, not a symlink; remove it manually or re-run with --force",
-                        link.display()
-                    );
+        match obstacle {
+            Some(InstallObstacle::AlreadyOwned) => {
+                if first_link.is_none() {
+                    first_link = Some(link);
                 }
-                std::fs::remove_file(&link).with_context(|| {
-                    format!("failed to remove existing file {}", link.display())
-                })?;
-            } else {
-                match std::fs::read_link(&link) {
-                    Ok(existing_target) => {
-                        if existing_target == target {
-                            // Already correct — skip creation for this name.
-                            if first_link.is_none() {
-                                first_link = Some(link);
-                            }
-                            continue;
-                        }
-                        std::fs::remove_file(&link).with_context(|| {
-                            format!("failed to remove stale symlink {}", link.display())
-                        })?;
-                    }
-                    Err(e) => {
-                        std::fs::remove_file(&link).with_context(|| {
-                            format!("failed to remove broken symlink {}: {e}", link.display())
-                        })?;
-                    }
-                }
+                continue;
             }
+            Some(InstallObstacle::NeedsReplacement) => {
+                std::fs::remove_file(&link).with_context(|| {
+                    format!("failed to remove existing path {}", link.display())
+                })?;
+            }
+            None => {}
         }
 
         #[cfg(unix)]
@@ -349,59 +416,106 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     Ok(first_link.unwrap_or_else(|| path_shim_link(home, PATH_SHIM_LINK_NAMES[0])))
 }
 
+/// Classify whether a shim link is safe to remove during uninstall.
+///
+/// Returns `Ok(true)` when the link should be removed, `Ok(false)` when it is
+/// absent (nothing to do), and `Err` when it exists but is not git-prism-owned.
+fn is_uninstallable_shim(link: &Path, current_exe: &Path, shim_dir: &Path) -> Result<bool> {
+    if !link.exists() && !link.is_symlink() {
+        return Ok(false);
+    }
+
+    let meta = link
+        .symlink_metadata()
+        .with_context(|| format!("failed to stat {}", link.display()))?;
+
+    if !meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "{} is a regular file, not a symlink managed by git-prism; \
+             remove it manually if you want to clean up this path",
+            link.display()
+        );
+    }
+
+    match std::fs::read_link(link) {
+        Ok(raw_target) => {
+            // Try to canonicalize the target.  For a live symlink this resolves
+            // the real path; for a dangling symlink canonicalize fails.
+            match raw_target.canonicalize() {
+                Ok(canonical_target) => {
+                    if canonical_target != current_exe {
+                        anyhow::bail!(
+                            "{} is a symlink pointing at {} which is not the running \
+                             git-prism binary ({}); remove it manually if you want to \
+                             clean up this path",
+                            link.display(),
+                            canonical_target.display(),
+                            current_exe.display()
+                        );
+                    }
+                    // Canonical target matches — git-prism-owned.
+                    Ok(true)
+                }
+                Err(_) => {
+                    // Dangling symlink: the target no longer exists on disk.
+                    // The link lives in our managed bin dir, which we own
+                    // exclusively. A dangling link here was created by
+                    // git-prism (e.g. brew upgrade GC'd the Cellar binary)
+                    // and should be cleaned up.
+                    //
+                    // Safety: only links inside `shim_dir` are passed here;
+                    // we never remove dangling symlinks outside our managed
+                    // directory.
+                    debug_assert!(
+                        link.parent() == Some(shim_dir),
+                        "is_uninstallable_shim called for a link outside the managed shim dir"
+                    );
+                    Ok(true)
+                }
+            }
+        }
+        Err(_) => {
+            // read_link itself failed — treat as broken/dangling, same as above.
+            Ok(true)
+        }
+    }
+}
+
 /// Remove all shim symlinks under `~/.local/share/git-prism/bin/` (one per
 /// entry in [`PATH_SHIM_LINK_NAMES`]), then remove the parent directory if it
 /// is empty.
 ///
 /// Only removes a path when it is a symlink pointing at the running
-/// `git-prism` binary. If the path is a regular file (not owned by us) this
-/// function returns an error rather than silently deleting it.
+/// `git-prism` binary, or a dangling symlink inside the managed bin directory
+/// (which git-prism itself created — the post-`brew upgrade` GC scenario).
+/// Regular files and foreign symlinks cause an error rather than silent deletion.
+///
+/// The pre-flight check validates ALL names before any filesystem mutation so
+/// that a refusal on one name never leaves sibling links in a partially-removed
+/// state.
 pub fn uninstall_path_shim(home: &Path) -> Result<()> {
     let current_exe = std::env::current_exe()
         .context("failed to resolve current executable path")?
         .canonicalize()
         .context("failed to canonicalize current executable path")?;
 
-    for name in PATH_SHIM_LINK_NAMES {
-        let link = path_shim_link(home, name);
+    let shim_dir = home.join(PATH_SHIM_REL_DIR);
 
-        if link.exists() || link.is_symlink() {
-            let meta = link
-                .symlink_metadata()
-                .with_context(|| format!("failed to stat {}", link.display()))?;
+    // Pre-flight: validate every name before removing any.
+    let should_remove: Vec<bool> = PATH_SHIM_LINK_NAMES
+        .iter()
+        .map(|name| is_uninstallable_shim(&path_shim_link(home, name), &current_exe, &shim_dir))
+        .collect::<Result<_>>()?;
 
-            if !meta.file_type().is_symlink() {
-                anyhow::bail!(
-                    "{} is a regular file, not a symlink managed by git-prism; \
-                     remove it manually if you want to clean up this path",
-                    link.display()
-                );
-            }
-
-            match std::fs::read_link(&link) {
-                Ok(target) => {
-                    let canonical_target = target.canonicalize().unwrap_or(target);
-                    if canonical_target != current_exe {
-                        anyhow::bail!(
-                            "{} is a symlink pointing at {} which is not the running git-prism binary ({}); \
-                             remove it manually if you want to clean up this path",
-                            link.display(),
-                            canonical_target.display(),
-                            current_exe.display()
-                        );
-                    }
-                }
-                Err(_) => {
-                    // Broken symlink — safe to remove (target doesn't exist anyway).
-                }
-            }
-
+    // Apply removals only after all checks passed.
+    for (name, remove) in PATH_SHIM_LINK_NAMES.iter().zip(should_remove) {
+        if remove {
+            let link = path_shim_link(home, name);
             std::fs::remove_file(&link)
                 .with_context(|| format!("failed to remove symlink {}", link.display()))?;
         }
     }
 
-    let shim_dir = home.join(PATH_SHIM_REL_DIR);
     if shim_dir.exists() {
         let is_empty = shim_dir
             .read_dir()
@@ -1102,6 +1216,254 @@ mod tests {
             user_content,
             "install_path_shim silently overwrote a regular file at {}",
             user_file.display()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Adversarial QA — gh symlink (issue #347): partial-state / mixed-ownership
+    // -------------------------------------------------------------------------
+
+    /// PARTIAL-STATE BUG (uninstall): when the `git` link is git-prism-owned but
+    /// the `gh` link is a FOREIGN symlink (points at some other binary),
+    /// `uninstall_path_shim` processes `git` first and removes it, THEN bails on
+    /// `gh`. Result: the user's `git` interception silently vanishes while the
+    /// error message only talks about `gh`. Uninstall should either be
+    /// all-or-nothing, or at minimum must not tear down a valid managed link
+    /// when it is going to abort on a sibling it refuses to touch.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_uninstall_must_not_remove_git_link_when_bailing_on_foreign_gh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        // Both links created pointing at the running binary (git-prism owned).
+        install_path_shim(home, false).unwrap();
+
+        // Replace the `gh` link with a FOREIGN symlink (a target that is not the
+        // running git-prism binary).
+        let gh_link = home.join(".local/share/git-prism/bin/gh");
+        let foreign_target = dir.path().join("some-other-binary");
+        std::fs::write(&foreign_target, b"not git-prism").unwrap();
+        std::fs::remove_file(&gh_link).unwrap();
+        std::os::unix::fs::symlink(&foreign_target, &gh_link).unwrap();
+
+        let git_link = home.join(".local/share/git-prism/bin/git");
+        assert!(git_link.is_symlink(), "precondition: git link exists");
+
+        // Uninstall MUST refuse (foreign gh) — that part is expected.
+        let result = uninstall_path_shim(home);
+        assert!(
+            result.is_err(),
+            "uninstall must error when gh is a foreign symlink"
+        );
+
+        // BUG: the git link is gone even though uninstall aborted. The managed
+        // `git` interception was torn down as a side effect of a refused
+        // operation, leaving the system in a half-uninstalled state.
+        assert!(
+            git_link.is_symlink(),
+            "uninstall removed the git symlink while bailing on a foreign gh link; \
+             refused-uninstall left a partial state"
+        );
+    }
+
+    /// PARTIAL-STATE BUG (install): when `gh` is a regular user file and `git`
+    /// does not yet exist, `install_path_shim(force=false)` processes `git`
+    /// first — creating the symlink — and only THEN reaches `gh`, where it
+    /// bails. Result: install reports an error but has already created the
+    /// `git` symlink. A failed install should not leave a half-installed state.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_install_must_not_create_git_link_when_bailing_on_regular_gh_file() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // A regular (non-symlink) user file sits at the `gh` target. No `git`
+        // link exists yet.
+        let gh_file = shim_dir.join("gh");
+        std::fs::write(&gh_file, b"USER OWNS THIS gh FILE\n").unwrap();
+
+        let result = install_path_shim(home, false);
+        assert!(
+            result.is_err(),
+            "install must error when gh is a regular file and force is false"
+        );
+
+        // BUG: install aborted (returned Err) but already created the git
+        // symlink during the first loop iteration, leaving a partial install.
+        let git_link = shim_dir.join("git");
+        assert!(
+            !git_link.exists() && !git_link.is_symlink(),
+            "install created the git symlink despite aborting on the gh regular file; \
+             failed install left a partial state"
+        );
+    }
+
+    /// DANGLING-LINK BUG (uninstall): a git-prism-created shim symlink whose
+    /// target was later removed (e.g. `brew upgrade` GC'd the Cellar binary —
+    /// the very scenario the staleness advisory in this file addresses) becomes
+    /// a dangling symlink. `uninstall_path_shim` cannot remove it: `read_link`
+    /// returns Ok(dangling_target), `canonicalize()` of that target fails and
+    /// falls back to the raw path, which never equals `current_exe`, so the
+    /// function BAILS with "is not the running git-prism binary". The inline
+    /// comment ("Broken symlink — safe to remove") proves the intended behavior
+    /// is to remove it, but the code never reaches that Err branch for a
+    /// dangling link. The user is left unable to clean up a shim git-prism
+    /// itself created.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_uninstall_must_remove_dangling_git_prism_owned_symlink() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // Simulate a git-prism shim install whose target was GC'd: a dangling
+        // symlink under the managed bin dir.
+        let dangling_target = home.join("Cellar/git-prism/0.9.0/bin/git-prism");
+        let git_link = shim_dir.join("git");
+        std::os::unix::fs::symlink(&dangling_target, &git_link).unwrap();
+        assert!(git_link.is_symlink(), "precondition: dangling git link");
+        assert!(!git_link.exists(), "precondition: target is gone");
+
+        let result = uninstall_path_shim(home);
+
+        // BUG: uninstall errors instead of cleaning up the dangling link.
+        assert!(
+            result.is_ok(),
+            "uninstall failed to remove a dangling git-prism-owned symlink: {:?}",
+            result.err()
+        );
+        assert!(
+            !git_link.is_symlink(),
+            "dangling shim symlink was left in place after uninstall"
+        );
+    }
+
+    /// TRIANGULATION: uninstall partial-state — git is foreign, gh is owned.
+    /// The git-prism-owned `gh` link must NOT be removed when the git link
+    /// is foreign and causes a refusal (reverse order of the primary test).
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_uninstall_must_not_remove_gh_link_when_bailing_on_foreign_git() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+
+        // Replace `git` with a foreign symlink.
+        let git_link = home.join(".local/share/git-prism/bin/git");
+        let foreign_target = dir.path().join("foreign-binary");
+        std::fs::write(&foreign_target, b"not git-prism").unwrap();
+        std::fs::remove_file(&git_link).unwrap();
+        std::os::unix::fs::symlink(&foreign_target, &git_link).unwrap();
+
+        let gh_link = home.join(".local/share/git-prism/bin/gh");
+        assert!(gh_link.is_symlink(), "precondition: gh link exists");
+
+        let result = uninstall_path_shim(home);
+        assert!(
+            result.is_err(),
+            "uninstall must error on foreign git symlink"
+        );
+
+        // gh must not have been removed — the refusal on git must have
+        // pre-flighted before any mutation.
+        assert!(
+            gh_link.is_symlink(),
+            "uninstall removed gh symlink while bailing on foreign git; partial state"
+        );
+    }
+
+    /// TRIANGULATION: install partial-state — git is the obstacle, not gh.
+    /// When git already has a foreign symlink, install must refuse BEFORE
+    /// creating anything (including gh).
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_install_must_not_create_gh_link_when_bailing_on_foreign_git_symlink() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // Foreign symlink at git, nothing at gh.
+        let foreign_target = dir.path().join("foreign-binary");
+        std::fs::write(&foreign_target, b"not git-prism").unwrap();
+        let git_link = shim_dir.join("git");
+        std::os::unix::fs::symlink(&foreign_target, &git_link).unwrap();
+
+        let result = install_path_shim(home, false);
+        assert!(result.is_err(), "install must error on foreign git symlink");
+
+        // gh must not have been created.
+        let gh_link = shim_dir.join("gh");
+        assert!(
+            !gh_link.exists() && !gh_link.is_symlink(),
+            "install created gh symlink despite aborting on foreign git; partial state"
+        );
+    }
+
+    /// TRIANGULATION: install with --force on a foreign symlink must succeed
+    /// and replace the foreign link.
+    #[test]
+    #[cfg(unix)]
+    fn install_with_force_replaces_foreign_symlink() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        let foreign_target = dir.path().join("foreign-gh");
+        std::fs::write(&foreign_target, b"user's gh").unwrap();
+        let gh_link = shim_dir.join("gh");
+        std::os::unix::fs::symlink(&foreign_target, &gh_link).unwrap();
+
+        install_path_shim(home, true).unwrap();
+
+        // gh must now point at the git-prism shim target, not the foreign binary.
+        let new_target = std::fs::read_link(&gh_link).unwrap();
+        assert_ne!(
+            new_target, foreign_target,
+            "install --force must replace foreign symlink with git-prism shim"
+        );
+    }
+
+    /// ASYMMETRY BUG (install clobbers foreign symlinks without --force): the
+    /// `--force` guard only protects REGULAR files. A user-created foreign
+    /// SYMLINK at the `gh` (or `git`) target — e.g. `gh` -> their own gh
+    /// wrapper — is silently removed and replaced by `install_path_shim` even
+    /// when `force` is false, with no error and no warning. This is
+    /// inconsistent with `uninstall_path_shim`, which REFUSES to touch a
+    /// foreign symlink. Install should refuse a foreign symlink without
+    /// `--force`, the same way it refuses a regular file.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_install_must_not_clobber_foreign_symlink_without_force() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // A user's pre-existing foreign symlink at the gh target.
+        let users_gh = dir.path().join("users-own-gh");
+        std::fs::write(&users_gh, b"user's gh wrapper").unwrap();
+        let gh_link = shim_dir.join("gh");
+        std::os::unix::fs::symlink(&users_gh, &gh_link).unwrap();
+
+        let result = install_path_shim(home, false);
+
+        // Without --force, install must NOT silently clobber the user's foreign
+        // symlink. Either it errors, or it leaves the user's symlink intact.
+        let still_points_at_users_target = std::fs::read_link(&gh_link)
+            .map(|t| t == users_gh)
+            .unwrap_or(false);
+        assert!(
+            result.is_err() || still_points_at_users_target,
+            "install silently replaced a user's foreign gh symlink without --force \
+             (result={result:?}); the --force guard only protects regular files, not \
+             foreign symlinks"
         );
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -167,8 +167,11 @@ pub fn uninstall_redirect_hook(scope: Scope, home: &Path, cwd: &Path) -> Result<
 /// Relative to `$HOME`.
 pub const PATH_SHIM_REL_DIR: &str = ".local/share/git-prism/bin";
 
-/// Name of the git shim symlink inside `PATH_SHIM_REL_DIR`.
-pub const PATH_SHIM_LINK_NAME: &str = "git";
+/// Names of the shim symlinks managed inside `PATH_SHIM_REL_DIR`.
+///
+/// Both `git` and `gh` are intercepted by the running `git-prism` binary.
+/// Install/status/uninstall iterate over every name in this slice.
+pub const PATH_SHIM_LINK_NAMES: &[&str] = &["git", "gh"];
 
 /// Status of the path-shim symlink reported by `hooks status`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,9 +191,9 @@ pub enum PathShimStatus {
     BrokenLink { reason: String },
 }
 
-/// Return the expected path to the shim symlink: `$HOME/.local/share/git-prism/bin/git`.
-fn path_shim_link(home: &Path) -> PathBuf {
-    home.join(PATH_SHIM_REL_DIR).join(PATH_SHIM_LINK_NAME)
+/// Return the expected path to a shim symlink: `$HOME/.local/share/git-prism/bin/<name>`.
+fn path_shim_link(home: &Path, name: &str) -> PathBuf {
+    home.join(PATH_SHIM_REL_DIR).join(name)
 }
 
 /// Given the canonicalized current-exe path, return a stable shim target.
@@ -253,13 +256,15 @@ pub(crate) fn stable_shim_target(canonical_exe: &Path) -> PathBuf {
     }
 }
 
-/// Create `~/.local/share/git-prism/bin/git` as a symlink pointing at the
-/// running `git-prism` binary.
+/// Create shim symlinks under `~/.local/share/git-prism/bin/` for every name
+/// in [`PATH_SHIM_LINK_NAMES`] (`git` and `gh`), each pointing at the running
+/// `git-prism` binary.
 ///
-/// Idempotent: if the symlink already exists and points at the current binary,
-/// this is a no-op. Returns the symlink path so callers can report it.
+/// Idempotent: symlinks that already point at the current binary are left
+/// unchanged. Returns the path of the first symlink (`git`) so callers can
+/// report it.
 ///
-/// If a regular file (not a symlink) already exists at the target path, this
+/// If a regular file (not a symlink) already exists at any target path, this
 /// function returns an error rather than overwriting it — unless `force` is
 /// `true`, in which case the file is removed and the symlink is created.
 pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
@@ -286,98 +291,114 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     // up-to-date. For cargo-install / source builds the path is unchanged.
     let target = stable_shim_target(&canonical_exe);
 
-    let link = path_shim_link(home);
+    let mut first_link: Option<PathBuf> = None;
 
-    if link.exists() || link.is_symlink() {
-        let meta = link
-            .symlink_metadata()
-            .with_context(|| format!("failed to stat {}", link.display()))?;
+    for name in PATH_SHIM_LINK_NAMES {
+        let link = path_shim_link(home, name);
 
-        if !meta.file_type().is_symlink() {
-            if !force {
-                anyhow::bail!(
-                    "{} is a regular file, not a symlink; remove it manually or re-run with --force",
-                    link.display()
-                );
-            }
-            std::fs::remove_file(&link)
-                .with_context(|| format!("failed to remove existing file {}", link.display()))?;
-        } else {
-            match std::fs::read_link(&link) {
-                Ok(existing_target) => {
-                    if existing_target == target {
-                        return Ok(link);
+        if link.exists() || link.is_symlink() {
+            let meta = link
+                .symlink_metadata()
+                .with_context(|| format!("failed to stat {}", link.display()))?;
+
+            if !meta.file_type().is_symlink() {
+                if !force {
+                    anyhow::bail!(
+                        "{} is a regular file, not a symlink; remove it manually or re-run with --force",
+                        link.display()
+                    );
+                }
+                std::fs::remove_file(&link).with_context(|| {
+                    format!("failed to remove existing file {}", link.display())
+                })?;
+            } else {
+                match std::fs::read_link(&link) {
+                    Ok(existing_target) => {
+                        if existing_target == target {
+                            // Already correct — skip creation for this name.
+                            if first_link.is_none() {
+                                first_link = Some(link);
+                            }
+                            continue;
+                        }
+                        std::fs::remove_file(&link).with_context(|| {
+                            format!("failed to remove stale symlink {}", link.display())
+                        })?;
                     }
-                    std::fs::remove_file(&link).with_context(|| {
-                        format!("failed to remove stale symlink {}", link.display())
-                    })?;
-                }
-                Err(e) => {
-                    std::fs::remove_file(&link).with_context(|| {
-                        format!("failed to remove broken symlink {}: {e}", link.display())
-                    })?;
+                    Err(e) => {
+                        std::fs::remove_file(&link).with_context(|| {
+                            format!("failed to remove broken symlink {}: {e}", link.display())
+                        })?;
+                    }
                 }
             }
+        }
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link)
+            .with_context(|| format!("failed to create symlink {}", link.display()))?;
+
+        #[cfg(not(unix))]
+        anyhow::bail!("path-shim install is not supported on non-Unix platforms");
+
+        if first_link.is_none() {
+            first_link = Some(link);
         }
     }
 
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(&target, &link)
-        .with_context(|| format!("failed to create symlink {}", link.display()))?;
-
-    #[cfg(not(unix))]
-    anyhow::bail!("path-shim install is not supported on non-Unix platforms");
-
-    Ok(link)
+    Ok(first_link.unwrap_or_else(|| path_shim_link(home, PATH_SHIM_LINK_NAMES[0])))
 }
 
-/// Remove `~/.local/share/git-prism/bin/git` if it exists, then remove the
-/// parent directory if it is empty.
+/// Remove all shim symlinks under `~/.local/share/git-prism/bin/` (one per
+/// entry in [`PATH_SHIM_LINK_NAMES`]), then remove the parent directory if it
+/// is empty.
 ///
-/// Only removes the path when it is a symlink pointing at the running
+/// Only removes a path when it is a symlink pointing at the running
 /// `git-prism` binary. If the path is a regular file (not owned by us) this
 /// function returns an error rather than silently deleting it.
 pub fn uninstall_path_shim(home: &Path) -> Result<()> {
-    let link = path_shim_link(home);
+    let current_exe = std::env::current_exe()
+        .context("failed to resolve current executable path")?
+        .canonicalize()
+        .context("failed to canonicalize current executable path")?;
 
-    if link.exists() || link.is_symlink() {
-        let meta = link
-            .symlink_metadata()
-            .with_context(|| format!("failed to stat {}", link.display()))?;
+    for name in PATH_SHIM_LINK_NAMES {
+        let link = path_shim_link(home, name);
 
-        if !meta.file_type().is_symlink() {
-            anyhow::bail!(
-                "{} is a regular file, not a symlink managed by git-prism; \
-                 remove it manually if you want to clean up this path",
-                link.display()
-            );
-        }
+        if link.exists() || link.is_symlink() {
+            let meta = link
+                .symlink_metadata()
+                .with_context(|| format!("failed to stat {}", link.display()))?;
 
-        let current_exe = std::env::current_exe()
-            .context("failed to resolve current executable path")?
-            .canonicalize()
-            .context("failed to canonicalize current executable path")?;
+            if !meta.file_type().is_symlink() {
+                anyhow::bail!(
+                    "{} is a regular file, not a symlink managed by git-prism; \
+                     remove it manually if you want to clean up this path",
+                    link.display()
+                );
+            }
 
-        match std::fs::read_link(&link) {
-            Ok(target) => {
-                let canonical_target = target.canonicalize().unwrap_or(target);
-                if canonical_target != current_exe {
-                    anyhow::bail!(
-                        "{} is a symlink pointing at {} which is not the running git-prism binary ({}); \
-                         remove it manually if you want to clean up this path",
-                        link.display(),
-                        canonical_target.display(),
-                        current_exe.display()
-                    );
+            match std::fs::read_link(&link) {
+                Ok(target) => {
+                    let canonical_target = target.canonicalize().unwrap_or(target);
+                    if canonical_target != current_exe {
+                        anyhow::bail!(
+                            "{} is a symlink pointing at {} which is not the running git-prism binary ({}); \
+                             remove it manually if you want to clean up this path",
+                            link.display(),
+                            canonical_target.display(),
+                            current_exe.display()
+                        );
+                    }
+                }
+                Err(_) => {
+                    // Broken symlink — safe to remove (target doesn't exist anyway).
                 }
             }
-            Err(_) => {
-                // Broken symlink — safe to remove (target doesn't exist anyway).
-            }
-        }
 
-        std::fs::remove_file(&link)
-            .with_context(|| format!("failed to remove symlink {}", link.display()))?;
+            std::fs::remove_file(&link)
+                .with_context(|| format!("failed to remove symlink {}", link.display()))?;
+        }
     }
 
     let shim_dir = home.join(PATH_SHIM_REL_DIR);
@@ -407,9 +428,17 @@ pub(crate) const CELLAR_STALENESS_ADVISORY: &str = "shim points at a version-pin
      run `git-prism shim install` to update to a stable path \
      that survives `brew upgrade`";
 
-/// Query the current state of the path-shim symlink without modifying anything.
+/// Query the current state of the `git` shim symlink without modifying anything.
+///
+/// This is a convenience wrapper around [`path_shim_status_for`] for the `git`
+/// symlink, used by tests and the legacy CLI path.
 pub fn path_shim_status(home: &Path) -> PathShimStatus {
-    let link = path_shim_link(home);
+    path_shim_status_for(home, PATH_SHIM_LINK_NAMES[0])
+}
+
+/// Query the current state of the named shim symlink without modifying anything.
+pub fn path_shim_status_for(home: &Path, name: &str) -> PathShimStatus {
+    let link = path_shim_link(home, name);
     if !link.exists() && !link.is_symlink() {
         return PathShimStatus::NotInstalled;
     }
@@ -734,7 +763,7 @@ mod tests {
         // Install the shim pointing directly at the Cellar path.
         let shim_dir = home.join(PATH_SHIM_REL_DIR);
         std::fs::create_dir_all(&shim_dir).unwrap();
-        let link = shim_dir.join(PATH_SHIM_LINK_NAME);
+        let link = shim_dir.join(PATH_SHIM_LINK_NAMES[0]);
         std::os::unix::fs::symlink(&cellar_exe, &link).unwrap();
 
         let status = path_shim_status(home);
@@ -766,7 +795,7 @@ mod tests {
 
         let shim_dir = home.join(PATH_SHIM_REL_DIR);
         std::fs::create_dir_all(&shim_dir).unwrap();
-        let link = shim_dir.join(PATH_SHIM_LINK_NAME);
+        let link = shim_dir.join(PATH_SHIM_LINK_NAMES[0]);
         std::os::unix::fs::symlink(&stable_exe, &link).unwrap();
 
         let status = path_shim_status(home);
@@ -948,6 +977,83 @@ mod tests {
         assert_eq!(
             result, short,
             "path with n<6 components must be returned unchanged; got {result:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // gh symlink — install/status/uninstall manage both git and gh
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn install_path_shim_creates_gh_symlink() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+
+        let link = home.join(".local/share/git-prism/bin/gh");
+        assert!(
+            link.is_symlink(),
+            "expected a gh symlink at {}",
+            link.display()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn install_path_shim_creates_both_symlinks_pointing_at_same_target() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+
+        let git_link = home.join(".local/share/git-prism/bin/git");
+        let gh_link = home.join(".local/share/git-prism/bin/gh");
+        assert!(git_link.is_symlink(), "git symlink must exist");
+        assert!(gh_link.is_symlink(), "gh symlink must exist");
+        assert_eq!(
+            std::fs::read_link(&git_link).unwrap(),
+            std::fs::read_link(&gh_link).unwrap(),
+            "git and gh symlinks must point at the same target"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn uninstall_path_shim_removes_both_symlinks() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+        uninstall_path_shim(home).unwrap();
+
+        let git_link = home.join(".local/share/git-prism/bin/git");
+        let gh_link = home.join(".local/share/git-prism/bin/gh");
+        assert!(
+            !git_link.exists() && !git_link.is_symlink(),
+            "git symlink must be removed"
+        );
+        assert!(
+            !gh_link.exists() && !gh_link.is_symlink(),
+            "gh symlink must be removed"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn install_path_shim_is_idempotent_for_gh_symlink() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+        let target_before = std::fs::read_link(home.join(".local/share/git-prism/bin/gh")).unwrap();
+        install_path_shim(home, false).unwrap();
+        let target_after = std::fs::read_link(home.join(".local/share/git-prism/bin/gh")).unwrap();
+
+        assert_eq!(
+            target_before, target_after,
+            "idempotent re-install must not change the gh symlink target"
         );
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -273,6 +273,7 @@ enum InstallObstacle {
 fn classify_install_obstacle(
     link: &Path,
     target: &Path,
+    shim_dir: &Path,
     force: bool,
 ) -> Result<Option<InstallObstacle>> {
     if !link.exists() && !link.is_symlink() {
@@ -324,7 +325,21 @@ fn classify_install_obstacle(
                     Ok(Some(InstallObstacle::NeedsReplacement))
                 }
                 Err(_) => {
-                    // Dangling symlink — target is gone, always safe to replace.
+                    // Dangling symlink — target no longer exists on disk.
+                    // Check raw target provenance: only treat the link as
+                    // git-prism-owned (safe to replace) when its raw target
+                    // is recognisably ours. A dangling link whose raw target
+                    // is foreign is treated like a live foreign symlink —
+                    // refuse without --force.
+                    if !dangling_target_is_git_prism_owned(&existing_target, shim_dir) && !force {
+                        anyhow::bail!(
+                            "{} is a dangling symlink pointing at {} which is outside \
+                             the git-prism managed directory; remove it manually or \
+                             re-run with --force",
+                            link.display(),
+                            existing_target.display()
+                        );
+                    }
                     Ok(Some(InstallObstacle::NeedsReplacement))
                 }
             }
@@ -377,7 +392,9 @@ pub fn install_path_shim(home: &Path, force: bool) -> Result<PathBuf> {
     // second name must not leave the first name half-installed.
     let obstacles: Vec<Option<InstallObstacle>> = PATH_SHIM_LINK_NAMES
         .iter()
-        .map(|name| classify_install_obstacle(&path_shim_link(home, name), &target, force))
+        .map(|name| {
+            classify_install_obstacle(&path_shim_link(home, name), &target, &shim_dir, force)
+        })
         .collect::<Result<_>>()?;
 
     // Apply mutations only after all pre-flight checks passed.
@@ -458,18 +475,24 @@ fn is_uninstallable_shim(link: &Path, current_exe: &Path, shim_dir: &Path) -> Re
                 }
                 Err(_) => {
                     // Dangling symlink: the target no longer exists on disk.
-                    // The link lives in our managed bin dir, which we own
-                    // exclusively. A dangling link here was created by
-                    // git-prism (e.g. brew upgrade GC'd the Cellar binary)
-                    // and should be cleaned up.
-                    //
-                    // Safety: only links inside `shim_dir` are passed here;
-                    // we never remove dangling symlinks outside our managed
-                    // directory.
+                    // Check raw target provenance: only remove the link when
+                    // its raw target is recognisably git-prism-owned (the
+                    // brew-upgrade GC scenario). A dangling link whose raw
+                    // target is foreign is treated like a live foreign
+                    // symlink — refuse to remove it.
                     debug_assert!(
                         link.parent() == Some(shim_dir),
                         "is_uninstallable_shim called for a link outside the managed shim dir"
                     );
+                    if !dangling_target_is_git_prism_owned(&raw_target, shim_dir) {
+                        anyhow::bail!(
+                            "{} is a dangling symlink pointing at {} which is outside \
+                             the git-prism managed directory; remove it manually if \
+                             you want to clean up this path",
+                            link.display(),
+                            raw_target.display()
+                        );
+                    }
                     Ok(true)
                 }
             }
@@ -535,6 +558,26 @@ pub fn uninstall_path_shim(home: &Path) -> Result<()> {
 /// version-pinned Homebrew Cellar path that will break after `brew upgrade`.
 fn path_contains_cellar_component(path: &Path) -> bool {
     path.components().any(|c| c.as_os_str() == "Cellar")
+}
+
+/// Return true when a dangling symlink's raw (unresolved) `target` is
+/// recognisably owned by git-prism and therefore safe to remove or replace.
+///
+/// A target is git-prism-owned when it either:
+/// - Lives inside `shim_dir` itself (e.g. a relative shim pointing back into
+///   the managed bin directory), or
+/// - Contains a `git-prism` path component (covers `brew`-installed Cellar
+///   paths such as `.../Cellar/git-prism/0.9.0/bin/git-prism` that get GC'd
+///   after `brew upgrade`).
+///
+/// Any other dangling target (e.g. a user's own wrapper that has since been
+/// moved) is treated as a foreign symlink that must not be touched without
+/// explicit user action.
+fn dangling_target_is_git_prism_owned(raw_target: &Path, shim_dir: &Path) -> bool {
+    raw_target.starts_with(shim_dir)
+        || raw_target
+            .components()
+            .any(|c| c.as_os_str() == "git-prism")
 }
 
 /// The advisory message shown when a shim target is a version-pinned Cellar path.
@@ -781,13 +824,18 @@ mod tests {
         let shim_dir = home.join(".local/share/git-prism/bin");
         std::fs::create_dir_all(&shim_dir).unwrap();
         let link = shim_dir.join("git");
-        std::os::unix::fs::symlink("/nonexistent/old-binary", &link).unwrap();
+        // Simulate a previously-installed git-prism shim whose target was GC'd
+        // by `brew upgrade` — the raw target contains "git-prism" in its path,
+        // making it recognisably ours.  The dangling-ownership check must allow
+        // this to be replaced without --force.
+        let stale_target = "/nonexistent/Cellar/git-prism/0.8.0/bin/git-prism";
+        std::os::unix::fs::symlink(stale_target, &link).unwrap();
 
         install_path_shim(home, false).unwrap();
 
         assert!(link.is_symlink());
         let target = std::fs::read_link(&link).unwrap();
-        assert_ne!(target, std::path::Path::new("/nonexistent/old-binary"));
+        assert_ne!(target, std::path::Path::new(stale_target));
     }
 
     #[test]
@@ -1464,6 +1512,106 @@ mod tests {
             "install silently replaced a user's foreign gh symlink without --force \
              (result={result:?}); the --force guard only protects regular files, not \
              foreign symlinks"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Adversarial QA pass 2 — probing the validate-then-apply refactor
+    // -------------------------------------------------------------------------
+
+    /// PASS-2 PROBE (install asymmetry — dangling foreign symlink): the pass-1
+    /// fix made `install_path_shim` REFUSE to clobber a *live* foreign symlink
+    /// without `--force` (matching uninstall). But `classify_install_obstacle`
+    /// treats a symlink whose target fails to canonicalize (a DANGLING symlink)
+    /// as `NeedsReplacement` UNCONDITIONALLY — ignoring `force`. So a user's
+    /// pre-existing foreign symlink that happens to be dangling (its target was
+    /// renamed/removed) is silently deleted and replaced on a plain
+    /// `install_path_shim(home, false)`, with no error.
+    ///
+    /// This is the same asymmetry the pass-1 "clobber foreign symlink" fix
+    /// closed for live links, but left open for dangling ones. A live foreign
+    /// link is protected; a dangling foreign link is not.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_install_must_not_clobber_dangling_foreign_symlink_without_force() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // A user's foreign symlink at `gh` whose target does NOT exist (dangling).
+        // e.g. they symlinked their own gh wrapper which they later moved.
+        let users_missing_target = dir.path().join("users-own-gh-wrapper-now-moved");
+        let gh_link = shim_dir.join("gh");
+        std::os::unix::fs::symlink(&users_missing_target, &gh_link).unwrap();
+        assert!(
+            gh_link.is_symlink(),
+            "precondition: dangling foreign gh link"
+        );
+        assert!(!gh_link.exists(), "precondition: its target is gone");
+
+        let result = install_path_shim(home, false);
+
+        // Without --force, install must NOT silently clobber the user's foreign
+        // symlink just because it happens to be dangling. Either it errors, or it
+        // leaves the user's symlink pointing where it was.
+        let still_points_at_users_target = std::fs::read_link(&gh_link)
+            .map(|t| t == users_missing_target)
+            .unwrap_or(false);
+        assert!(
+            result.is_err() || still_points_at_users_target,
+            "install silently replaced a user's DANGLING foreign gh symlink without \
+             --force (result={result:?}); classify_install_obstacle treats any \
+             canonicalize-failure as NeedsReplacement, bypassing the --force guard \
+             that protects live foreign symlinks"
+        );
+    }
+
+    /// PASS-2 PROBE (uninstall over-correction — dangling link pointing OUTSIDE
+    /// the managed dir at a non-git-prism path): the pass-1 fix for bug 3 made
+    /// `uninstall_path_shim` remove dangling symlinks inside the managed bin
+    /// dir, on the theory that git-prism owns that dir exclusively. But the
+    /// dangling branch removes the link regardless of where it POINTED — so a
+    /// foreign dangling symlink (a user's own link to an external wrapper that
+    /// later vanished) is deleted by `uninstall`, even though uninstall REFUSES
+    /// to remove a *live* foreign symlink. The `debug_assert` only checks the
+    /// link's parent dir, never the target's provenance.
+    ///
+    /// This test documents the over-correction the task asked about: does the
+    /// fix delete something it shouldn't? It removes a dangling link that points
+    /// at a clearly non-git-prism external path.
+    #[test]
+    #[cfg(unix)]
+    fn adversarial_uninstall_removes_dangling_link_pointing_outside_managed_dir() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+
+        // A user's own foreign symlink at `git`, pointing at an EXTERNAL wrapper
+        // outside the managed dir, whose target has since been removed (dangling).
+        let external_target = dir.path().join("opt/some-tool/bin/git-wrapper");
+        let git_link = shim_dir.join("git");
+        std::os::unix::fs::symlink(&external_target, &git_link).unwrap();
+        assert!(
+            git_link.is_symlink(),
+            "precondition: dangling foreign git link"
+        );
+        assert!(!git_link.exists(), "precondition: external target is gone");
+
+        let _ = uninstall_path_shim(home);
+
+        // Symmetry expectation: uninstall refuses to remove a LIVE foreign
+        // symlink (it errors). A dangling foreign symlink that points outside
+        // the managed dir should be treated with the same caution rather than
+        // silently deleted. Currently it is deleted unconditionally.
+        assert!(
+            git_link.is_symlink(),
+            "uninstall removed a dangling symlink that points OUTSIDE the managed dir \
+             at a non-git-prism path ({}); the dangling branch removes by directory \
+             membership alone, ignoring the target's provenance — over-correcting the \
+             bug-3 fix",
+            external_target.display()
         );
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -497,8 +497,15 @@ fn is_uninstallable_shim(link: &Path, current_exe: &Path, shim_dir: &Path) -> Re
                 }
             }
         }
-        Err(_) => {
+        Err(e) => {
             // read_link itself failed — treat as broken/dangling, same as above.
+            // Surface the underlying errno so that if the subsequent remove_file
+            // also fails, the user has the original cause (e.g. EACCES on the
+            // parent dir) instead of a bare "broken link" assumption with no trail.
+            eprintln!(
+                "git-prism: could not read symlink {} ({e}); treating as broken and removing",
+                link.display()
+            );
             Ok(true)
         }
     }
@@ -797,6 +804,13 @@ mod tests {
             "expected a symlink at {}",
             link.display()
         );
+        // is_symlink() alone passes even for a symlink pointing at nowhere.
+        // The link must point at the running git-prism binary.
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            expected_shim_target(),
+            "git symlink must point at the git-prism binary"
+        );
     }
 
     #[test]
@@ -806,12 +820,21 @@ mod tests {
         let home = dir.path();
 
         install_path_shim(home, false).unwrap();
+        let link = home.join(".local/share/git-prism/bin/git");
+        let target_before = std::fs::read_link(&link).unwrap();
+
         install_path_shim(home, false).unwrap();
 
-        let link = home.join(".local/share/git-prism/bin/git");
         assert!(
             link.is_symlink(),
             "symlink must still exist after second install"
+        );
+        // Idempotency means the target is UNCHANGED, not merely that some
+        // symlink survives. A second install must leave the git target alone.
+        let target_after = std::fs::read_link(&link).unwrap();
+        assert_eq!(
+            target_before, target_after,
+            "idempotent re-install must not change the git symlink target"
         );
     }
 
@@ -836,6 +859,28 @@ mod tests {
         assert!(link.is_symlink());
         let target = std::fs::read_link(&link).unwrap();
         assert_ne!(target, std::path::Path::new(stale_target));
+        // assert_ne! alone is satisfied by ANY non-stale target (even garbage).
+        // Pin it: the replacement must point at the running git-prism binary,
+        // i.e. exactly the target install_path_shim computes for a fresh install.
+        let expected = expected_shim_target();
+        assert_eq!(
+            target, expected,
+            "stale replacement must repoint at the current git-prism binary, not just away from the stale path"
+        );
+    }
+
+    /// The shim target `install_path_shim` writes for a fresh install: the
+    /// canonicalized current executable, mapped through `stable_shim_target`.
+    /// Tests use this to assert the symlink points at the RIGHT binary, not
+    /// merely that it points somewhere (which a `assert_ne!` against a stale
+    /// path would tolerate even for a garbage target).
+    #[cfg(unix)]
+    fn expected_shim_target() -> PathBuf {
+        let canonical = std::env::current_exe()
+            .expect("current_exe")
+            .canonicalize()
+            .expect("canonicalize current_exe");
+        stable_shim_target(&canonical)
     }
 
     #[test]
@@ -847,10 +892,26 @@ mod tests {
         install_path_shim(home, false).unwrap();
 
         let status = path_shim_status(home);
-        assert!(
-            matches!(status, PathShimStatus::Installed { .. }),
-            "expected Installed, got {status:?}"
-        );
+        // Don't just match the variant — verify the REPORTED target (the CLI
+        // surfaces this) is the real binary and that a fresh install carries no
+        // spurious staleness warning.
+        match status {
+            PathShimStatus::Installed {
+                target,
+                staleness_warning,
+            } => {
+                assert_eq!(
+                    target,
+                    expected_shim_target(),
+                    "status must report the actual shim target"
+                );
+                assert!(
+                    staleness_warning.is_none(),
+                    "a fresh non-Cellar install must not carry a staleness warning; got {staleness_warning:?}"
+                );
+            }
+            other => panic!("expected Installed, got {other:?}"),
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -1160,6 +1221,13 @@ mod tests {
             "expected a gh symlink at {}",
             link.display()
         );
+        // is_symlink() alone passes even for a symlink pointing at nowhere.
+        // The link must point at the running git-prism binary.
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            expected_shim_target(),
+            "gh symlink must point at the git-prism binary"
+        );
     }
 
     #[test]
@@ -1216,6 +1284,55 @@ mod tests {
         assert_eq!(
             target_before, target_after,
             "idempotent re-install must not change the gh symlink target"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn path_shim_status_for_gh_reports_installed_target() {
+        // path_shim_status_for is per-name; `gh` is the new name added in #347.
+        // Exercise the gh branch directly, not just the default `git` wrapper.
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        install_path_shim(home, false).unwrap();
+
+        match path_shim_status_for(home, "gh") {
+            PathShimStatus::Installed {
+                target,
+                staleness_warning,
+            } => {
+                assert_eq!(
+                    target,
+                    expected_shim_target(),
+                    "gh status must report the actual shim target"
+                );
+                assert!(
+                    staleness_warning.is_none(),
+                    "fresh gh install must not warn; got {staleness_warning:?}"
+                );
+            }
+            other => panic!("expected gh Installed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn path_shim_status_for_gh_reports_not_installed_when_only_git_present() {
+        // Installing only a `git` symlink by hand must leave `gh` reporting
+        // NotInstalled — status is genuinely per-name, not a shared verdict.
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let shim_dir = home.join(PATH_SHIM_REL_DIR);
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        let exe = shim_dir.join("git-prism-fake");
+        std::fs::write(&exe, b"binary").unwrap();
+        std::os::unix::fs::symlink(&exe, shim_dir.join("git")).unwrap();
+
+        assert_eq!(
+            path_shim_status_for(home, "gh"),
+            PathShimStatus::NotInstalled,
+            "gh must report NotInstalled when only git is present"
         );
     }
 
@@ -1475,6 +1592,13 @@ mod tests {
         assert_ne!(
             new_target, foreign_target,
             "install --force must replace foreign symlink with git-prism shim"
+        );
+        // assert_ne! alone tolerates a garbage replacement. Pin the exact target:
+        // --force must repoint at the running git-prism binary.
+        assert_eq!(
+            new_target,
+            expected_shim_target(),
+            "install --force must repoint gh at the git-prism binary, not just away from the foreign target"
         );
     }
 

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -162,8 +162,16 @@ fn detect_rc_file(home: &std::path::Path) -> std::path::PathBuf {
 }
 
 /// Testable rc-file detection with an injected shell string.
+///
+/// Matches on the basename of the shell path so that a path which merely
+/// contains "bash" as a substring (e.g. `/usr/local/bin/newbash`) is not
+/// misidentified as bash.
 pub(crate) fn detect_rc_file_for(home: &std::path::Path, shell: &str) -> std::path::PathBuf {
-    let rc_name = if shell.contains("bash") {
+    let basename = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(shell);
+    let rc_name = if basename == "bash" {
         ".bash_profile"
     } else {
         ".zprofile"
@@ -395,6 +403,20 @@ mod tests {
         assert!(
             rc.ends_with(".zprofile"),
             "unknown shell must default to .zprofile, got: {}",
+            rc.display()
+        );
+    }
+
+    /// A path that merely CONTAINS "bash" as a substring (e.g. `/usr/local/newbash`)
+    /// must not be misidentified as bash — only a path whose final component IS
+    /// "bash" (or the bare string "bash") should select `.bash_profile`.
+    #[test]
+    fn detect_rc_file_does_not_misroute_shell_path_containing_bash_as_substring() {
+        let dir = TempDir::new().unwrap();
+        let rc = detect_rc_file_for(dir.path(), "/usr/local/bin/newbash");
+        assert!(
+            rc.ends_with(".zprofile"),
+            "shell whose basename is 'newbash' (not 'bash') must default to .zprofile, got: {}",
             rc.display()
         );
     }

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -49,8 +49,11 @@ pub fn run_install_with_io(
     stdout: &mut dyn Write,
     rc_path: &std::path::Path,
 ) -> Result<()> {
-    let symlink_path = hooks::install_path_shim(home, force)?;
-    writeln!(stdout, "Created symlink: {}", symlink_path.display())?;
+    hooks::install_path_shim(home, force)?;
+    let shim_bin = home.join(hooks::PATH_SHIM_REL_DIR);
+    for name in hooks::PATH_SHIM_LINK_NAMES {
+        writeln!(stdout, "Created symlink: {}", shim_bin.join(name).display())?;
+    }
 
     let shim_dir = home.join(SHIM_EXPORT_FRAGMENT);
     let shim_dir_str = shim_dir.to_string_lossy().into_owned();
@@ -147,13 +150,23 @@ fn print_manual_instructions(stdout: &mut dyn Write) -> Result<()> {
     Ok(())
 }
 
-/// Determine the shell rc file based on `$SHELL`, defaulting to `.zshrc`.
+/// Determine the login-shell rc file based on `$SHELL`, defaulting to `.zprofile`.
+///
+/// Non-interactive login shells (like Claude Code's) source `.zprofile` / `.bash_profile`
+/// but skip `.zshrc` / `.bashrc`. macOS `path_helper` also demotes PATH entries inherited
+/// from the environment behind `/usr/bin`, so writing to `.zshrc` has no effect in that
+/// context. Use login-shell rc files to ensure the export takes effect.
 fn detect_rc_file(home: &std::path::Path) -> std::path::PathBuf {
     let shell = std::env::var("SHELL").unwrap_or_default();
+    detect_rc_file_for(home, &shell)
+}
+
+/// Testable rc-file detection with an injected shell string.
+pub(crate) fn detect_rc_file_for(home: &std::path::Path, shell: &str) -> std::path::PathBuf {
     let rc_name = if shell.contains("bash") {
-        ".bashrc"
+        ".bash_profile"
     } else {
-        ".zshrc"
+        ".zprofile"
     };
     home.join(rc_name)
 }
@@ -168,34 +181,43 @@ pub fn run_uninstall(home: &std::path::Path) -> Result<()> {
 /// Report whether the PATH shim is installed, not installed, or broken.
 ///
 /// Output always includes the shim directory path so the user knows where
-/// to add to `$PATH` regardless of install state.
+/// to add to `$PATH` regardless of install state. Each managed symlink name
+/// (`git`, `gh`) is reported on a separate line.
 pub fn run_status(home: &std::path::Path) -> Result<()> {
+    run_status_with_io(home, &mut std::io::stdout())
+}
+
+/// Testable status implementation with injected output writer.
+pub fn run_status_with_io(home: &std::path::Path, out: &mut dyn std::io::Write) -> Result<()> {
     let shim_dir = home.join(hooks::PATH_SHIM_REL_DIR);
     let shim_dir_str = shim_dir.to_string_lossy();
-    match hooks::path_shim_status(home) {
-        hooks::PathShimStatus::Installed {
-            target,
-            staleness_warning,
-        } => {
-            println!(
-                "shim: installed at {} -> {}",
-                shim_dir.join(hooks::PATH_SHIM_LINK_NAME).display(),
-                target.display()
-            );
-            println!("shim directory: {shim_dir_str}");
-            if let Some(warning) = staleness_warning {
-                println!("warning: {warning}");
+
+    for name in hooks::PATH_SHIM_LINK_NAMES {
+        match hooks::path_shim_status_for(home, name) {
+            hooks::PathShimStatus::Installed {
+                target,
+                staleness_warning,
+            } => {
+                writeln!(
+                    out,
+                    "shim {name}: installed at {} -> {}",
+                    shim_dir.join(name).display(),
+                    target.display()
+                )?;
+                if let Some(warning) = staleness_warning {
+                    writeln!(out, "warning ({name}): {warning}")?;
+                }
+            }
+            hooks::PathShimStatus::NotInstalled => {
+                writeln!(out, "shim {name}: not installed")?;
+            }
+            hooks::PathShimStatus::BrokenLink { reason } => {
+                writeln!(out, "shim {name}: broken link ({reason})")?;
             }
         }
-        hooks::PathShimStatus::NotInstalled => {
-            println!("shim: not installed");
-            println!("shim directory: {shim_dir_str}");
-        }
-        hooks::PathShimStatus::BrokenLink { reason } => {
-            println!("shim: broken link ({reason})");
-            println!("shim directory: {shim_dir_str}");
-        }
     }
+
+    writeln!(out, "shim directory: {shim_dir_str}")?;
     Ok(())
 }
 
@@ -337,5 +359,56 @@ mod tests {
         let dir = TempDir::new().unwrap();
         install_with_decline(dir.path());
         run_status(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn detect_rc_file_returns_zprofile_for_zsh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // Simulate SHELL=zsh by calling detect_rc_file directly.
+        // We need to test the logic without relying on the CI runner's $SHELL.
+        // detect_rc_file_for lets us inject the shell string.
+        let rc = detect_rc_file_for(home, "zsh");
+        assert!(
+            rc.ends_with(".zprofile"),
+            "zsh rc must be .zprofile (login-shell sourced), got: {}",
+            rc.display()
+        );
+    }
+
+    #[test]
+    fn detect_rc_file_returns_bash_profile_for_bash() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let rc = detect_rc_file_for(home, "bash");
+        assert!(
+            rc.ends_with(".bash_profile"),
+            "bash rc must be .bash_profile (login-shell sourced), got: {}",
+            rc.display()
+        );
+    }
+
+    #[test]
+    fn detect_rc_file_defaults_to_zprofile_when_shell_unknown() {
+        let dir = TempDir::new().unwrap();
+        let rc = detect_rc_file_for(dir.path(), "");
+        assert!(
+            rc.ends_with(".zprofile"),
+            "unknown shell must default to .zprofile, got: {}",
+            rc.display()
+        );
+    }
+
+    #[test]
+    fn run_status_output_mentions_gh_symlink() {
+        let dir = TempDir::new().unwrap();
+        install_with_decline(dir.path());
+        let mut out = Vec::new();
+        run_status_with_io(dir.path(), &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("gh"),
+            "status output must mention the gh symlink; got: {text:?}"
+        );
     }
 }

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -11,9 +11,6 @@ use anyhow::Result;
 
 use crate::hooks;
 
-/// The export line fragment used to detect existing entries and compute the shim dir.
-const SHIM_EXPORT_FRAGMENT: &str = ".local/share/git-prism/bin";
-
 /// The full export line written to shell rc files.
 const SHIM_EXPORT_LINE: &str = r#"export PATH="$HOME/.local/share/git-prism/bin:$PATH""#;
 
@@ -50,12 +47,11 @@ pub fn run_install_with_io(
     rc_path: &std::path::Path,
 ) -> Result<()> {
     hooks::install_path_shim(home, force)?;
-    let shim_bin = home.join(hooks::PATH_SHIM_REL_DIR);
+    let shim_dir = home.join(hooks::PATH_SHIM_REL_DIR);
     for name in hooks::PATH_SHIM_LINK_NAMES {
-        writeln!(stdout, "Created symlink: {}", shim_bin.join(name).display())?;
+        writeln!(stdout, "Created symlink: {}", shim_dir.join(name).display())?;
     }
 
-    let shim_dir = home.join(SHIM_EXPORT_FRAGMENT);
     let shim_dir_str = shim_dir.to_string_lossy().into_owned();
 
     if shim_dir_is_in_path(&shim_dir_str) {
@@ -236,6 +232,11 @@ mod tests {
 
     use super::*;
     use tempfile::TempDir;
+
+    /// The shim-dir path fragment, derived from the canonical constant in
+    /// `hooks` so these assertions track the real install location instead of a
+    /// drifting literal copy.
+    const SHIM_EXPORT_FRAGMENT: &str = hooks::PATH_SHIM_REL_DIR;
 
     /// Install with consent, using an explicit `.zshrc` path so the test is
     /// independent of the CI runner's `$SHELL`.

--- a/tests/shim_auto_path_pentest.rs
+++ b/tests/shim_auto_path_pentest.rs
@@ -34,7 +34,8 @@ fn count_real_export_lines(rc: &str) -> usize {
 fn consent_appends_export_even_when_fragment_appears_in_unrelated_line() {
     let bin = env!("CARGO_BIN_EXE_git-prism");
     let home = TempDir::new().unwrap();
-    let rc = home.path().join(".zshrc");
+    // Use .zprofile — the login-shell rc file that detect_rc_file targets for zsh.
+    let rc = home.path().join(".zprofile");
     // Unrelated line that contains the fragment as a substring.
     std::fs::write(
         &rc,

--- a/tests/shim_auto_path_pentest.rs
+++ b/tests/shim_auto_path_pentest.rs
@@ -111,4 +111,11 @@ fn trailing_slash_path_entry_is_recognized_as_already_present() {
         "shim dir present with a trailing slash should count as already-in-PATH; \
          got prompt: {stdout}"
     );
+    // Recognized-as-present must also mean the rc is left untouched: no export
+    // line is appended when PATH already contains the shim dir.
+    let rc_after = std::fs::read_to_string(home.path().join(".zshrc")).unwrap();
+    assert_eq!(
+        rc_after, "# rc\n",
+        "already-present detection must not append an export line; rc was: {rc_after:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #347 (blocker 1 of #346, plus the PATH-UX note).

`git-prism shim install` previously created only the `git` symlink, so the `gh` interception that shipped in #333 (v0.9.0) never actually worked unless a `gh` symlink was added by hand. `install` / `status` / `uninstall` now manage **both** `git` and `gh`. The install PATH-UX also writes the `export PATH=…` line to a file that non-interactive **login** shells source (`.zprofile` / `.zshenv`) rather than `.zshrc`, which those shells (including Claude Code agents) skip.

## What changed

- `PATH_SHIM_LINK_NAMES` slice (`git`, `gh`); install/status/uninstall iterate over both.
- **Validate-then-apply**: pre-flight every name before mutating any, so a refusal on `gh` never leaves `git` half-installed (or vice versa).
- **Foreign / dangling symlink safety**: refuse to clobber or remove a foreign symlink — live *or* dangling — without `--force`, while still cleaning up git-prism-owned dangling links (the `brew upgrade` Cellar-GC case).
- rc-file target keyed on the shell basename → `.zprofile` / `.bash_profile`.

## Gauntlet

- **Adversarial QA (3 passes)**: found 6 real bugs — 4 atomicity/partial-state, 2 dangling-foreign-symlink — all fixed with tests proving each.
- **Church**: arch (removed a duplicated shim-dir literal), test (strengthened weak assertions + added coverage), observability (preserved a dropped `read_link` error cause).
- 1035 tests pass; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

Generated with [Claude Code](https://claude.ai/claude-code)
