### PR TITLE
fix(shim): write PATH block to .zshenv + .zshrc so the shim wins for agent shells (#355)

### DIFF
--- a/bdd/features/shim_parity.feature
+++ b/bdd/features/shim_parity.feature
@@ -184,49 +184,55 @@ Feature: Shim parity with the redirect hook and first-class shim subcommand
   # decline, and already-in-PATH (no prompt needed).
   # ===========================================================================
 
-  Rule: User consents to auto-PATH setup — rc file is updated idempotently
+  Rule: User consents to auto-PATH setup — rc files are updated idempotently
 
     @ISSUE-325
-    Scenario: Accepting PATH setup appends the export line to the shell rc
+    Scenario: Accepting PATH setup writes the managed block to .zshenv for agent shells
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zprofile" under HOME
       When I run "git-prism shim install" and consent to PATH setup with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zprofile" under HOME contains the shim directory export line
+      And the rc file ".zshenv" under HOME contains the shim directory export line
       And the output contains "restart"
 
     @ISSUE-325
-    Scenario: Re-running install does not append the export line a second time
+    Scenario: Accepting PATH setup writes the managed block to .zshrc to win over brew prepends
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zprofile" under HOME
+      When I run "git-prism shim install" and consent to PATH setup with the isolated HOME
+      Then the exit code is 0
+      And the rc file ".zshrc" under HOME contains the shim directory export line
+
+    @ISSUE-325
+    Scenario: Re-running install does not duplicate the managed block
+      Given an isolated HOME directory
+      And the shim directory is not in PATH
       When I run "git-prism shim install" and consent to PATH setup with the isolated HOME
       And I run "git-prism shim install" and consent to PATH setup with the isolated HOME again
-      Then the rc file ".zprofile" under HOME contains the shim export line exactly once
+      Then the rc file ".zshenv" under HOME contains the shim export line exactly once
 
-  Rule: User declines auto-PATH setup — rc file is not modified
+  Rule: User declines auto-PATH setup — rc files are not modified
 
     @ISSUE-325
-    Scenario: Declining PATH setup prints manual instructions and leaves rc unchanged
+    Scenario: Declining PATH setup prints manual instructions and leaves rc files unchanged
       Given an isolated HOME directory
       And the shim directory is not in PATH
-      And a shell rc file exists at ".zprofile" under HOME
+      And a shell rc file exists at ".zshenv" under HOME
       When I run "git-prism shim install" and decline PATH setup with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zprofile" under HOME is unchanged
+      And the rc file ".zshenv" under HOME is unchanged
       And the output contains ".local/share/git-prism/bin"
 
-  Rule: Shim directory already in PATH — no prompt, no rc modification
+  Rule: Shim directory already first in PATH — no prompt, no rc modification
 
     @ISSUE-325
-    Scenario: No PATH prompt when shim directory is already in PATH
+    Scenario: No PATH prompt when shim directory is already first in PATH
       Given an isolated HOME directory
       And the shim directory is already in PATH
-      And a shell rc file exists at ".zprofile" under HOME
+      And a shell rc file exists at ".zshenv" under HOME
       When I run "git-prism shim install" with the isolated HOME
       Then the exit code is 0
-      And the rc file ".zprofile" under HOME is unchanged
+      And the rc file ".zshenv" under HOME is unchanged
 
   # ===========================================================================
   # @ISSUE-326 — redirect hook removal (hard removal, no deprecation phase)

--- a/bdd/steps/shim_parity_steps.py
+++ b/bdd/steps/shim_parity_steps.py
@@ -651,17 +651,25 @@ def step_rc_contains_export(context: Context, rel_path: str) -> None:
     )
 
 
+_SHIM_BLOCK_START_MARKER = "# >>> git-prism shim >>>"
+
+
 @then("the rc file \"{rel_path}\" under HOME contains the shim export line exactly once")
 def step_rc_contains_export_exactly_once(context: Context, rel_path: str) -> None:
-    """Assert the shim export line appears exactly once (idempotency)."""
+    """Assert the managed PATH block appears exactly once (idempotency).
+
+    The new marker-delimited block contains the shim path fragment twice (once
+    in each branch of the case statement), so we count block start-markers
+    rather than raw fragment occurrences.
+    """
     rc_path = context.isolated_home / rel_path
     assert rc_path.exists(), f"RC file not found: {rc_path}"
     content = rc_path.read_text()
-    occurrences = content.count(_SHIM_EXPORT_FRAGMENT)
+    occurrences = content.count(_SHIM_BLOCK_START_MARKER)
     assert occurrences == 1, (
-        f"Expected the shim export fragment to appear exactly once in {rc_path}, "
-        f"but found {occurrences} occurrences.\n"
-        f"Fragment: {_SHIM_EXPORT_FRAGMENT!r}\n"
+        f"Expected the managed PATH block to appear exactly once in {rc_path}, "
+        f"but found {occurrences} occurrences of the start marker.\n"
+        f"Marker: {_SHIM_BLOCK_START_MARKER!r}\n"
         f"File contents:\n{content}"
     )
 

--- a/bdd/steps/shim_parity_steps.py
+++ b/bdd/steps/shim_parity_steps.py
@@ -21,6 +21,7 @@ Platform note for @ISSUE-322:
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -141,10 +142,9 @@ def step_shim_dir_already_in_path(context: Context) -> None:
 
     Stores the modified PATH in context so the When step can inject it.
     """
-    shim_dir = str(_shim_dir_path(context))
     shim_dir_path = _shim_dir_path(context)
     shim_dir_path.mkdir(parents=True, exist_ok=True)
-    context.injected_path = f"{shim_dir}:{os.environ.get('PATH', '')}"
+    context.injected_path = f"{shim_dir_path}:{os.environ.get('PATH', '')}"
 
 
 @given("the shim is installed with a \"gh\" symlink")
@@ -479,8 +479,9 @@ def step_shim_install_consent(context: Context) -> None:
     """Run git-prism shim install, answering 'y' to the PATH setup prompt."""
     binary = _find_binary(context)
     env = _isolated_env(context)
-    # Pin SHELL to zsh so detect_rc_file always picks .zprofile, regardless of
-    # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
+    # Pin SHELL to zsh so the install always writes the zsh rc files
+    # (.zshenv + .zshrc), regardless of the CI runner's ambient $SHELL
+    # (which is /bin/bash on GitHub Actions).
     env["SHELL"] = "/bin/zsh"
     # If the shim dir was injected into PATH by a prior Given step, use that.
     if hasattr(context, "injected_path"):
@@ -505,8 +506,9 @@ def step_shim_install_consent_again(context: Context) -> None:
     """Run git-prism shim install a second time with 'y' consent (idempotency check)."""
     binary = _find_binary(context)
     env = _isolated_env(context)
-    # Pin SHELL to zsh so detect_rc_file always picks .zprofile, regardless of
-    # the CI runner's ambient $SHELL (which is /bin/bash on GitHub Actions).
+    # Pin SHELL to zsh so the install always writes the zsh rc files
+    # (.zshenv + .zshrc), regardless of the CI runner's ambient $SHELL
+    # (which is /bin/bash on GitHub Actions).
     env["SHELL"] = "/bin/zsh"
     result = subprocess.run(  # noqa: S603
         [str(binary), "shim", "install"],
@@ -717,11 +719,10 @@ def step_files_entries_have_change_scope(context: Context) -> None:
     binary returns plain text or its own JSON, neither of which has a
     change_scope field on file entries.
     """
-    import json as _json
     stdout = (context.result.stdout or "").strip()
     try:
-        data = _json.loads(stdout)
-    except _json.JSONDecodeError as exc:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
         raise AssertionError(
             f"Output is not valid JSON: {exc}\n"
             f"stdout: {stdout[:500]}\n"

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -227,17 +227,20 @@ fn write_marker_block(rc_path: &std::path::Path) -> Result<()> {
 ///   - Inverted block: END appears before START
 ///   - Orphaned END markers with no preceding START
 ///
-/// The invariant: after this call, the returned string contains neither
-/// `BLOCK_START_MARKER` nor `BLOCK_END_MARKER`.
+/// Marker detection uses full-line equality (`line.trim() == MARKER`), not
+/// substring matching.  A user line that merely *mentions* the marker text
+/// (e.g. `echo "# >>> git-prism shim >>>"`) is preserved unchanged.  Only a
+/// line whose entire trimmed content is the marker string is treated as a
+/// block boundary.
 fn strip_all_marker_blocks(content: &str) -> String {
     let mut result = String::with_capacity(content.len());
     let mut inside_block = false;
 
     for line in content.lines() {
-        if line.contains(BLOCK_START_MARKER) {
+        if line.trim() == BLOCK_START_MARKER {
             // Enter managed block; discard this line.
             inside_block = true;
-        } else if line.contains(BLOCK_END_MARKER) {
+        } else if line.trim() == BLOCK_END_MARKER {
             // Exit managed block; discard this line regardless of whether we
             // saw a matching START (handles orphaned END markers).
             inside_block = false;
@@ -510,6 +513,39 @@ mod tests {
             after.matches(BLOCK_START_MARKER).count(),
             1,
             "exactly one managed block must remain; got:\n{after}"
+        );
+    }
+
+    /// ADVERSARIAL QA (issue #355, gate-3 pass 2): a user line that merely
+    /// *contains* the start-marker text as a substring (e.g. an `echo` or a
+    /// comment that references the marker, or instructions the tool itself
+    /// printed and the user pasted as a note) must NOT cause the writer to treat
+    /// everything after it as a managed block and silently delete it.
+    ///
+    /// `strip_all_marker_blocks` keys on `line.contains(BLOCK_START_MARKER)`, so
+    /// the substring flips `inside_block = true` and every following user line is
+    /// dropped until an END marker appears — and if none does, deletion runs to
+    /// EOF. This is real data loss of user-owned rc content.
+    #[test]
+    fn write_rc_block_does_not_eat_user_lines_that_mention_the_marker_substring() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // No real managed block here — just a user comment/echo that happens to
+        // quote the marker text, followed by genuine user config.
+        let initial = format!(
+            "export EDITOR=vim\necho \"paste the {BLOCK_START_MARKER} line into your rc\"\nexport SECRET_TOKEN=keepme\nalias gp='git-prism'\n"
+        );
+        std::fs::write(home.join(".zshenv"), &initial).unwrap();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let after = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            after.contains("export SECRET_TOKEN=keepme"),
+            "user config after a line that only mentions the marker substring must \
+             be preserved, not deleted; got:\n{after}"
+        );
+        assert!(
+            after.contains("alias gp='git-prism'"),
+            "all trailing user config must survive; got:\n{after}"
         );
     }
 

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -11,9 +11,6 @@ use anyhow::Result;
 
 use crate::hooks;
 
-/// The full export line written to shell rc files.
-const SHIM_EXPORT_LINE: &str = r#"export PATH="$HOME/.local/share/git-prism/bin:$PATH""#;
-
 /// Install the PATH shim symlink and print the result to stdout.
 ///
 /// Idempotent: if the symlink already exists and points at the current binary,
@@ -21,30 +18,34 @@ const SHIM_EXPORT_LINE: &str = r#"export PATH="$HOME/.local/share/git-prism/bin:
 /// target path.
 ///
 /// After installing the symlink, checks whether the shim directory is already
-/// in `PATH`. If not, prompts the user via stdin for consent to append the
-/// export line to their shell rc file.
+/// first on PATH for non-login shells. If not, prompts the user via stdin for
+/// consent to write the managed PATH block to the appropriate rc files.
 pub fn run_install(home: &std::path::Path, force: bool) -> Result<()> {
-    let rc_path = detect_rc_file(home);
+    let shell = std::env::var("SHELL").unwrap_or_default();
     run_install_with_io(
         home,
         force,
         &mut io::stdin().lock(),
         &mut io::stdout(),
-        &rc_path,
+        &shell,
     )
 }
 
 /// Testable install implementation with injected I/O.
 ///
-/// `rc_path` is the shell rc file to append the export line to when the user
-/// consents. Production callers pass `detect_rc_file(home)`; tests pass an
-/// explicit path so the result is independent of the runner's `$SHELL`.
+/// `shell` drives which rc files receive the managed PATH block when the user
+/// consents:
+///   - `"zsh"` → `.zshenv` + `.zshrc`
+///   - `"bash"` → `.bash_profile` + `.bashrc`
+///
+/// Production callers pass the ambient `$SHELL`; tests pass an explicit value
+/// so results are independent of the CI runner's shell.
 pub fn run_install_with_io(
     home: &std::path::Path,
     force: bool,
     stdin: &mut dyn BufRead,
     stdout: &mut dyn Write,
-    rc_path: &std::path::Path,
+    shell: &str,
 ) -> Result<()> {
     hooks::install_path_shim(home, force)?;
     let shim_dir = home.join(hooks::PATH_SHIM_REL_DIR);
@@ -54,36 +55,40 @@ pub fn run_install_with_io(
 
     let shim_dir_str = shim_dir.to_string_lossy().into_owned();
 
-    if shim_dir_is_in_path(&shim_dir_str) {
-        // Already on PATH — nothing to do.
+    if shim_dir_is_first_in_path(&shim_dir_str) {
+        // Already first on PATH — nothing to do.
         return Ok(());
     }
 
-    offer_path_setup(home, rc_path, stdin, stdout)?;
+    offer_path_setup(home, shell, stdin, stdout)?;
     Ok(())
 }
 
-/// Return true if the shim directory string appears in the current `PATH` env var.
-/// Normalizes trailing slashes so a PATH entry like `/path/to/bin/` matches `/path/to/bin`.
-fn shim_dir_is_in_path(shim_dir: &str) -> bool {
+/// Return true if the shim directory is the FIRST entry in the current `PATH`.
+///
+/// Unlike the old "present anywhere" check, this requires the shim to be first
+/// so that it wins over Homebrew/cargo/nvm entries that re-prepend later.
+/// Normalizes trailing slashes so `/path/to/bin/` matches `/path/to/bin`.
+fn shim_dir_is_first_in_path(shim_dir: &str) -> bool {
     let path_env = std::env::var("PATH").unwrap_or_default();
     let normalized_shim = shim_dir.trim_end_matches('/');
-    path_env.split(':').any(|entry| {
-        let normalized_entry = entry.trim_end_matches('/');
-        normalized_entry == normalized_shim
-    })
+    path_env
+        .split(':')
+        .next()
+        .map(|first| first.trim_end_matches('/') == normalized_shim)
+        .unwrap_or(false)
 }
 
 /// Prompt for PATH consent and act on the answer.
 fn offer_path_setup(
     home: &std::path::Path,
-    rc_path: &std::path::Path,
+    shell: &str,
     stdin: &mut dyn BufRead,
     stdout: &mut dyn Write,
 ) -> Result<()> {
     writeln!(
         stdout,
-        "\nThe shim directory is not in your PATH.\nAdd it automatically? [y/N] "
+        "\nThe shim directory is not first in your PATH.\nAdd it automatically? [y/N] "
     )?;
     stdout.flush()?;
 
@@ -91,48 +96,30 @@ fn offer_path_setup(
     stdin.read_line(&mut answer)?;
 
     if answer.trim().eq_ignore_ascii_case("y") {
-        append_to_rc_idempotent(home, rc_path, stdout)?;
+        write_rc_block_for_shell(home, shell)?;
+        print_setup_success(shell, stdout)?;
     } else {
         print_manual_instructions(stdout)?;
     }
     Ok(())
 }
 
-/// Append the export line to the shell rc file, unless it is already present.
-/// Detects presence by matching the full export line (line-wise, ignoring comments).
-fn append_to_rc_idempotent(
-    home: &std::path::Path,
-    rc_path: &std::path::Path,
-    stdout: &mut dyn Write,
-) -> Result<()> {
-    let existing = if rc_path.exists() {
-        std::fs::read_to_string(rc_path)?
+/// Print success message after writing the managed PATH block.
+fn print_setup_success(shell: &str, stdout: &mut dyn Write) -> Result<()> {
+    let basename = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(shell);
+    let (env_file, rc_file) = if basename == "bash" {
+        (".bash_profile", ".bashrc")
     } else {
-        String::new()
+        (".zshenv", ".zshrc")
     };
-
-    // Check if the full export line already exists (non-comment, trimmed match).
-    let export_line_already_present = existing.lines().any(|line| {
-        let trimmed = line.trim_start();
-        !trimmed.starts_with('#') && trimmed.trim() == SHIM_EXPORT_LINE.trim()
-    });
-
-    if !export_line_already_present {
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(rc_path)?;
-        writeln!(file, "\n{SHIM_EXPORT_LINE}")?;
-    }
-
-    let rc_display = rc_path
-        .strip_prefix(home)
-        .map(|p| format!("~/{}", p.display()))
-        .unwrap_or_else(|_| rc_path.display().to_string());
-
+    let env_display = format!("~/{env_file}");
+    let rc_display = format!("~/{rc_file}");
     writeln!(
         stdout,
-        "Added to {rc_display}. Please restart Claude Code so the new PATH takes effect in its shell snapshot."
+        "Added to {env_display} and {rc_display}. Please restart Claude Code so the new PATH takes effect in its shell snapshot."
     )?;
     Ok(())
 }
@@ -141,38 +128,100 @@ fn append_to_rc_idempotent(
 fn print_manual_instructions(stdout: &mut dyn Write) -> Result<()> {
     writeln!(
         stdout,
-        "To complete setup, add this line to your shell rc manually:\n  {SHIM_EXPORT_LINE}"
+        "To complete setup, add this block to ~/.zshenv and the end of ~/.zshrc manually:\n\
+         \n\
+         {BLOCK_START_MARKER}\n\
+         {SHIM_PATH_BLOCK_BODY}\n\
+         {BLOCK_END_MARKER}"
     )?;
     Ok(())
 }
 
-/// Determine the login-shell rc file based on `$SHELL`, defaulting to `.zprofile`.
+/// Write the marker-delimited PATH shim block to the appropriate rc files for the given shell.
 ///
-/// Non-interactive login shells (like Claude Code's) source `.zprofile` / `.bash_profile`
-/// but skip `.zshrc` / `.bashrc`. macOS `path_helper` also demotes PATH entries inherited
-/// from the environment behind `/usr/bin`, so writing to `.zshrc` has no effect in that
-/// context. Use login-shell rc files to ensure the export takes effect.
-fn detect_rc_file(home: &std::path::Path) -> std::path::PathBuf {
-    let shell = std::env::var("SHELL").unwrap_or_default();
-    detect_rc_file_for(home, &shell)
-}
-
-/// Testable rc-file detection with an injected shell string.
+/// For zsh: writes to `~/.zshenv` (covers non-login non-interactive agent shells)
+/// and appends/replaces at the end of `~/.zshrc` (re-asserts priority after brew/cargo prepends).
+/// For bash: writes to `~/.bashrc` and `~/.bash_profile`.
 ///
-/// Matches on the basename of the shell path so that a path which merely
-/// contains "bash" as a substring (e.g. `/usr/local/bin/newbash`) is not
-/// misidentified as bash.
-pub(crate) fn detect_rc_file_for(home: &std::path::Path, shell: &str) -> std::path::PathBuf {
+/// The block is marker-delimited so re-running replaces the existing block (idempotent).
+pub(crate) fn write_rc_block_for_shell(home: &std::path::Path, shell: &str) -> Result<()> {
     let basename = std::path::Path::new(shell)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(shell);
-    let rc_name = if basename == "bash" {
-        ".bash_profile"
+    let (env_file, rc_file) = if basename == "bash" {
+        (".bash_profile", ".bashrc")
     } else {
-        ".zprofile"
+        (".zshenv", ".zshrc")
     };
-    home.join(rc_name)
+    write_marker_block(home, &home.join(env_file))?;
+    write_marker_block(home, &home.join(rc_file))?;
+    Ok(())
+}
+
+/// Markers that delimit the managed PATH block so it can be replaced idempotently.
+const BLOCK_START_MARKER: &str = "# >>> git-prism shim >>>";
+const BLOCK_END_MARKER: &str = "# <<< git-prism shim <<<";
+
+/// The managed PATH block content (without markers).
+const SHIM_PATH_BLOCK_BODY: &str = r#"case ":$PATH:" in
+  ":$HOME/.local/share/git-prism/bin:"*) ;;
+  *) PATH="$HOME/.local/share/git-prism/bin:${PATH//:$HOME\/.local\/share\/git-prism\/bin:/:}"; export PATH ;;
+esac"#;
+
+/// Write (or replace) the marker-delimited PATH block in the given rc file.
+///
+/// If the file already contains the markers, the block between them is replaced.
+/// If not, the block is appended. Creates the file if it doesn't exist.
+fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Result<()> {
+    let existing = if rc_path.exists() {
+        std::fs::read_to_string(rc_path)?
+    } else {
+        String::new()
+    };
+
+    let new_block = format!("{BLOCK_START_MARKER}\n{SHIM_PATH_BLOCK_BODY}\n{BLOCK_END_MARKER}\n");
+
+    let new_content = if existing.contains(BLOCK_START_MARKER) {
+        // Replace the existing block between markers (handles the end marker too).
+        replace_marker_block(&existing, &new_block)
+    } else {
+        // Append the block, ensuring a single newline separator.
+        let separator = if existing.ends_with('\n') || existing.is_empty() {
+            ""
+        } else {
+            "\n"
+        };
+        format!("{existing}{separator}\n{new_block}")
+    };
+
+    std::fs::write(rc_path, new_content)?;
+
+    let rc_display = rc_path
+        .strip_prefix(home)
+        .map(|p| format!("~/{}", p.display()))
+        .unwrap_or_else(|_| rc_path.display().to_string());
+    let _ = rc_display; // used in caller output
+    Ok(())
+}
+
+/// Replace the content between (and including) the start and end markers with `new_block`.
+fn replace_marker_block(content: &str, new_block: &str) -> String {
+    let start = content.find(BLOCK_START_MARKER);
+    let end = content.find(BLOCK_END_MARKER);
+    match (start, end) {
+        (Some(s), Some(e)) => {
+            let after_end = e + BLOCK_END_MARKER.len();
+            // Consume the trailing newline after the end marker if present.
+            let after_end = if content[after_end..].starts_with('\n') {
+                after_end + 1
+            } else {
+                after_end
+            };
+            format!("{}{}{}", &content[..s], new_block, &content[after_end..])
+        }
+        _ => format!("{content}\n{new_block}"),
+    }
 }
 
 /// Remove the PATH shim symlink.
@@ -187,12 +236,37 @@ pub fn run_uninstall(home: &std::path::Path) -> Result<()> {
 /// Output always includes the shim directory path so the user knows where
 /// to add to `$PATH` regardless of install state. Each managed symlink name
 /// (`git`, `gh`) is reported on a separate line.
+///
+/// Also checks whether the shim directory is first on PATH using the current
+/// process environment, and emits a warning when it is not.
 pub fn run_status(home: &std::path::Path) -> Result<()> {
-    run_status_with_io(home, &mut std::io::stdout())
+    let path_env = std::env::var("PATH").ok();
+    run_status_with_path(home, &mut std::io::stdout(), path_env.as_deref())
 }
 
 /// Testable status implementation with injected output writer.
+#[cfg(test)]
 pub fn run_status_with_io(home: &std::path::Path, out: &mut dyn std::io::Write) -> Result<()> {
+    let path_env = std::env::var("PATH").ok();
+    run_status_with_path(home, out, path_env.as_deref())
+}
+
+/// Fully-injectable status implementation for testing (injected PATH string).
+#[cfg(test)]
+pub(crate) fn run_status_with_path_for_test(
+    home: &std::path::Path,
+    out: &mut dyn std::io::Write,
+    path_override: Option<&str>,
+) -> Result<()> {
+    run_status_with_path(home, out, path_override)
+}
+
+/// Core status implementation with injected PATH.
+fn run_status_with_path(
+    home: &std::path::Path,
+    out: &mut dyn std::io::Write,
+    path_env: Option<&str>,
+) -> Result<()> {
     let shim_dir = home.join(hooks::PATH_SHIM_REL_DIR);
     let shim_dir_str = shim_dir.to_string_lossy();
 
@@ -222,6 +296,25 @@ pub fn run_status_with_io(home: &std::path::Path, out: &mut dyn std::io::Write) 
     }
 
     writeln!(out, "shim directory: {shim_dir_str}")?;
+
+    // Warn when the shim dir is not first on PATH — this is the condition that
+    // causes agent shells to resolve the real git/gh instead of the shim.
+    if let Some(path) = path_env {
+        let normalized_shim = shim_dir_str.trim_end_matches('/');
+        let is_first = path
+            .split(':')
+            .next()
+            .map(|first| first.trim_end_matches('/') == normalized_shim)
+            .unwrap_or(false);
+        if !is_first {
+            writeln!(
+                out,
+                "warning: shim directory is not first on PATH — agent shells will not intercept git/gh.\n\
+                 Run `git-prism shim install` and restart Claude Code to fix this."
+            )?;
+        }
+    }
+
     Ok(())
 }
 
@@ -233,25 +326,187 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    // ---------------------------------------------------------------------------
+    // TDD: marker-delimited multi-file block writer (issue #355)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn write_rc_block_creates_zshenv_and_zshrc_for_zsh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        assert!(
+            home.join(".zshenv").exists(),
+            ".zshenv must be created for zsh"
+        );
+        assert!(
+            home.join(".zshrc").exists(),
+            ".zshrc must be created for zsh"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_creates_bash_profile_and_bashrc_for_bash() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "bash").unwrap();
+        assert!(
+            home.join(".bash_profile").exists(),
+            ".bash_profile must be created for bash"
+        );
+        assert!(
+            home.join(".bashrc").exists(),
+            ".bashrc must be created for bash"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_contains_marker_delimiters() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            zshenv.contains(BLOCK_START_MARKER),
+            ".zshenv must contain start marker"
+        );
+        assert!(
+            zshenv.contains(BLOCK_END_MARKER),
+            ".zshenv must contain end marker"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_is_idempotent_no_duplicate_block() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        let start_count = zshenv.matches(BLOCK_START_MARKER).count();
+        assert_eq!(
+            start_count, 1,
+            "start marker must appear exactly once after two writes; content:\n{zshenv}"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_uses_forces_first_case_statement() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        // The block must use `case` (not a simple guard) to force-prepend even
+        // when the shim dir already appears later in PATH.
+        assert!(
+            zshenv.contains("case \":$PATH:\""),
+            ".zshenv block must use case statement for forces-first semantics; got:\n{zshenv}"
+        );
+        assert!(
+            zshenv.contains("export PATH"),
+            ".zshenv block must export PATH"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_replaces_existing_block_on_rerun() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // Manually write a "stale" block.
+        let stale = format!(
+            "{}\n# stale content\n{}\n",
+            BLOCK_START_MARKER, BLOCK_END_MARKER
+        );
+        std::fs::write(home.join(".zshenv"), &stale).unwrap();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let after = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            !after.contains("stale content"),
+            "stale block content must be replaced on rerun; got:\n{after}"
+        );
+        assert!(
+            after.contains("case \":$PATH:\""),
+            "replacement block must contain the current case statement"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_preserves_content_after_end_marker() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let initial = format!(
+            "{}\n# old block\n{}\n# user stuff after\n",
+            BLOCK_START_MARKER, BLOCK_END_MARKER
+        );
+        std::fs::write(home.join(".zshenv"), &initial).unwrap();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let after = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            after.contains("user stuff after"),
+            "content after the end marker must be preserved; got:\n{after}"
+        );
+    }
+
+    #[test]
+    fn write_rc_block_works_with_full_shell_path_like_bin_zsh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        write_rc_block_for_shell(home, "/bin/zsh").unwrap();
+        assert!(
+            home.join(".zshenv").exists(),
+            ".zshenv must be created for /bin/zsh"
+        );
+        assert!(
+            home.join(".zshrc").exists(),
+            ".zshrc must be created for /bin/zsh"
+        );
+    }
+
     /// The shim-dir path fragment, derived from the canonical constant in
     /// `hooks` so these assertions track the real install location instead of a
     /// drifting literal copy.
     const SHIM_EXPORT_FRAGMENT: &str = hooks::PATH_SHIM_REL_DIR;
 
-    /// Install with consent, using an explicit `.zshrc` path so the test is
-    /// independent of the CI runner's `$SHELL`.
+    /// Install with consent, pinning shell to zsh so tests are independent of
+    /// the CI runner's `$SHELL`.
     fn install_with_consent(home: &std::path::Path) {
-        let rc = home.join(".zshrc");
         let mut stdin = Cursor::new("y\n");
         let mut stdout = Vec::new();
-        run_install_with_io(home, false, &mut stdin, &mut stdout, &rc).unwrap();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, "zsh").unwrap();
     }
 
     fn install_with_decline(home: &std::path::Path) {
-        let rc = home.join(".zshrc");
         let mut stdin = Cursor::new("n\n");
         let mut stdout = Vec::new();
-        run_install_with_io(home, false, &mut stdin, &mut stdout, &rc).unwrap();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, "zsh").unwrap();
+    }
+
+    #[test]
+    fn consent_writes_marker_block_to_zshenv_for_zsh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let mut stdin = Cursor::new("y\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, "zsh").unwrap();
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            zshenv.contains(BLOCK_START_MARKER),
+            ".zshenv must contain the marker block after consent"
+        );
+    }
+
+    #[test]
+    fn consent_writes_marker_block_to_zshrc_for_zsh() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let mut stdin = Cursor::new("y\n");
+        let mut stdout = Vec::new();
+        run_install_with_io(home, false, &mut stdin, &mut stdout, "zsh").unwrap();
+        let zshrc = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert!(
+            zshrc.contains(BLOCK_START_MARKER),
+            ".zshrc must contain the marker block after consent"
+        );
     }
 
     #[test]
@@ -290,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    fn consent_appends_export_line_exactly_once_on_repeat() {
+    fn consent_appends_block_exactly_once_on_repeat() {
         let dir = TempDir::new().unwrap();
         let rc = dir.path().join(".zshrc");
         std::fs::write(&rc, "# shell rc\n").unwrap();
@@ -299,19 +554,21 @@ mod tests {
         install_with_consent(dir.path());
 
         let content = std::fs::read_to_string(&rc).unwrap();
-        let count = content.matches(SHIM_EXPORT_FRAGMENT).count();
-        assert_eq!(count, 1, "export fragment must appear exactly once");
+        // Count the start marker — exactly one block means exactly one marker.
+        let count = content.matches(BLOCK_START_MARKER).count();
+        assert_eq!(
+            count, 1,
+            "managed PATH block must appear exactly once after two consents; rc:\n{content}"
+        );
     }
 
     #[test]
     fn consent_output_contains_restart() {
         let dir = TempDir::new().unwrap();
-        let rc = dir.path().join(".zshrc");
-        std::fs::write(&rc, "# shell rc\n").unwrap();
 
         let mut stdin = Cursor::new("y\n");
         let mut stdout = Vec::new();
-        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, &rc).unwrap();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, "zsh").unwrap();
 
         let out = String::from_utf8(stdout).unwrap();
         assert!(
@@ -321,25 +578,35 @@ mod tests {
     }
 
     #[test]
-    fn decline_leaves_rc_file_unchanged() {
+    fn decline_leaves_rc_files_unchanged() {
         let dir = TempDir::new().unwrap();
-        let rc = dir.path().join(".zshrc");
-        std::fs::write(&rc, "# shell rc\n").unwrap();
-        let original = std::fs::read_to_string(&rc).unwrap();
+        let home = dir.path();
+        // Pre-create both files so we can check neither is modified.
+        std::fs::write(home.join(".zshenv"), "# zshenv\n").unwrap();
+        std::fs::write(home.join(".zshrc"), "# zshrc\n").unwrap();
+        let zshenv_before = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        let zshrc_before = std::fs::read_to_string(home.join(".zshrc")).unwrap();
 
-        install_with_decline(dir.path());
+        install_with_decline(home);
 
-        let after = std::fs::read_to_string(&rc).unwrap();
-        assert_eq!(original, after, "rc file must be unchanged after decline");
+        let zshenv_after = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        let zshrc_after = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert_eq!(
+            zshenv_before, zshenv_after,
+            ".zshenv must be unchanged after decline"
+        );
+        assert_eq!(
+            zshrc_before, zshrc_after,
+            ".zshrc must be unchanged after decline"
+        );
     }
 
     #[test]
     fn decline_output_contains_shim_dir_path() {
         let dir = TempDir::new().unwrap();
-        let rc = dir.path().join(".zshrc");
         let mut stdin = Cursor::new("n\n");
         let mut stdout = Vec::new();
-        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, &rc).unwrap();
+        run_install_with_io(dir.path(), false, &mut stdin, &mut stdout, "zsh").unwrap();
 
         let out = String::from_utf8(stdout).unwrap();
         assert!(
@@ -371,54 +638,77 @@ mod tests {
     }
 
     #[test]
-    fn detect_rc_file_returns_zprofile_for_zsh() {
+    fn shell_routing_writes_zshenv_and_zshrc_for_zsh() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
-        // Simulate SHELL=zsh by calling detect_rc_file directly.
-        // We need to test the logic without relying on the CI runner's $SHELL.
-        // detect_rc_file_for lets us inject the shell string.
-        let rc = detect_rc_file_for(home, "zsh");
-        assert!(
-            rc.ends_with(".zprofile"),
-            "zsh rc must be .zprofile (login-shell sourced), got: {}",
-            rc.display()
-        );
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        assert!(home.join(".zshenv").exists(), "zsh must write .zshenv");
+        assert!(home.join(".zshrc").exists(), "zsh must write .zshrc");
     }
 
     #[test]
-    fn detect_rc_file_returns_bash_profile_for_bash() {
+    fn shell_routing_writes_bash_profile_and_bashrc_for_bash() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
-        let rc = detect_rc_file_for(home, "bash");
+        write_rc_block_for_shell(home, "bash").unwrap();
         assert!(
-            rc.ends_with(".bash_profile"),
-            "bash rc must be .bash_profile (login-shell sourced), got: {}",
-            rc.display()
+            home.join(".bash_profile").exists(),
+            "bash must write .bash_profile"
         );
+        assert!(home.join(".bashrc").exists(), "bash must write .bashrc");
     }
 
     #[test]
-    fn detect_rc_file_defaults_to_zprofile_when_shell_unknown() {
+    fn shell_routing_defaults_to_zsh_files_for_unknown_shell() {
         let dir = TempDir::new().unwrap();
-        let rc = detect_rc_file_for(dir.path(), "");
+        write_rc_block_for_shell(dir.path(), "").unwrap();
         assert!(
-            rc.ends_with(".zprofile"),
-            "unknown shell must default to .zprofile, got: {}",
-            rc.display()
+            dir.path().join(".zshenv").exists(),
+            "unknown shell must default to .zshenv"
         );
     }
 
     /// A path that merely CONTAINS "bash" as a substring (e.g. `/usr/local/newbash`)
-    /// must not be misidentified as bash — only a path whose final component IS
-    /// "bash" (or the bare string "bash") should select `.bash_profile`.
+    /// must not be misidentified as bash — only a path whose final component IS "bash"
+    /// should route to bash files.
     #[test]
-    fn detect_rc_file_does_not_misroute_shell_path_containing_bash_as_substring() {
+    fn shell_routing_does_not_misroute_shell_path_containing_bash_as_substring() {
         let dir = TempDir::new().unwrap();
-        let rc = detect_rc_file_for(dir.path(), "/usr/local/bin/newbash");
+        write_rc_block_for_shell(dir.path(), "/usr/local/bin/newbash").unwrap();
         assert!(
-            rc.ends_with(".zprofile"),
-            "shell whose basename is 'newbash' (not 'bash') must default to .zprofile, got: {}",
-            rc.display()
+            dir.path().join(".zshenv").exists(),
+            "shell whose basename is 'newbash' (not 'bash') must default to .zshenv"
+        );
+    }
+
+    #[test]
+    fn run_status_warns_when_shim_not_first_in_nonlogin_shell_path() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        install_with_decline(home);
+        let mut out = Vec::new();
+        // Simulate a non-login shell where the shim dir is present but NOT first.
+        run_status_with_path_for_test(home, &mut out, Some("/opt/homebrew/bin:/usr/bin")).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains("warning") || text.contains("not first"),
+            "status must warn when shim dir is not first on PATH; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn run_status_no_warning_when_shim_is_first_in_path() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        install_with_decline(home);
+        let shim_dir = home.join(".local/share/git-prism/bin");
+        let path_with_shim_first = format!("{}:/opt/homebrew/bin:/usr/bin", shim_dir.display());
+        let mut out = Vec::new();
+        run_status_with_path_for_test(home, &mut out, Some(&path_with_shim_first)).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            !text.contains("not first"),
+            "status must not warn when shim dir is first on PATH; got: {text:?}"
         );
     }
 

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -7,7 +7,7 @@
 
 use std::io::{self, BufRead, Write};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::hooks;
 
@@ -99,36 +99,45 @@ fn offer_path_setup(
         write_rc_block_for_shell(home, shell)?;
         print_setup_success(shell, stdout)?;
     } else {
-        print_manual_instructions(stdout)?;
+        print_manual_instructions(shell, stdout)?;
     }
     Ok(())
 }
 
-/// Print success message after writing the managed PATH block.
-fn print_setup_success(shell: &str, stdout: &mut dyn Write) -> Result<()> {
+/// Resolve the (env-file, rc-file) pair for a shell, keyed on the basename of
+/// `$SHELL`. `"bash"` routes to the bash startup files; everything else (zsh,
+/// empty, unknown) defaults to the zsh pair.
+///
+/// Matching on the basename — not a substring of the whole path — means a shell
+/// at `/usr/local/bin/newbash` is correctly treated as not-bash.
+fn rc_files_for_shell(shell: &str) -> (&'static str, &'static str) {
     let basename = std::path::Path::new(shell)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(shell);
-    let (env_file, rc_file) = if basename == "bash" {
+    if basename == "bash" {
         (".bash_profile", ".bashrc")
     } else {
         (".zshenv", ".zshrc")
-    };
-    let env_display = format!("~/{env_file}");
-    let rc_display = format!("~/{rc_file}");
+    }
+}
+
+/// Print success message after writing the managed PATH block.
+fn print_setup_success(shell: &str, stdout: &mut dyn Write) -> Result<()> {
+    let (env_file, rc_file) = rc_files_for_shell(shell);
     writeln!(
         stdout,
-        "Added to {env_display} and {rc_display}. Please restart Claude Code so the new PATH takes effect in its shell snapshot."
+        "Added to ~/{env_file} and ~/{rc_file}. Please restart Claude Code so the new PATH takes effect in its shell snapshot."
     )?;
     Ok(())
 }
 
-/// Print manual PATH instructions to stdout.
-fn print_manual_instructions(stdout: &mut dyn Write) -> Result<()> {
+/// Print manual PATH instructions naming the rc files for the active shell.
+fn print_manual_instructions(shell: &str, stdout: &mut dyn Write) -> Result<()> {
+    let (env_file, rc_file) = rc_files_for_shell(shell);
     writeln!(
         stdout,
-        "To complete setup, add this block to ~/.zshenv and the end of ~/.zshrc manually:\n\
+        "To complete setup, add this block to ~/{env_file} and the end of ~/{rc_file} manually:\n\
          \n\
          {BLOCK_START_MARKER}\n\
          {SHIM_PATH_BLOCK_BODY}\n\
@@ -145,17 +154,9 @@ fn print_manual_instructions(stdout: &mut dyn Write) -> Result<()> {
 ///
 /// The block is marker-delimited so re-running replaces the existing block (idempotent).
 pub(crate) fn write_rc_block_for_shell(home: &std::path::Path, shell: &str) -> Result<()> {
-    let basename = std::path::Path::new(shell)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(shell);
-    let (env_file, rc_file) = if basename == "bash" {
-        (".bash_profile", ".bashrc")
-    } else {
-        (".zshenv", ".zshrc")
-    };
-    write_marker_block(home, &home.join(env_file))?;
-    write_marker_block(home, &home.join(rc_file))?;
+    let (env_file, rc_file) = rc_files_for_shell(shell);
+    write_marker_block(&home.join(env_file))?;
+    write_marker_block(&home.join(rc_file))?;
     Ok(())
 }
 
@@ -189,9 +190,10 @@ esac"#;
 /// Strips ALL existing managed blocks and stray markers (handles corruption
 /// from hand-edits, interrupted writes, or prior buggy runs) then appends
 /// exactly one canonical block.  Creates the file if it doesn't exist.
-fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Result<()> {
+fn write_marker_block(rc_path: &std::path::Path) -> Result<()> {
     let existing = if rc_path.exists() {
-        std::fs::read_to_string(rc_path)?
+        std::fs::read_to_string(rc_path)
+            .with_context(|| format!("failed to read rc file {}", rc_path.display()))?
     } else {
         String::new()
     };
@@ -212,13 +214,8 @@ fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Resu
         format!("{cleaned}{separator}\n{new_block}")
     };
 
-    std::fs::write(rc_path, new_content)?;
-
-    let rc_display = rc_path
-        .strip_prefix(home)
-        .map(|p| format!("~/{}", p.display()))
-        .unwrap_or_else(|_| rc_path.display().to_string());
-    let _ = rc_display; // used in caller output
+    std::fs::write(rc_path, new_content)
+        .with_context(|| format!("failed to write PATH shim block to {}", rc_path.display()))?;
     Ok(())
 }
 
@@ -485,6 +482,38 @@ mod tests {
     }
 
     #[test]
+    fn write_rc_block_preserves_content_before_start_marker() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        // User content sits BEFORE an existing managed block. The rewrite strips
+        // the old block but must not eat the lines that precede it.
+        let initial = format!(
+            "export EDITOR=vim\n# my own path tweaks\n{}\n# old block body\n{}\n",
+            BLOCK_START_MARKER, BLOCK_END_MARKER
+        );
+        std::fs::write(home.join(".zshenv"), &initial).unwrap();
+        write_rc_block_for_shell(home, "zsh").unwrap();
+        let after = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            after.contains("export EDITOR=vim"),
+            "user content before the start marker must be preserved; got:\n{after}"
+        );
+        assert!(
+            after.contains("# my own path tweaks"),
+            "all user lines before the start marker must be preserved; got:\n{after}"
+        );
+        assert!(
+            !after.contains("# old block body"),
+            "the stale block body must still be stripped; got:\n{after}"
+        );
+        assert_eq!(
+            after.matches(BLOCK_START_MARKER).count(),
+            1,
+            "exactly one managed block must remain; got:\n{after}"
+        );
+    }
+
+    #[test]
     fn write_rc_block_works_with_full_shell_path_like_bin_zsh() {
         let dir = TempDir::new().unwrap();
         let home = dir.path();
@@ -727,9 +756,16 @@ mod tests {
         // Simulate a non-login shell where the shim dir is present but NOT first.
         run_status_with_path_for_test(home, &mut out, Some("/opt/homebrew/bin:/usr/bin")).unwrap();
         let text = String::from_utf8(out).unwrap();
+        // Assert the specific PATH-ordering warning, not a bare "warning" substring
+        // (the staleness path also prints "warning", so an OR would mask a
+        // regression that dropped the not-first message but kept some other warning).
         assert!(
-            text.contains("warning") || text.contains("not first"),
-            "status must warn when shim dir is not first on PATH; got: {text:?}"
+            text.contains("not first on PATH"),
+            "status must warn that the shim dir is not first on PATH; got: {text:?}"
+        );
+        assert!(
+            text.contains("git-prism shim install"),
+            "the not-first warning must name the remedy (`git-prism shim install`); got: {text:?}"
         );
     }
 

--- a/src/shim_cmd.rs
+++ b/src/shim_cmd.rs
@@ -164,15 +164,31 @@ const BLOCK_START_MARKER: &str = "# >>> git-prism shim >>>";
 const BLOCK_END_MARKER: &str = "# <<< git-prism shim <<<";
 
 /// The managed PATH block content (without markers).
+///
+/// Strips the shim dir from ALL positions in PATH (front, middle, or end) before
+/// prepending it exactly once. The implementation wraps PATH in colons so every
+/// entry is colon-bounded on both sides, applies a global substitution, then
+/// unwraps. Only the exact shim dir path is removed; superstring siblings such as
+/// `git-prism/bin-extra` are not affected because the patterns are colon-anchored.
 const SHIM_PATH_BLOCK_BODY: &str = r#"case ":$PATH:" in
   ":$HOME/.local/share/git-prism/bin:"*) ;;
-  *) PATH="$HOME/.local/share/git-prism/bin:${PATH//:$HOME\/.local\/share\/git-prism\/bin:/:}"; export PATH ;;
+  *)
+    _gp_shim="$HOME/.local/share/git-prism/bin"
+    _gp_p=":${PATH}:"
+    _gp_p="${_gp_p//:${_gp_shim}:/:}"
+    _gp_p="${_gp_p#:}"
+    _gp_p="${_gp_p%:}"
+    PATH="${_gp_shim}${_gp_p:+:${_gp_p}}"
+    export PATH
+    unset _gp_shim _gp_p
+    ;;
 esac"#;
 
 /// Write (or replace) the marker-delimited PATH block in the given rc file.
 ///
-/// If the file already contains the markers, the block between them is replaced.
-/// If not, the block is appended. Creates the file if it doesn't exist.
+/// Strips ALL existing managed blocks and stray markers (handles corruption
+/// from hand-edits, interrupted writes, or prior buggy runs) then appends
+/// exactly one canonical block.  Creates the file if it doesn't exist.
 fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Result<()> {
     let existing = if rc_path.exists() {
         std::fs::read_to_string(rc_path)?
@@ -182,17 +198,18 @@ fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Resu
 
     let new_block = format!("{BLOCK_START_MARKER}\n{SHIM_PATH_BLOCK_BODY}\n{BLOCK_END_MARKER}\n");
 
-    let new_content = if existing.contains(BLOCK_START_MARKER) {
-        // Replace the existing block between markers (handles the end marker too).
-        replace_marker_block(&existing, &new_block)
+    let cleaned = strip_all_marker_blocks(&existing);
+
+    // Append the single canonical block with a blank-line separator.
+    let separator = if cleaned.ends_with('\n') || cleaned.is_empty() {
+        ""
     } else {
-        // Append the block, ensuring a single newline separator.
-        let separator = if existing.ends_with('\n') || existing.is_empty() {
-            ""
-        } else {
-            "\n"
-        };
-        format!("{existing}{separator}\n{new_block}")
+        "\n"
+    };
+    let new_content = if cleaned.is_empty() {
+        new_block
+    } else {
+        format!("{cleaned}{separator}\n{new_block}")
     };
 
     std::fs::write(rc_path, new_content)?;
@@ -205,22 +222,42 @@ fn write_marker_block(home: &std::path::Path, rc_path: &std::path::Path) -> Resu
     Ok(())
 }
 
-/// Replace the content between (and including) the start and end markers with `new_block`.
-fn replace_marker_block(content: &str, new_block: &str) -> String {
-    let start = content.find(BLOCK_START_MARKER);
-    let end = content.find(BLOCK_END_MARKER);
-    match (start, end) {
-        (Some(s), Some(e)) => {
-            let after_end = e + BLOCK_END_MARKER.len();
-            // Consume the trailing newline after the end marker if present.
-            let after_end = if content[after_end..].starts_with('\n') {
-                after_end + 1
-            } else {
-                after_end
-            };
-            format!("{}{}{}", &content[..s], new_block, &content[after_end..])
+/// Remove every git-prism managed block (and any stray marker lines) from `content`.
+///
+/// Handles all corruption forms:
+///   - Well-formed START..END pairs (any number of them)
+///   - Truncated block: START present, END missing
+///   - Inverted block: END appears before START
+///   - Orphaned END markers with no preceding START
+///
+/// The invariant: after this call, the returned string contains neither
+/// `BLOCK_START_MARKER` nor `BLOCK_END_MARKER`.
+fn strip_all_marker_blocks(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut inside_block = false;
+
+    for line in content.lines() {
+        if line.contains(BLOCK_START_MARKER) {
+            // Enter managed block; discard this line.
+            inside_block = true;
+        } else if line.contains(BLOCK_END_MARKER) {
+            // Exit managed block; discard this line regardless of whether we
+            // saw a matching START (handles orphaned END markers).
+            inside_block = false;
+        } else if !inside_block {
+            result.push_str(line);
+            result.push('\n');
         }
-        _ => format!("{content}\n{new_block}"),
+        // Lines inside a managed block are silently dropped.
+    }
+
+    // Trim trailing blank lines introduced by block removal, but preserve a
+    // single trailing newline when the original content ended with one.
+    let trimmed = result.trim_end_matches('\n');
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("{trimmed}\n")
     }
 }
 

--- a/tests/shim_auto_path_pentest.rs
+++ b/tests/shim_auto_path_pentest.rs
@@ -5,40 +5,37 @@
 //! These drive the built binary end-to-end via `git-prism shim install`,
 //! injecting stdin and an isolated HOME. They probe the idempotency /
 //! consent logic in `src/shim_cmd.rs`.
+//!
+//! Updated for issue #355: install now writes a marker-delimited block to
+//! `~/.zshenv` + `~/.zshrc` (not a single export line to `~/.zprofile`).
 
 use std::process::{Command, Stdio};
 
 use tempfile::TempDir;
 
-/// Clean PATH that does NOT contain the isolated shim dir, so detection always
-/// reports "not in PATH" and the consent prompt fires.
+/// Clean PATH that does NOT lead with the isolated shim dir, so detection always
+/// reports "not first in PATH" and the consent prompt fires.
 const CLEAN_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
 
-fn count_real_export_lines(rc: &str) -> usize {
-    rc.lines()
-        .filter(|l| {
-            let t = l.trim_start();
-            !t.starts_with('#')
-                && t.contains(r#"export PATH="$HOME/.local/share/git-prism/bin:$PATH""#)
-        })
-        .count()
+const BLOCK_START_MARKER: &str = "# >>> git-prism shim >>>";
+
+fn count_marker_blocks(rc: &str) -> usize {
+    rc.matches(BLOCK_START_MARKER).count()
 }
 
-/// BUG: when the rc file merely MENTIONS the fragment `.local/share/git-prism/bin`
-/// in an unrelated line (a comment, a backup-dir path, a doc reference), the
-/// idempotency check `existing.contains(SHIM_EXPORT_FRAGMENT)` false-positives.
-/// On consent the export line is NOT appended, yet stdout claims
-/// "Added to ~/.zshrc. Please restart Claude Code...". The user is told setup
-/// succeeded while the rc has no working export — a silent failure plus a lie.
+/// The old bug: when the rc file merely MENTIONS the fragment `.local/share/git-prism/bin`
+/// in a comment, the fragment-based idempotency check false-positives and skips writing
+/// the real block. With marker-based idempotency this is fixed: the start marker must be
+/// present (not any fragment) for the block to be considered already written.
 #[test]
-fn consent_appends_export_even_when_fragment_appears_in_unrelated_line() {
+fn consent_writes_block_even_when_fragment_appears_in_unrelated_line() {
     let bin = env!("CARGO_BIN_EXE_git-prism");
     let home = TempDir::new().unwrap();
-    // Use .zprofile — the login-shell rc file that detect_rc_file targets for zsh.
-    let rc = home.path().join(".zprofile");
-    // Unrelated line that contains the fragment as a substring.
+    // Pre-populate .zshenv with a comment that contains the path fragment.
+    // With the old fragment-based check this would have caused a false positive.
+    let zshenv = home.path().join(".zshenv");
     std::fs::write(
-        &rc,
+        &zshenv,
         "# I once read about .local/share/git-prism/bin in the docs\n",
     )
     .unwrap();
@@ -60,34 +57,36 @@ fn consent_appends_export_even_when_fragment_appears_in_unrelated_line() {
         .unwrap();
 
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let rc_after = std::fs::read_to_string(&rc).unwrap();
+    let zshenv_after = std::fs::read_to_string(&zshenv).unwrap();
 
-    // The tool claims success...
+    // The tool must report success...
     assert!(
         stdout.contains("Added to"),
-        "precondition: consent path prints the success message; got: {stdout}"
+        "consent path must print the success message; got: {stdout}"
     );
-    // ...but a real, working export line must actually be present.
+    // ...and exactly one marker block must be present in .zshenv.
     assert_eq!(
-        count_real_export_lines(&rc_after),
+        count_marker_blocks(&zshenv_after),
         1,
-        "consent must write exactly one real export line even when the \
-         fragment appears as an unrelated substring; rc was: {rc_after:?}"
+        "consent must write exactly one marker block to .zshenv even when the \
+         fragment appears as an unrelated substring; .zshenv was:\n{zshenv_after}"
     );
 }
 
-/// SUSPICIOUS (false negative): a shim dir already on PATH but written with a
-/// trailing slash is not recognized as present (`entry == shim_dir` is exact).
-/// The tool re-prompts and offers to add a duplicate export line. Not data loss,
-/// but a UX defect: a user who already configured PATH (with a trailing slash)
-/// is told it's missing.
+/// A shim dir already FIRST on PATH (even with a trailing slash) must be recognized
+/// as already-in-position and suppress the consent prompt entirely.
+///
+/// The check is now "is the shim dir first?" not "is it present anywhere?", so a
+/// trailing slash on the first entry must still count as already-first.
 #[test]
-fn trailing_slash_path_entry_is_recognized_as_already_present() {
+fn trailing_slash_path_entry_is_recognized_as_already_first() {
     let bin = env!("CARGO_BIN_EXE_git-prism");
     let home = TempDir::new().unwrap();
+    std::fs::write(home.path().join(".zshenv"), "# zshenv\n").unwrap();
     std::fs::write(home.path().join(".zshrc"), "# rc\n").unwrap();
     let shim_dir = home.path().join(".local/share/git-prism/bin");
 
+    // Put the shim dir FIRST with a trailing slash.
     let path_with_trailing_slash = format!("{}/:{}", shim_dir.display(), CLEAN_PATH);
 
     let out = Command::new(bin)
@@ -107,15 +106,19 @@ fn trailing_slash_path_entry_is_recognized_as_already_present() {
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        !stdout.contains("not in your PATH"),
-        "shim dir present with a trailing slash should count as already-in-PATH; \
+        !stdout.contains("not first"),
+        "shim dir first with a trailing slash should count as already-first-in-PATH; \
          got prompt: {stdout}"
     );
-    // Recognized-as-present must also mean the rc is left untouched: no export
-    // line is appended when PATH already contains the shim dir.
-    let rc_after = std::fs::read_to_string(home.path().join(".zshrc")).unwrap();
+    // Recognized-as-first must mean rc files are left untouched.
+    let zshenv_after = std::fs::read_to_string(home.path().join(".zshenv")).unwrap();
     assert_eq!(
-        rc_after, "# rc\n",
-        "already-present detection must not append an export line; rc was: {rc_after:?}"
+        zshenv_after, "# zshenv\n",
+        "already-first detection must not append a block to .zshenv; got:\n{zshenv_after}"
+    );
+    let zshrc_after = std::fs::read_to_string(home.path().join(".zshrc")).unwrap();
+    assert_eq!(
+        zshrc_after, "# rc\n",
+        "already-first detection must not append a block to .zshrc; got:\n{zshrc_after}"
     );
 }

--- a/tests/shim_marker_pentest.rs
+++ b/tests/shim_marker_pentest.rs
@@ -148,6 +148,21 @@ fn end_before_start_does_not_grow_unboundedly() {
     );
 }
 
+/// Whether `zsh` is available to execute generated shell codegen. CI runners
+/// without zsh (e.g. ubuntu-latest, windows-latest) skip the shell-execution
+/// check rather than failing on `NotFound`; the marker and idempotency logic is
+/// fully covered by the hermetic unit tests in `src/shim_cmd.rs`, so skipping
+/// the codegen-under-zsh check on those platforms loses no coverage of the
+/// pure logic — only the optional "does it actually run under zsh" assertion.
+fn zsh_available() -> bool {
+    Command::new("zsh")
+        .arg("-c")
+        .arg("exit 0")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// Run the EXTRACTED block body under zsh (the production-targeted shell — the
 /// body uses `${var//…}` which is a zsh/bash extension, not POSIX `sh`) with the
 /// given starting `PATH`, and return the `$PATH` the block produces. `HOME` is
@@ -178,6 +193,13 @@ fn run_block_with_path(block_body: &str, home: &str, start_path: &str) -> String
 /// shim dir exactly once and preserves the other entries in order.
 #[test]
 fn generated_block_puts_shim_first_exactly_once_from_any_path_position() {
+    if !zsh_available() {
+        eprintln!(
+            "skipping: zsh is not available on this platform; the marker and \
+             forces-first logic is covered by the hermetic unit tests"
+        );
+        return;
+    }
     let (after, _) = install_with_zshenv("", b"y\n");
     let body = extract_block_body(&after);
 

--- a/tests/shim_marker_pentest.rs
+++ b/tests/shim_marker_pentest.rs
@@ -27,6 +27,24 @@ fn count_start_markers(rc: &str) -> usize {
     rc.matches(BLOCK_START_MARKER).count()
 }
 
+fn count_end_markers(rc: &str) -> usize {
+    rc.matches(BLOCK_END_MARKER).count()
+}
+
+/// Extract the shell code BETWEEN the first START and END markers (the actual
+/// runnable PATH-mutation block), so a test can execute the real generated body
+/// rather than asserting on a substring of it.
+fn extract_block_body(rc: &str) -> String {
+    let start = rc
+        .find(BLOCK_START_MARKER)
+        .expect("rc must contain a START marker");
+    let after_start = start + BLOCK_START_MARKER.len();
+    let end_rel = rc[after_start..]
+        .find(BLOCK_END_MARKER)
+        .expect("rc must contain an END marker after the START marker");
+    rc[after_start..after_start + end_rel].trim().to_string()
+}
+
 /// Run `git-prism shim install`, feeding `consent` to stdin, with the given
 /// pre-existing `.zshenv` content. Returns the post-run `.zshenv` content.
 fn install_with_zshenv(initial_zshenv: &str, consent: &[u8]) -> (String, String) {
@@ -74,6 +92,21 @@ fn truncated_block_only_start_marker_does_not_accumulate() {
         "a truncated block (START only) must converge to exactly ONE managed \
          block, not accumulate across runs; final .zshenv was:\n{after_two}"
     );
+    // A balanced result is part of the contract: convergence to one START but a
+    // leftover stray END (or vice versa) is still corruption. The writer's
+    // documented invariant is exactly one well-formed START..END pair.
+    assert_eq!(
+        count_end_markers(&after_two),
+        1,
+        "convergence must leave exactly one END marker too, not a dangling one; \
+         final .zshenv was:\n{after_two}"
+    );
+    // The leftover body from the corrupt input must not survive inside the block.
+    assert!(
+        !after_two.contains("/some/leftover"),
+        "the corrupt block's body must be stripped, not carried forward; \
+         final .zshenv was:\n{after_two}"
+    );
 }
 
 /// BUG candidate: a stray END marker appearing BEFORE the START marker (a
@@ -115,27 +148,65 @@ fn end_before_start_does_not_grow_unboundedly() {
     );
 }
 
-/// SUSPICIOUS finding: the old strip `${PATH//:$SHIM:/:}` is colon-bounded on
-/// BOTH sides, so a shim dir that is the LAST PATH entry (`...:$SHIM` with no
-/// trailing colon) would not be stripped, causing a duplicate on the next
-/// install. The generated block must handle shim in any position.
-///
-/// We verify this structurally: the written block must contain a pattern that
-/// strips the shim from a colon-padded copy of PATH (wrapping ensures all
-/// positions have colons on both sides), not a bare `${PATH//:SHIM:/:}`.
-#[test]
-fn generated_block_strips_shim_from_any_path_position() {
-    let (after, _) = install_with_zshenv("", b"y\n");
-    // The robust strip wraps PATH in colons before substitution so the shim dir
-    // is always colon-bounded regardless of its position. Any of these patterns
-    // indicate the implementation handles all positions correctly.
-    let has_robust_strip = after.contains(":${PATH}:")
-        || after.contains(":$PATH:") && (after.contains("_gp_p") || after.contains("${_gp_p"));
+/// Run the EXTRACTED block body under zsh (the production-targeted shell — the
+/// body uses `${var//…}` which is a zsh/bash extension, not POSIX `sh`) with the
+/// given starting `PATH`, and return the `$PATH` the block produces. `HOME` is
+/// pinned so `$HOME/.local/share/git-prism/bin` resolves to a known shim dir.
+fn run_block_with_path(block_body: &str, home: &str, start_path: &str) -> String {
+    let script = format!("{block_body}\nprintf '%s' \"$PATH\"");
+    let out = Command::new("zsh")
+        .arg("-c")
+        .arg(&script)
+        .env("HOME", home)
+        .env("PATH", start_path)
+        .output()
+        .expect("zsh must be available to execute the generated block");
     assert!(
-        has_robust_strip,
-        "generated block must use a colon-padded PATH strip that handles \
-         shim in front, middle, AND last position; got:\n{after}"
+        out.status.success(),
+        "generated block must execute cleanly under zsh; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
     );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// BEHAVIORAL replacement for the old structural substring check. The earlier
+/// bug (`${PATH//:$SHIM:/:}`) failed to strip a shim dir that was the LAST PATH
+/// entry, leaving a duplicate. Asserting on the block's *source text* could not
+/// catch that — only running it can. So we extract the real generated block and
+/// EXECUTE it under zsh for the shim in front, middle, last, and absent
+/// positions, asserting that in every case the resulting PATH leads with the
+/// shim dir exactly once and preserves the other entries in order.
+#[test]
+fn generated_block_puts_shim_first_exactly_once_from_any_path_position() {
+    let (after, _) = install_with_zshenv("", b"y\n");
+    let body = extract_block_body(&after);
+
+    let home = "/tmp/gp-block-test-home";
+    let shim = format!("{home}/.local/share/git-prism/bin");
+    let rest = "/usr/bin:/bin";
+
+    let cases = [
+        ("front", format!("{shim}:{rest}")),
+        ("middle", format!("/usr/bin:{shim}:/bin")),
+        ("last", format!("{rest}:{shim}")),
+        ("absent", rest.to_string()),
+    ];
+
+    for (label, start_path) in cases {
+        let result = run_block_with_path(&body, home, &start_path);
+        assert_eq!(
+            result,
+            format!("{shim}:{rest}"),
+            "for the '{label}' case (start PATH={start_path:?}), the block must \
+             prepend the shim dir exactly once and keep {rest} in order; got {result:?}"
+        );
+        // Defense in depth: the shim dir must appear exactly once, never duplicated.
+        let occurrences = result.split(':').filter(|e| *e == shim).count();
+        assert_eq!(
+            occurrences, 1,
+            "shim dir must appear exactly once for the '{label}' case; got {result:?}"
+        );
+    }
 }
 
 /// BUG candidate: two pre-existing managed blocks (e.g. a user copy-pasted, or
@@ -153,5 +224,16 @@ fn two_existing_blocks_collapse_to_one() {
         1,
         "two pre-existing managed blocks must collapse to exactly one on \
          rewrite; got:\n{after}"
+    );
+    assert_eq!(
+        count_end_markers(&after),
+        1,
+        "collapse must also leave exactly one END marker, not a stray from the \
+         second block; got:\n{after}"
+    );
+    // Neither stale body must survive the collapse.
+    assert!(
+        !after.contains("old body 1") && !after.contains("old body 2"),
+        "both stale block bodies must be stripped on collapse; got:\n{after}"
     );
 }

--- a/tests/shim_marker_pentest.rs
+++ b/tests/shim_marker_pentest.rs
@@ -1,0 +1,157 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #355, gate 3): marker-delimited block writer robustness.
+//!
+//! Drives the built binary end-to-end via `git-prism shim install`, injecting an
+//! isolated HOME and a PATH that does NOT lead with the shim dir (so the consent
+//! prompt always fires and the managed block gets written).
+//!
+//! Focus: idempotency under hand-edited / corrupt / scrambled marker states.
+//! The block writer keys idempotency on the START marker (`contains(START)`),
+//! then `replace_marker_block` reassembles using the FIRST `find()` of each
+//! marker. These tests probe what happens when the markers are not in the clean
+//! START..END order the happy path assumes.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+/// PATH that never leads with the isolated shim dir → "not first" → prompt fires.
+const CLEAN_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+const BLOCK_START_MARKER: &str = "# >>> git-prism shim >>>";
+const BLOCK_END_MARKER: &str = "# <<< git-prism shim <<<";
+
+fn count_start_markers(rc: &str) -> usize {
+    rc.matches(BLOCK_START_MARKER).count()
+}
+
+/// Run `git-prism shim install`, feeding `consent` to stdin, with the given
+/// pre-existing `.zshenv` content. Returns the post-run `.zshenv` content.
+fn install_with_zshenv(initial_zshenv: &str, consent: &[u8]) -> (String, String) {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let home = TempDir::new().unwrap();
+    let zshenv = home.path().join(".zshenv");
+    std::fs::write(&zshenv, initial_zshenv).unwrap();
+
+    let out = Command::new(bin)
+        .env("HOME", home.path())
+        .env("PATH", CLEAN_PATH)
+        .env("SHELL", "/bin/zsh")
+        .args(["shim", "install"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child.stdin.take().unwrap().write_all(consent).unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let after = std::fs::read_to_string(&zshenv).unwrap();
+    (after, stdout)
+}
+
+/// BUG candidate: a TRUNCATED managed block (START present, END missing —
+/// e.g. a previous write was interrupted, or a user deleted the end marker)
+/// must be repaired to exactly one block. The writer keys on `contains(START)`
+/// → "replace", but `replace_marker_block` can't find END and falls to the
+/// append branch, so each run adds another block. We install twice.
+#[test]
+fn truncated_block_only_start_marker_does_not_accumulate() {
+    let corrupt = format!("{BLOCK_START_MARKER}\nPATH=/some/leftover\n");
+    // First install on the corrupt file.
+    let (after_one, _) = install_with_zshenv(&corrupt, b"y\n");
+    // Feed the FIRST result back in as the starting state for a second install.
+    let (after_two, _) = install_with_zshenv(&after_one, b"y\n");
+
+    assert_eq!(
+        count_start_markers(&after_two),
+        1,
+        "a truncated block (START only) must converge to exactly ONE managed \
+         block, not accumulate across runs; final .zshenv was:\n{after_two}"
+    );
+}
+
+/// BUG candidate: a stray END marker appearing BEFORE the START marker (a
+/// hand-edit, or the user pasting the end marker as a comment) makes `find()`
+/// return the earliest END (index < START index). `replace_marker_block` then
+/// computes `after_end < s` and the reassembly leaves the real START marker in
+/// the tail — so the managed block survives AND a new one is prepended.
+#[test]
+fn end_marker_before_start_marker_does_not_accumulate() {
+    let scrambled = format!(
+        "{BLOCK_END_MARKER}\n# user note\n{BLOCK_START_MARKER}\ncase old in esac\n{BLOCK_END_MARKER}\n"
+    );
+    let (after, _) = install_with_zshenv(&scrambled, b"y\n");
+
+    assert_eq!(
+        count_start_markers(&after),
+        1,
+        "with an END marker preceding the START marker, exactly one managed \
+         block must remain after a write; got:\n{after}"
+    );
+}
+
+/// BUG severity probe: with an END-before-START file, does the block writer
+/// merely fail to converge, or does it GROW unboundedly across reruns? Two
+/// installs chained — count must not increase run-over-run.
+#[test]
+fn end_before_start_does_not_grow_unboundedly() {
+    let scrambled = format!(
+        "{BLOCK_END_MARKER}\n# user note\n{BLOCK_START_MARKER}\ncase old in esac\n{BLOCK_END_MARKER}\n"
+    );
+    let (after_one, _) = install_with_zshenv(&scrambled, b"y\n");
+    let count_one = count_start_markers(&after_one);
+    let (after_two, _) = install_with_zshenv(&after_one, b"y\n");
+    let count_two = count_start_markers(&after_two);
+    assert!(
+        count_two <= count_one,
+        "managed block count must not grow on rerun (run1={count_one}, run2={count_two}); \
+         final .zshenv:\n{after_two}"
+    );
+}
+
+/// SUSPICIOUS finding: the old strip `${PATH//:$SHIM:/:}` is colon-bounded on
+/// BOTH sides, so a shim dir that is the LAST PATH entry (`...:$SHIM` with no
+/// trailing colon) would not be stripped, causing a duplicate on the next
+/// install. The generated block must handle shim in any position.
+///
+/// We verify this structurally: the written block must contain a pattern that
+/// strips the shim from a colon-padded copy of PATH (wrapping ensures all
+/// positions have colons on both sides), not a bare `${PATH//:SHIM:/:}`.
+#[test]
+fn generated_block_strips_shim_from_any_path_position() {
+    let (after, _) = install_with_zshenv("", b"y\n");
+    // The robust strip wraps PATH in colons before substitution so the shim dir
+    // is always colon-bounded regardless of its position. Any of these patterns
+    // indicate the implementation handles all positions correctly.
+    let has_robust_strip = after.contains(":${PATH}:")
+        || after.contains(":$PATH:") && (after.contains("_gp_p") || after.contains("${_gp_p"));
+    assert!(
+        has_robust_strip,
+        "generated block must use a colon-padded PATH strip that handles \
+         shim in front, middle, AND last position; got:\n{after}"
+    );
+}
+
+/// BUG candidate: two pre-existing managed blocks (e.g. a user copy-pasted, or
+/// a prior buggy run accumulated) must collapse to exactly ONE on rewrite.
+/// `replace_marker_block` only replaces from the first START to the first END,
+/// so the second block survives.
+#[test]
+fn two_existing_blocks_collapse_to_one() {
+    let one = format!("{BLOCK_START_MARKER}\nold body 1\n{BLOCK_END_MARKER}\n");
+    let two = format!("{BLOCK_START_MARKER}\nold body 2\n{BLOCK_END_MARKER}\n");
+    let (after, _) = install_with_zshenv(&format!("{one}{two}"), b"y\n");
+
+    assert_eq!(
+        count_start_markers(&after),
+        1,
+        "two pre-existing managed blocks must collapse to exactly one on \
+         rewrite; got:\n{after}"
+    );
+}

--- a/tests/shim_stable_path_pentest.rs
+++ b/tests/shim_stable_path_pentest.rs
@@ -414,9 +414,11 @@ fn dangling_non_cellar_target_gets_no_cellar_advisory() {
     std::os::unix::fs::symlink(&dangling, &link).unwrap();
 
     let stdout = run_status(&bin, h);
+    // The Cellar-staleness advisory is only for genuine Homebrew Cellar targets;
+    // a dangling non-Cellar path must not trigger it. We check for the
+    // Brew-specific phrase — the PATH warning is unrelated and allowed here.
     assert!(
-        !stdout.to_lowercase().contains("brew upgrade")
-            && !stdout.contains("git-prism shim install"),
+        !stdout.to_lowercase().contains("brew upgrade"),
         "a dangling non-Cellar target must not emit a Homebrew/Cellar advisory; \
          got: {stdout:?}"
     );


### PR DESCRIPTION
## Summary

Closes #355.

`git-prism shim install` only wrote the PATH prepend to `~/.zprofile` (login shells only), so the primary target — agent shells (Claude Code's non-login `zsh -c`, which read only `~/.zshenv`) — never got the shim on PATH. And even with `.zshenv`, a typical `~/.zshrc` re-prepends Homebrew (`brew shellenv`) / cargo / nvm *after* it, demoting the shim behind real git/gh. Net: install reported success but nothing intercepted.

## What changed

- Install writes a **marker-delimited, idempotent** block (`# >>> git-prism shim >>>` … `# <<< git-prism shim <<<`) to **two** files per shell — `~/.zshenv` + the end of `~/.zshrc` (zsh), `~/.bash_profile` + `~/.bashrc` (bash). `.zshenv` covers agent shells; the `.zshrc` write re-asserts priority after the brew/cargo prepends.
- **Forces-first** PATH semantics: the block strips any demoted occurrence of the shim dir (in front/middle/last position) and prepends exactly one — so it wins even when later rc lines prepend other dirs.
- **Idempotent + safe:** re-running install strips *all* prior managed blocks (and orphaned/reordered markers) and writes exactly one. Marker detection uses full-line equality, so a user rc line that merely *mentions* the marker text is never mistaken for a block boundary.
- `git-prism shim status` now warns when the shim dir isn't first on PATH for a non-login shell.

## Gauntlet

- **Adversarial QA (3 passes):** pass 1 found 2 marker idempotency bugs (duplicate blocks never collapsed; END-before-START caused unbounded growth); pass 2 found a **HIGH silent-data-loss** bug (substring marker match deleted user rc lines to EOF, including pasted setup instructions); pass 3 confirmed all fixed. 1040 tests, behave 18/18.
- **Church:** rust-purist caught a real bug (bash users were told the wrong rc files on decline) + helper extraction; test-purist replaced a fraudulent "any-position" assertion with one that *executes* the generated block under zsh; observability error context; naming/python cleanup.

Deferred (non-blocking, tracked): `SHIM_PATH_BLOCK_BODY` hardcodes the shim path literal rather than deriving from `hooks::PATH_SHIM_REL_DIR` — a drift risk that needs a const→runtime shape change.

Generated with [Claude Code](https://claude.ai/claude-code)
