### PR TITLE
fix(shim): emit telemetry from shim mode — init + bounded force-flush (#348)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,12 @@ async fn main() -> std::process::ExitCode {
         // structured-output path run_shim returns an ExitCode, and we
         // force_flush before returning so metrics reach the exporter even
         // though the PeriodicReader hasn't ticked yet.
-        let mut telemetry_guard = telemetry::init();
+        //
+        // Use `init_quiet`: the shim runs once per intercepted git/gh command,
+        // so the per-invocation "telemetry initialized" banner would flood the
+        // developer's shell with one stderr line per git call. Failure paths
+        // still log, so a misconfigured endpoint stays visible.
+        let mut telemetry_guard = telemetry::init_quiet();
         // run_shim either exec-replaces the process (passthrough, never returns)
         // or returns ExitCode after printing structured JSON or an error.
         // On passthrough paths force_flush is called inside run_shim before execvp.

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,9 +275,19 @@ async fn main() -> std::process::ExitCode {
             env: &agent_detection::StdEnvSource,
             argv0: args.first().copied().unwrap_or("git"),
         };
+        // Initialize telemetry when an OTLP endpoint is configured. The guard
+        // must live until after run_shim returns — on the exec-replace
+        // (passthrough) path the process is replaced and Rust's drop glue
+        // never runs anyway, so no flush is needed there. On the
+        // structured-output path run_shim returns an ExitCode, and we
+        // force_flush before returning so metrics reach the exporter even
+        // though the PeriodicReader hasn't ticked yet.
+        let mut telemetry_guard = telemetry::init();
         // run_shim either exec-replaces the process (passthrough, never returns)
         // or returns ExitCode after printing structured JSON or an error.
-        return shim::run_shim(&args, &agent_detection::StdEnvSource, &exec);
+        let exit_code = shim::run_shim(&args, &agent_detection::StdEnvSource, &exec);
+        telemetry_guard.force_flush();
+        return exit_code;
     }
 
     if let Err(e) = run().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,14 @@ async fn main() -> std::process::ExitCode {
         let mut telemetry_guard = telemetry::init();
         // run_shim either exec-replaces the process (passthrough, never returns)
         // or returns ExitCode after printing structured JSON or an error.
-        let exit_code = shim::run_shim(&args, &agent_detection::StdEnvSource, &exec);
+        // On passthrough paths force_flush is called inside run_shim before execvp.
+        // On the structured-output path the guard is flushed here after run_shim returns.
+        let exit_code = shim::run_shim(
+            &args,
+            &agent_detection::StdEnvSource,
+            &exec,
+            &mut telemetry_guard,
+        );
         telemetry_guard.force_flush();
         return exit_code;
     }

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -12,11 +12,22 @@ pub(crate) mod shadow;
 
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Duration;
 
 use crate::agent_detection::EnvSource;
 use crate::metrics::{ShimOutcome, ShimSubcommand};
 use crate::shim::classify::{Classification, classify};
 use crate::shim::real_git::RealGitExec;
+use crate::telemetry::TelemetryGuard;
+
+/// Flush deadline used on passthrough paths (before execvp).
+///
+/// A DOWN OTLP collector makes `force_flush()` block up to `EXPORT_TIMEOUT`
+/// (5 s).  That would stall the shell on every intercepted git command even
+/// when the collector is unreachable.  This cap bounds the wait; the flush
+/// thread is abandoned if it hasn't completed in time and will be torn down
+/// when the process image is replaced by execvp.
+const PASSTHROUGH_FLUSH_TIMEOUT: Duration = Duration::from_millis(300);
 
 /// Main entry point for shim mode.
 ///
@@ -33,18 +44,34 @@ use crate::shim::real_git::RealGitExec;
 /// structured-dispatch path (step 4) — never on passthrough or loop-break
 /// paths.  This invariant ensures dashboards that aggregate
 /// `shim_invocations_total` get an accurate per-call count.
-pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(argv: &[&str], env: &E, exec: &G) -> ExitCode {
+///
+/// # Telemetry flush on passthrough
+///
+/// On passthrough paths `exec.passthrough()` calls `execvp`, which replaces
+/// the process image and never returns.  `Drop` glue and the flush in
+/// `main.rs` are unreachable on those paths.  `telemetry_guard.force_flush()`
+/// is called on every passthrough branch **before** `exec.passthrough()` so
+/// the buffered metric reaches the OTLP endpoint.  A second flush / `Drop`
+/// is a documented no-op (`TelemetryGuard::force_flush` is idempotent).
+pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(
+    argv: &[&str],
+    env: &E,
+    exec: &G,
+    telemetry_guard: &mut TelemetryGuard,
+) -> ExitCode {
     let metrics = crate::metrics::get();
 
     // 1. Loop-break sentinel: a nested git call from within the shim.
     if env.get("GIT_PRISM_INSIDE_SHIM").is_some() {
         metrics.record_shim_invocation(ShimOutcome::LoopBreak);
+        telemetry_guard.force_flush_bounded(PASSTHROUGH_FLUSH_TIMEOUT);
         return exec.passthrough(argv);
     }
 
     // 2. Only intercept when an AI agent is the caller.
     if crate::agent_detection::detect_calling_agent(env).is_none() {
         metrics.record_shim_invocation(ShimOutcome::NoAgent);
+        telemetry_guard.force_flush_bounded(PASSTHROUGH_FLUSH_TIMEOUT);
         return exec.passthrough(argv);
     }
 
@@ -53,6 +80,7 @@ pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(argv: &[&str], env: &E, exe
     let subcommand = classification_to_subcommand(&classification);
     if classification == Classification::Passthrough {
         metrics.record_shim_invocation(ShimOutcome::Passthrough);
+        telemetry_guard.force_flush_bounded(PASSTHROUGH_FLUSH_TIMEOUT);
         return exec.passthrough(argv);
     }
 
@@ -61,6 +89,7 @@ pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(argv: &[&str], env: &E, exe
         Some(p) => p,
         None => {
             metrics.record_shim_invocation(ShimOutcome::Passthrough);
+            telemetry_guard.force_flush();
             return exec.passthrough(argv);
         }
     };
@@ -171,8 +200,9 @@ mod tests {
             ("CLAUDECODE", "1"),
         ]));
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
-        run_shim(&["git", "diff", "main..HEAD"], &env, &exec);
+        run_shim(&["git", "diff", "main..HEAD"], &env, &exec, &mut guard);
 
         assert!(
             exec.called.get(),
@@ -185,8 +215,9 @@ mod tests {
         // No CLAUDECODE, no AI_AGENT — detect_calling_agent returns None.
         let env = MapEnv(HashMap::new());
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
-        run_shim(&["git", "diff", "main..HEAD"], &env, &exec);
+        run_shim(&["git", "diff", "main..HEAD"], &env, &exec, &mut guard);
 
         assert!(
             exec.called.get(),
@@ -198,8 +229,9 @@ mod tests {
     fn it_passes_through_when_subcommand_is_not_on_watch_list() {
         let env = MapEnv(HashMap::from([("CLAUDECODE", "1")]));
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
-        run_shim(&["git", "status"], &env, &exec);
+        run_shim(&["git", "status"], &env, &exec, &mut guard);
 
         assert!(
             exec.called.get(),
@@ -215,8 +247,9 @@ mod tests {
             ("CLAUDECODE", "1"),
         ]));
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
-        run_shim(&["git", "diff", "main..HEAD"], &env, &exec);
+        run_shim(&["git", "diff", "main..HEAD"], &env, &exec, &mut guard);
 
         assert!(
             exec.called.get(),
@@ -258,9 +291,10 @@ mod tests {
             ("GIT_PRISM_REPO", repo_str),
         ]));
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
         // git diff main..HEAD is a classified command that routes to handle_manifest.
-        let code = run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec);
+        let code = run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec, &mut guard);
 
         // SpyExec must NOT have been called — the handler ran instead.
         assert!(
@@ -306,10 +340,11 @@ mod tests {
             ("GIT_PRISM_CWD_UNAVAILABLE", "1"),
         ]));
         let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
 
         // argv is a classified command so it would normally dispatch — but
         // the cwd failure must cause passthrough instead.
-        run_shim(&["git", "diff", "main..HEAD"], &env, &exec);
+        run_shim(&["git", "diff", "main..HEAD"], &env, &exec, &mut guard);
 
         assert!(
             exec.called.get(),

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -89,7 +89,7 @@ pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(
         Some(p) => p,
         None => {
             metrics.record_shim_invocation(ShimOutcome::Passthrough);
-            telemetry_guard.force_flush();
+            telemetry_guard.force_flush_bounded(PASSTHROUGH_FLUSH_TIMEOUT);
             return exec.passthrough(argv);
         }
     };

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -73,6 +73,44 @@ impl TelemetryGuard {
             eprintln!("git-prism: failed to force-flush traces: {e}");
         }
     }
+
+    /// Best-effort flush with a wall-clock deadline.
+    ///
+    /// Runs `force_flush` on a background thread and waits at most `timeout`
+    /// for it to complete.  If the collector is unreachable and the flush
+    /// blocks (up to `EXPORT_TIMEOUT = 5 s`), this method returns after
+    /// `timeout` without blocking the caller.
+    ///
+    /// Use this on the shim passthrough path where every intercepted git
+    /// command pays the flush cost: a DOWN OTLP endpoint must not stall the
+    /// developer's shell for 5 s per invocation.
+    ///
+    /// Safe to call on a no-op guard: completes immediately with no overhead.
+    pub fn force_flush_bounded(&mut self, timeout: Duration) {
+        if self.meter_provider.is_none() && self.tracer_provider.is_none() {
+            return;
+        }
+        // Clone the Arc-backed provider handles so they can be moved into the thread.
+        let mp = self.meter_provider.clone();
+        let tp = self.tracer_provider.clone();
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            if let Some(mp) = mp
+                && let Err(e) = mp.force_flush()
+            {
+                eprintln!("git-prism: failed to force-flush metrics: {e}");
+            }
+            if let Some(tp) = tp
+                && let Err(e) = tp.force_flush()
+            {
+                eprintln!("git-prism: failed to force-flush traces: {e}");
+            }
+            let _ = tx.send(());
+        });
+        // Wait up to `timeout`; if the flush thread is still blocked, abandon it.
+        // The thread will be torn down with the process on execvp or normal exit.
+        let _ = rx.recv_timeout(timeout);
+    }
 }
 
 /// The design spec targets a 5s flush on shutdown. The SDK's `.shutdown()` handles
@@ -129,6 +167,24 @@ pub fn init() -> TelemetryGuard {
     init_with_attacher(attach_tracing_subscriber_default)
 }
 
+/// Read the service name from the environment, falling back to the default
+/// when the variable is absent **or empty**.
+fn resolve_service_name() -> String {
+    match std::env::var(ENV_SERVICE_NAME) {
+        Ok(v) if !v.is_empty() => v,
+        _ => DEFAULT_SERVICE_NAME.to_string(),
+    }
+}
+
+/// Read the service version from the environment, falling back to the crate
+/// version when the variable is absent **or empty**.
+fn resolve_service_version() -> String {
+    match std::env::var(ENV_SERVICE_VERSION) {
+        Ok(v) if !v.is_empty() => v,
+        _ => env!("CARGO_PKG_VERSION").to_string(),
+    }
+}
+
 /// Core telemetry initialization body, parameterized by a subscriber-attach
 /// function so tests can inject a failure without touching tracing's
 /// process-global state.
@@ -156,10 +212,8 @@ where
     let base = endpoint.trim_end_matches('/');
     let (traces_endpoint, metrics_endpoint) = signal_endpoints(base);
 
-    let service_name =
-        std::env::var(ENV_SERVICE_NAME).unwrap_or_else(|_| DEFAULT_SERVICE_NAME.to_string());
-    let service_version = std::env::var(ENV_SERVICE_VERSION)
-        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    let service_name = resolve_service_name();
+    let service_version = resolve_service_version();
 
     // Build the OTLP trace exporter.
     let trace_exporter = match opentelemetry_otlp::SpanExporter::builder()
@@ -244,6 +298,25 @@ where
     TelemetryGuard {
         tracer_provider: Some(tracer_provider),
         meter_provider: Some(meter_provider),
+    }
+}
+
+/// Test-only constructors for `TelemetryGuard`.
+///
+/// Placed in a `#[cfg(test)]` impl block so the dead-code lint does not fire
+/// in non-test builds — the methods are invisible outside test compilation.
+#[cfg(test)]
+impl TelemetryGuard {
+    /// Construct a no-op guard with no providers attached.
+    ///
+    /// Used in unit tests that need to pass a `TelemetryGuard` to functions
+    /// under test without initializing real OTLP providers.  `force_flush`,
+    /// `force_flush_bounded`, and `Drop` on this guard are zero-cost no-ops.
+    pub(crate) fn noop() -> Self {
+        Self {
+            tracer_provider: None,
+            meter_provider: None,
+        }
     }
 }
 
@@ -387,6 +460,52 @@ mod tests {
         drop(guard);
     }
 
+    /// Verify that an empty `GIT_PRISM_SERVICE_VERSION` falls back to the crate
+    /// version rather than passing an empty string as the service.version attribute.
+    ///
+    /// The production code path under test is in `init_with_attacher`:
+    ///   `std::env::var(ENV_SERVICE_VERSION).unwrap_or_else(|_| env!(...).to_string())`
+    /// Without the `is_empty()` guard, `Ok("")` is returned and the empty string
+    /// is used as the service version.  This test calls `resolve_service_version`
+    /// which is the extracted helper that applies the guard.
+    #[test]
+    fn it_uses_crate_version_when_service_version_env_is_empty_string() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_SERVICE_VERSION, "");
+        }
+        let version = resolve_service_version();
+        unsafe {
+            std::env::remove_var(ENV_SERVICE_VERSION);
+        }
+        assert_eq!(
+            version,
+            env!("CARGO_PKG_VERSION"),
+            "empty GIT_PRISM_SERVICE_VERSION must fall back to crate version"
+        );
+    }
+
+    /// Verify that an empty `GIT_PRISM_SERVICE_NAME` falls back to `"git-prism"`.
+    #[test]
+    fn it_uses_default_service_name_when_service_name_env_is_empty_string() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_SERVICE_NAME, "");
+        }
+        let name = resolve_service_name();
+        unsafe {
+            std::env::remove_var(ENV_SERVICE_NAME);
+        }
+        assert_eq!(
+            name, DEFAULT_SERVICE_NAME,
+            "empty GIT_PRISM_SERVICE_NAME must fall back to default 'git-prism'"
+        );
+    }
+
     #[test]
     fn it_uses_crate_version_when_service_version_env_is_unset() {
         let _lock = ENV_MUTEX.lock().unwrap();
@@ -415,6 +534,13 @@ mod tests {
             crate_version, "0.9.0",
             "version must not be the old hardcoded value 0.9.0; got {crate_version}"
         );
+    }
+
+    #[test]
+    fn it_force_flushes_bounded_noop_guard_without_panic() {
+        let mut guard = TelemetryGuard::noop();
+        // force_flush_bounded on a no-op guard must complete immediately with no panic.
+        guard.force_flush_bounded(Duration::from_millis(200));
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -62,15 +62,15 @@ impl TelemetryGuard {
     ///
     /// Safe to call on a no-op guard: it is a documented zero-cost no-op.
     pub fn force_flush(&mut self) {
-        if let Some(mp) = &self.meter_provider {
-            if let Err(e) = mp.force_flush() {
-                eprintln!("git-prism: failed to force-flush metrics: {e}");
-            }
+        if let Some(mp) = &self.meter_provider
+            && let Err(e) = mp.force_flush()
+        {
+            eprintln!("git-prism: failed to force-flush metrics: {e}");
         }
-        if let Some(tp) = &self.tracer_provider {
-            if let Err(e) = tp.force_flush() {
-                eprintln!("git-prism: failed to force-flush traces: {e}");
-            }
+        if let Some(tp) = &self.tracer_provider
+            && let Err(e) = tp.force_flush()
+        {
+            eprintln!("git-prism: failed to force-flush traces: {e}");
         }
     }
 }
@@ -385,6 +385,36 @@ mod tests {
             std::env::remove_var(ENV_SERVICE_NAME);
         }
         drop(guard);
+    }
+
+    #[test]
+    fn it_uses_crate_version_when_service_version_env_is_unset() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+        }
+        // When GIT_PRISM_SERVICE_VERSION is not set, the guard should still
+        // initialize (no-op when no endpoint), and the crate version constant
+        // must equal the Cargo.toml version. We verify the constant is wired
+        // by checking it matches the package version used at compile time.
+        let crate_version = env!("CARGO_PKG_VERSION");
+        assert!(
+            !crate_version.is_empty(),
+            "CARGO_PKG_VERSION must be non-empty"
+        );
+        // Verify the fallback value matches by checking the env var is absent.
+        assert!(
+            std::env::var(ENV_SERVICE_VERSION).is_err(),
+            "ENV_SERVICE_VERSION must be unset for this test"
+        );
+        // The guard init path uses env!("CARGO_PKG_VERSION") as fallback —
+        // confirmed by reading telemetry.rs:162. This test guards against
+        // regression to a hardcoded string.
+        assert_ne!(
+            crate_version, "0.9.0",
+            "version must not be the old hardcoded value 0.9.0; got {crate_version}"
+        );
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -51,6 +51,28 @@ impl TelemetryGuard {
     pub fn is_active(&self) -> bool {
         self.tracer_provider.is_some()
     }
+
+    /// Force-flush pending telemetry to the exporter immediately.
+    ///
+    /// The `PeriodicReader` used by the metrics provider only fires on its
+    /// configured interval (default 60 s). A short-lived process — such as the
+    /// shim — exits before the reader ticks, so `Drop` alone never delivers
+    /// metrics. Calling `force_flush` before process exit ensures buffered
+    /// measurements reach the OTLP endpoint.
+    ///
+    /// Safe to call on a no-op guard: it is a documented zero-cost no-op.
+    pub fn force_flush(&mut self) {
+        if let Some(mp) = &self.meter_provider {
+            if let Err(e) = mp.force_flush() {
+                eprintln!("git-prism: failed to force-flush metrics: {e}");
+            }
+        }
+        if let Some(tp) = &self.tracer_provider {
+            if let Err(e) = tp.force_flush() {
+                eprintln!("git-prism: failed to force-flush traces: {e}");
+            }
+        }
+    }
 }
 
 /// The design spec targets a 5s flush on shutdown. The SDK's `.shutdown()` handles
@@ -361,6 +383,38 @@ mod tests {
         unsafe {
             std::env::remove_var(ENV_OTLP_ENDPOINT);
             std::env::remove_var(ENV_SERVICE_NAME);
+        }
+        drop(guard);
+    }
+
+    #[test]
+    fn it_force_flushes_noop_guard_without_panic() {
+        let mut guard = TelemetryGuard {
+            tracer_provider: None,
+            meter_provider: None,
+        };
+        // force_flush on a no-op guard must be a no-op with zero overhead.
+        guard.force_flush();
+    }
+
+    #[tokio::test]
+    async fn it_force_flushes_active_guard_without_panic() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://localhost:4318");
+        }
+        let mut guard = init();
+        assert!(
+            guard.is_active(),
+            "guard must be active for this test to exercise flush"
+        );
+        // force_flush on an active guard must not panic even when no exporter is reachable.
+        guard.force_flush();
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
         }
         drop(guard);
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -164,7 +164,19 @@ fn attach_tracing_subscriber_default(_tracer_provider: &SdkTracerProvider) -> Re
 /// When `GIT_PRISM_OTLP_ENDPOINT` is not set, this returns a no-op guard
 /// with zero overhead.
 pub fn init() -> TelemetryGuard {
-    init_with_attacher(attach_tracing_subscriber_default)
+    init_with_attacher(attach_tracing_subscriber_default, true)
+}
+
+/// Like [`init`], but suppresses the one-line "telemetry initialized" success
+/// banner on stderr.
+///
+/// The shim runs once per intercepted `git`/`gh` invocation, so emitting the
+/// success line every time would flood the developer's shell with one stderr
+/// line per git command. Failure paths still log (a misconfigured endpoint must
+/// remain visible) and the endpoint is still recorded in the exported resource;
+/// only the per-invocation success banner is silenced.
+pub fn init_quiet() -> TelemetryGuard {
+    init_with_attacher(attach_tracing_subscriber_default, false)
 }
 
 /// Read the service name from the environment, falling back to the default
@@ -194,7 +206,11 @@ fn resolve_service_version() -> String {
 /// user-visible "telemetry initialized" message. Every failure path must
 /// return a no-op `TelemetryGuard` AND suppress the success message —
 /// otherwise operators see "initialized" while spans silently disappear.
-fn init_with_attacher<F>(attach_subscriber: F) -> TelemetryGuard
+///
+/// `emit_success_banner` controls only the one-line success message printed
+/// when initialization fully succeeds. Failure paths log unconditionally so a
+/// misconfigured endpoint is never silently swallowed regardless of caller.
+fn init_with_attacher<F>(attach_subscriber: F, emit_success_banner: bool) -> TelemetryGuard
 where
     F: FnOnce(&SdkTracerProvider) -> Result<(), String>,
 {
@@ -293,7 +309,9 @@ where
         };
     }
 
-    eprintln!("git-prism: telemetry initialized (HTTP/protobuf, endpoint={base})");
+    if emit_success_banner {
+        eprintln!("git-prism: telemetry initialized (HTTP/protobuf, endpoint={base})");
+    }
 
     TelemetryGuard {
         tracer_provider: Some(tracer_provider),
@@ -378,6 +396,41 @@ mod tests {
         unsafe {
             std::env::remove_var(ENV_OTLP_ENDPOINT);
         }
+    }
+
+    #[test]
+    fn test_init_quiet_without_env_returns_noop() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+        }
+        let guard = init_quiet();
+        assert!(
+            !guard.is_active(),
+            "init_quiet must produce a no-op guard when no endpoint is set, same as init"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_quiet_with_endpoint_creates_providers() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://localhost:4318");
+        }
+        let guard = init_quiet();
+        assert!(
+            guard.is_active(),
+            "init_quiet must still create active providers when an endpoint is set; \
+             suppressing the banner must not suppress telemetry itself"
+        );
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
+        }
+        drop(guard);
     }
 
     #[tokio::test]
@@ -487,6 +540,57 @@ mod tests {
         );
     }
 
+    /// Verify a non-empty `GIT_PRISM_SERVICE_NAME` is returned verbatim — the
+    /// resolver must actually read the env var, not always return the default.
+    /// Kills the mutation where the custom-value branch is dropped.
+    #[test]
+    fn it_uses_custom_service_name_when_service_name_env_is_set() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_SERVICE_NAME, "custom-prism");
+        }
+        let name = resolve_service_name();
+        unsafe {
+            std::env::remove_var(ENV_SERVICE_NAME);
+        }
+        assert_eq!(
+            name, "custom-prism",
+            "a non-empty GIT_PRISM_SERVICE_NAME must be used verbatim, not replaced by the default"
+        );
+        assert_ne!(
+            name, DEFAULT_SERVICE_NAME,
+            "the custom name must not collapse to the default"
+        );
+    }
+
+    /// Verify a non-empty `GIT_PRISM_SERVICE_VERSION` is returned verbatim
+    /// rather than the crate-version fallback. Kills the mutation where the
+    /// custom-value branch is dropped in favor of always returning the fallback.
+    #[test]
+    fn it_uses_custom_service_version_when_service_version_env_is_set() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_SERVICE_VERSION, "9.9.9-custom");
+        }
+        let version = resolve_service_version();
+        unsafe {
+            std::env::remove_var(ENV_SERVICE_VERSION);
+        }
+        assert_eq!(
+            version, "9.9.9-custom",
+            "a non-empty GIT_PRISM_SERVICE_VERSION must be used verbatim"
+        );
+        assert_ne!(
+            version,
+            env!("CARGO_PKG_VERSION"),
+            "the custom version must not collapse to the crate-version fallback"
+        );
+    }
+
     /// Verify that an empty `GIT_PRISM_SERVICE_NAME` falls back to `"git-prism"`.
     #[test]
     fn it_uses_default_service_name_when_service_name_env_is_empty_string() {
@@ -513,26 +617,59 @@ mod tests {
         unsafe {
             clear_telemetry_env();
         }
-        // When GIT_PRISM_SERVICE_VERSION is not set, the guard should still
-        // initialize (no-op when no endpoint), and the crate version constant
-        // must equal the Cargo.toml version. We verify the constant is wired
-        // by checking it matches the package version used at compile time.
-        let crate_version = env!("CARGO_PKG_VERSION");
-        assert!(
-            !crate_version.is_empty(),
-            "CARGO_PKG_VERSION must be non-empty"
+        // With GIT_PRISM_SERVICE_VERSION unset, the resolver must return exactly
+        // the compiled-in crate version — not an empty string, not a stale
+        // hardcoded constant. Asserting equality against CARGO_PKG_VERSION binds
+        // the test to the live package version, so a regression to a literal
+        // string (the original bug this guards) fails immediately.
+        let version = resolve_service_version();
+        assert_eq!(
+            version,
+            env!("CARGO_PKG_VERSION"),
+            "unset GIT_PRISM_SERVICE_VERSION must fall back to the crate version"
         );
-        // Verify the fallback value matches by checking the env var is absent.
         assert!(
-            std::env::var(ENV_SERVICE_VERSION).is_err(),
-            "ENV_SERVICE_VERSION must be unset for this test"
+            !version.is_empty(),
+            "the crate-version fallback must never be empty"
         );
-        // The guard init path uses env!("CARGO_PKG_VERSION") as fallback —
-        // confirmed by reading telemetry.rs:162. This test guards against
-        // regression to a hardcoded string.
-        assert_ne!(
-            crate_version, "0.9.0",
-            "version must not be the old hardcoded value 0.9.0; got {crate_version}"
+    }
+
+    /// `init_quiet` must produce the same guard semantics as `init` — it only
+    /// suppresses the success banner, not provider construction. An active
+    /// endpoint must still yield an active guard.
+    #[tokio::test]
+    async fn it_quiet_init_still_activates_providers_when_endpoint_is_set() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://localhost:4318");
+        }
+        let guard = init_quiet();
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
+        }
+        assert!(
+            guard.is_active(),
+            "init_quiet must still create providers when an endpoint is configured; \
+             it only suppresses the stderr success banner"
+        );
+        drop(guard);
+    }
+
+    /// With no endpoint, `init_quiet` degrades to a no-op guard just like `init`.
+    #[test]
+    fn it_quiet_init_returns_noop_without_endpoint() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+        }
+        let guard = init_quiet();
+        assert!(
+            !guard.is_active(),
+            "init_quiet must be a no-op guard when no endpoint is set"
         );
     }
 
@@ -575,6 +712,89 @@ mod tests {
         drop(guard);
     }
 
+    /// Double-flush must be idempotent: `force_flush` borrows the providers
+    /// (`&mut self`) rather than taking them, so a second call — and a
+    /// subsequent `Drop` — must still succeed without panic or double-free.
+    /// This is the real shim sequence: flush before exec, then Drop on exit.
+    #[tokio::test]
+    async fn it_tolerates_double_force_flush_then_drop_on_active_guard() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://localhost:4318");
+        }
+        let mut guard = init();
+        assert!(
+            guard.is_active(),
+            "guard must be active for this test to exercise repeated flush"
+        );
+        guard.force_flush();
+        // Second flush must remain a no-panic no-op: providers are still owned.
+        guard.force_flush();
+        // Guard must still be active after repeated flushes — flush does not
+        // consume the providers the way Drop does.
+        assert!(
+            guard.is_active(),
+            "force_flush must not consume the providers; guard stays active"
+        );
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
+        }
+        // Drop after two flushes must not double-free or panic.
+        drop(guard);
+    }
+
+    /// Double-flush on a no-op guard must remain a zero-cost no-op across
+    /// repeated calls and a final Drop.
+    #[test]
+    fn it_tolerates_double_force_flush_on_noop_guard() {
+        let mut guard = TelemetryGuard::noop();
+        guard.force_flush();
+        guard.force_flush();
+        assert!(
+            !guard.is_active(),
+            "a no-op guard must stay inactive across repeated force_flush calls"
+        );
+        drop(guard);
+    }
+
+    /// `force_flush_bounded` on an active guard must return within the deadline
+    /// even when the configured OTLP endpoint is unreachable. The 5 s exporter
+    /// timeout must NOT leak through: we cap the wait at 200 ms and assert the
+    /// call returns in well under the exporter timeout. This is the property the
+    /// shim relies on so a DOWN collector never stalls the developer's shell.
+    #[tokio::test]
+    async fn it_force_flushes_bounded_active_guard_within_deadline() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            // Unroutable TEST-NET-1 address (RFC 5737): connections hang/fail,
+            // exercising the bounded-wait path rather than a fast local refusal.
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://192.0.2.1:4318");
+        }
+        let mut guard = init();
+        assert!(
+            guard.is_active(),
+            "guard must be active to exercise the bounded-flush wait path"
+        );
+        let start = std::time::Instant::now();
+        guard.force_flush_bounded(Duration::from_millis(200));
+        let elapsed = start.elapsed();
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
+        }
+        drop(guard);
+        assert!(
+            elapsed < EXPORT_TIMEOUT,
+            "bounded flush must abandon a stalled exporter well before the {EXPORT_TIMEOUT:?} \
+             export timeout; took {elapsed:?}"
+        );
+    }
+
     /// Regression test for PR #210 blocker B1.
     ///
     /// Before the fix: when `Registry::default().with(otel_layer).try_init()`
@@ -598,8 +818,10 @@ mod tests {
             clear_telemetry_env();
             std::env::set_var(ENV_OTLP_ENDPOINT, "http://localhost:4318");
         }
-        let guard =
-            init_with_attacher(|_tp| Err("subscriber already registered (simulated)".to_string()));
+        let guard = init_with_attacher(
+            |_tp| Err("subscriber already registered (simulated)".to_string()),
+            true,
+        );
         // SAFETY: cleanup
         unsafe {
             std::env::remove_var(ENV_OTLP_ENDPOINT);

--- a/tests/shim_passthrough_telemetry_pentest.rs
+++ b/tests/shim_passthrough_telemetry_pentest.rs
@@ -1,0 +1,195 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #348, gate 3): the shim must flush telemetry on the
+//! passthrough / process-replacement path, not only on the structured-output
+//! path.
+//!
+//! Issue #348 explicitly states (Notes):
+//!   "The exec-replacement passthrough path never returns — ensure flush
+//!    happens before exec/exit on every path that emitted metrics."
+//!
+//! and (Scope):
+//!   "call it before the shim exits (covering BOTH the passthrough path
+//!    where reachable and the structured-output path)."
+//!
+//! `run_shim` records `shim_invocations_total{outcome=...}` on EVERY passthrough
+//! path (loop-break, no-agent, unsupported-subcommand) BEFORE calling
+//! `exec.passthrough()`, which replaces the process image and never returns.
+//! The only `force_flush()` call site lives in `main.rs` AFTER `run_shim`
+//! returns — unreachable on passthrough. So the metric the shim just emitted is
+//! buffered in the `PeriodicReader` (60 s tick) and the process is replaced
+//! before it ever ticks: the measurement is silently dropped.
+//!
+//! This test drives the built binary end-to-end through the passthrough path
+//! with `GIT_PRISM_OTLP_ENDPOINT` pointed at a local capture server, and asserts
+//! the OTLP metrics export arrives. It currently FAILS because no flush happens
+//! before the process is replaced.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+/// Spawn a one-shot HTTP capture server. Returns the bound `base` URL (no
+/// trailing path) and a receiver that yields `true` once ANY HTTP request body
+/// (an OTLP export) is received.
+fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base = format!("http://{}", addr);
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(500)))
+                .ok();
+            let mut buf = [0u8; 4096];
+            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            if got {
+                let _ = tx.send(true);
+            }
+        }
+    });
+
+    (base, rx)
+}
+
+/// Create a fast fake `git` so the passthrough succeeds in milliseconds.
+fn make_fake_git(dir: &std::path::Path) {
+    let git = dir.join("git");
+    std::fs::write(&git, b"#!/bin/sh\nexit 0\n").unwrap();
+    let mut perms = std::fs::metadata(&git).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&git, perms).unwrap();
+}
+
+#[test]
+fn it_flushes_shim_invocation_metric_on_passthrough_before_process_replacement() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    let real_dir = tmp.path().join("realbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    std::fs::create_dir_all(&real_dir).unwrap();
+
+    // Symlink the shim binary in as `git` (argv[0] = "git" triggers shim mode).
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    // A fast fake real-git so the passthrough returns immediately.
+    make_fake_git(&real_dir);
+
+    let path = format!("{}:{}", shim_dir.display(), real_dir.display());
+
+    let (endpoint, rx) = spawn_capture_server();
+
+    // GIT_PRISM_INSIDE_SHIM=1 forces the passthrough (loop-break) path, which
+    // records shim_invocations_total{outcome="loop_break"} and then replaces the
+    // process with the fake git. The metric MUST be flushed to the OTLP endpoint
+    // before the process is replaced.
+    let status = Command::new(&shim_git)
+        .env("GIT_PRISM_INSIDE_SHIM", "1")
+        .env("GIT_PRISM_OTLP_ENDPOINT", &endpoint)
+        .env("PATH", &path)
+        .arg("status")
+        .status()
+        .unwrap();
+    assert_eq!(status.code(), Some(0), "fake git passthrough should exit 0");
+
+    // A correct implementation force-flushes before replacing the process, so a
+    // real export arrives in well under 5 s. If nothing arrives, the metric was
+    // dropped when the process image was replaced — the bug.
+    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+
+    assert!(
+        received,
+        "shim recorded a shim_invocations_total metric on the passthrough path \
+         but the process was replaced before any flush; no OTLP export was \
+         received. Issue #348 requires flushing before exec on every path that \
+         emitted metrics."
+    );
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+}
+
+fn head_sha(repo: &std::path::Path) -> String {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// CONTROL TEST (must PASS): the structured-output path DOES call
+/// `force_flush()` in `main.rs` before returning. This validates that the
+/// capture-server harness works end-to-end — if the structured path exports
+/// successfully while the passthrough path above does not, the missing flush is
+/// isolated to the passthrough path, not a broken test harness.
+#[test]
+fn it_flushes_shim_metric_on_structured_path_control() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    // A real two-commit fixture repo so the structured handler succeeds.
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "t@t.com"]);
+    git(&repo, &["config", "user.name", "T"]);
+    std::fs::write(repo.join("a.txt"), "alpha\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "first"]);
+    std::fs::write(repo.join("a.txt"), "alpha\nbeta\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "second"]);
+    let sha = head_sha(&repo);
+
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", shim_dir.display(), real_path);
+
+    let (endpoint, rx) = spawn_capture_server();
+
+    // AI_AGENT → agent detected; `git show <sha>` is a classified command →
+    // structured dispatch → run_shim returns → main.rs force_flushes.
+    let out = Command::new(&shim_git)
+        .env("AI_AGENT", "1")
+        .env("GIT_PRISM_REPO", &repo)
+        .env("GIT_PRISM_OTLP_ENDPOINT", &endpoint)
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["show", &sha])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "structured show should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+    assert!(
+        received,
+        "control: structured path must export via force_flush; if this fails, \
+         the harness is broken and the passthrough finding is inconclusive"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #348 (blocker 2 of #346, plus the version-label note).

Shim mode emitted **no telemetry**: the `git || gh` dispatch branch in `main.rs` returned `run_shim(...)` and never called `telemetry::init()` (which runs only on the `serve` path). So the global meter was a no-op, the `record_shim_*` counters wrote nothing, and `GIT_PRISM_OTLP_ENDPOINT` was never read. A sub-second shim process also never triggers the `PeriodicReader`, so `Drop` alone can't flush — an explicit flush is required.

## What changed

- Shim dispatch calls `telemetry::init()` (via a banner-suppressed `init_quiet()`) when the endpoint is set, holds the guard, and flushes before exit.
- New `TelemetryGuard::force_flush_bounded(Duration)` — flushes on a background thread with an `mpsc` `recv_timeout`. The passthrough paths flush with a **300 ms** cap **before `execvp`** replaces the process, so a recorded metric is never dropped, and a down/unreachable collector can't add the full 5 s `EXPORT_TIMEOUT` to every intercepted git command.
- Service version / name default to `env!("CARGO_PKG_VERSION")` / the built-in name when the env var is unset or empty.

## Note for the reporter

The "telemetry mislabeled `0.9.0`" symptom in #346 is **not** a code bug — `telemetry.rs` already defaulted the version to the crate version. It comes from the MCP client registration passing `env: { GIT_PRISM_SERVICE_VERSION: "0.9.0" }` to `git-prism serve`. Drop that override (or set it to the current version) in the MCP config.

## Gauntlet

- **Adversarial QA (2 passes)**: found the passthrough metric-drop bug (recorded then `execvp` before flush) — fixed with a paired OTLP-capture test; verified stdout JSON contract stays clean and metric attributes are bounded enums (no PII / cardinality leak).
- **Church**: observability (added `init_quiet` so the success banner doesn't print on every git command; made the cwd-failure branch use the bounded flush like its siblings), test (version-default + double-flush + bounded-deadline coverage).
- 1033 tests pass; clippy `-D warnings` clean; fmt clean.

Generated with [Claude Code](https://claude.ai/claude-code)
