### PR TITLE
fix(shim): bound structured-path telemetry teardown (#361) + per-invocation opt-out (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Per-invocation shim opt-out via `GIT_PRISM_PASSTHROUGH` / `GIT_PRISM_DISABLE`.** Setting either env var to a truthy value (`1` or case-insensitive `true`) makes the shim `exec` the real `git` / `gh` immediately — before `telemetry::init_quiet()` and before command classification — with near-zero added latency and no recording. This replaces the all-or-nothing `PATH` hack for agent workflows that shell `git` heavily in throwaway tmp repos, where per-call cold-start and telemetry overhead is unwanted and recording ephemeral repos is undesirable anyway. The opt-out exec is recursion-safe (it resolves and runs the real binary, not the shim symlink, even when the shim is first on `PATH`). (#362)
+
+### Fixed
+
+- **The shim's structured-output path (`git diff` / `log` / `show` / `blame`) no longer stalls on an unreachable OpenTelemetry collector.** The structured path flushed telemetry with an unbounded `force_flush()`, and `main` then dropped the `TelemetryGuard`, whose `Drop` ran unbounded `shutdown()` calls — so a single `git diff` could block for minutes (≈10 s per call was reproduced against a black-hole endpoint: 5 s tracer shutdown + 5 s meter shutdown). Both the explicit flush and the `Drop`-path shutdown are now time-bounded (500 ms each), mirroring the already-bounded passthrough path; a saturated or unreachable collector can no longer stall an intercepted git command. Telemetry still delivers normally when the collector is responsive (proven by an end-to-end data-loss guard against a live capture server). (#361)
+
 ## [0.9.3] — 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -166,6 +166,27 @@ yourself to force vanilla git for one command:
 GIT_PRISM_INSIDE_SHIM=1 git diff main..HEAD   # bypasses the shim
 ```
 
+### Per-invocation opt-out (`GIT_PRISM_PASSTHROUGH`)
+
+Set `GIT_PRISM_PASSTHROUGH=1` (or the alias `GIT_PRISM_DISABLE=1`) to make the
+shim exec the real git/gh **immediately** — before telemetry init, before
+classification, with zero added latency:
+
+```bash
+GIT_PRISM_PASSTHROUGH=1 git diff main..HEAD   # real git, no shim overhead
+```
+
+This is the first-class alternative to putting `/usr/bin` ahead of the shim on
+`PATH`. Use it to wrap a test suite or tight loop where shim processing and
+telemetry are not desirable:
+
+```bash
+GIT_PRISM_PASSTHROUGH=1 cargo test   # git calls inside tests skip the shim
+```
+
+Accepted truthy values: `1`, `true` (case-insensitive). Any other value (or
+unset) leaves the shim active.
+
 ### Debugging
 
 Set `GIT_PRISM_DEBUG_RESOLVER=1` to print the resolved real-git path to stderr,
@@ -739,6 +760,8 @@ Optional OpenTelemetry instrumentation, disabled by default and opt-in via envir
 | `GIT_PRISM_OTLP_HEADERS` | Planned, not yet wired ([#43](https://github.com/mikelane/git-prism/issues/43)). Setting this variable has no effect today; managed OTLP backends that require auth headers need a local collector proxy. | unset |
 | `GIT_PRISM_SERVICE_NAME` | Service name reported to the backend. | `git-prism` |
 | `GIT_PRISM_SERVICE_VERSION` | Service version reported to the backend. | crate version |
+| `GIT_PRISM_PASSTHROUGH` | Set to `1` or `true` to skip shim processing and telemetry entirely for a single invocation. See [Per-invocation opt-out](#per-invocation-opt-out-git_prism_passthrough). | unset |
+| `GIT_PRISM_DISABLE` | Alias for `GIT_PRISM_PASSTHROUGH`. | unset |
 
 Quick start with Jaeger (any OTLP-compatible backend works):
 ```bash

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ GIT_PRISM_INSIDE_SHIM=1 git diff main..HEAD   # bypasses the shim
 
 Set `GIT_PRISM_PASSTHROUGH=1` (or the alias `GIT_PRISM_DISABLE=1`) to make the
 shim exec the real git/gh **immediately** — before telemetry init, before
-classification, with zero added latency:
+classification, with near-zero added latency:
 
 ```bash
 GIT_PRISM_PASSTHROUGH=1 git diff main..HEAD   # real git, no shim overhead

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,7 +298,7 @@ async fn main() -> std::process::ExitCode {
             &exec,
             &mut telemetry_guard,
         );
-        telemetry_guard.force_flush();
+        telemetry_guard.force_flush_bounded(shim::STRUCTURED_FLUSH_TIMEOUT);
         return exit_code;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ pub(crate) mod metrics;
 pub(crate) mod pagination;
 pub(crate) mod privacy;
 mod server;
-// The shim module is complete but not yet wired to argv[0] dispatch (#287).
-#[allow(dead_code)]
 mod shim;
 mod shim_cmd;
 mod telemetry;
@@ -18,6 +16,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 use git::refs::{RefRange, parse_range, validate_commit_range};
+use shim::real_git::RealGitExec as _;
 use tools::{
     ContextOptions, FunctionContextResponse, ManifestOptions, SnapshotOptions,
     build_function_context_with_options, build_snapshots, collect_all_history_pages,
@@ -275,6 +274,16 @@ async fn main() -> std::process::ExitCode {
             env: &agent_detection::StdEnvSource,
             argv0: args.first().copied().unwrap_or("git"),
         };
+
+        // Per-invocation opt-out: exec the real binary immediately with zero
+        // overhead — no telemetry init, no classification, no metric recording.
+        // This is the first-class escape hatch for callers that set
+        // GIT_PRISM_PASSTHROUGH=1 (or GIT_PRISM_DISABLE=1) to skip the shim
+        // entirely for a specific invocation or test suite run.
+        if shim::passthrough_opt_out_requested(&agent_detection::StdEnvSource) {
+            return exec.passthrough(&args);
+        }
+
         // Initialize telemetry when an OTLP endpoint is configured. The guard
         // must live until after run_shim returns — on the exec-replace
         // (passthrough) path the process is replaced and Rust's drop glue

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -315,6 +315,26 @@ mod tests {
         );
     }
 
+    /// A non-zero exit code from the real binary must propagate through the
+    /// opt-out passthrough path unchanged.
+    #[test]
+    fn it_propagates_nonzero_exit_code_on_passthrough_opt_out() {
+        let env = MapEnv(HashMap::from([
+            ("CLAUDECODE", "1"),
+            ("GIT_PRISM_PASSTHROUGH", "1"),
+        ]));
+        let exec = SpyExec::new(ExitCode::from(2));
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
+
+        let code = run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec, &mut guard);
+
+        assert!(
+            exec.called.get(),
+            "expected immediate passthrough when GIT_PRISM_PASSTHROUGH=1"
+        );
+        assert_eq!(code, ExitCode::from(2));
+    }
+
     /// With opt-out unset, a classified agent command must NOT passthrough immediately.
     #[test]
     fn it_does_not_passthrough_immediately_when_opt_out_var_is_unset() {
@@ -580,10 +600,10 @@ mod tests {
             std::env::remove_var("GIT_PRISM_OTLP_ENDPOINT");
         }
         drop(guard);
-        // Must return well before the 5 s SDK export timeout.
+        // Must return well before the 2 s budget (500ms cap × 4 margin).
         assert!(
-            elapsed.as_secs() < 5,
-            "structured-path bounded flush must not stall for the full SDK export timeout; \
+            elapsed < Duration::from_secs(2),
+            "structured-path bounded flush must not stall significantly beyond the 500ms cap; \
              took {elapsed:?}"
         );
     }

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -29,6 +29,14 @@ use crate::telemetry::TelemetryGuard;
 /// when the process image is replaced by execvp.
 const PASSTHROUGH_FLUSH_TIMEOUT: Duration = Duration::from_millis(300);
 
+/// Flush deadline used on the structured-output path (after JSON is printed).
+///
+/// The agent has already received its response by the time the flush runs, so
+/// a longer cap is acceptable — but it must still be finite so a saturated or
+/// unreachable OTLP collector cannot stall a `git diff`/`log`/`show`/`blame`
+/// call indefinitely (the #360 multi-minute stall scenario).
+pub(crate) const STRUCTURED_FLUSH_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// Main entry point for shim mode.
 ///
 /// Decision tree:
@@ -349,6 +357,75 @@ mod tests {
         assert!(
             exec.called.get(),
             "expected passthrough when current directory cannot be determined"
+        );
+    }
+
+    /// The structured-path and passthrough-path flush timeouts must be distinct
+    /// values.  The structured path can afford a longer cap (the agent already
+    /// received its JSON response) while the passthrough path is latency-critical.
+    /// This test kills the mutation that collapses one constant to the other.
+    #[test]
+    fn structured_flush_timeout_differs_from_passthrough_flush_timeout() {
+        assert_ne!(
+            STRUCTURED_FLUSH_TIMEOUT, PASSTHROUGH_FLUSH_TIMEOUT,
+            "structured and passthrough flush timeouts must be different values; \
+             the structured path can afford a longer cap"
+        );
+        assert!(
+            STRUCTURED_FLUSH_TIMEOUT > PASSTHROUGH_FLUSH_TIMEOUT,
+            "structured-path timeout should be >= passthrough timeout \
+             since the agent already has its response"
+        );
+    }
+
+    /// `STRUCTURED_FLUSH_TIMEOUT` must exist and be reasonable (non-zero, shorter
+    /// than `EXPORT_TIMEOUT` which is 5 s) so an uncapped flush cannot occur on
+    /// the structured-output path.
+    #[test]
+    fn structured_flush_timeout_constant_is_positive_and_below_export_timeout() {
+        // The constant must be > 0 (no instant-timeout) and < 5 s (below the
+        // SDK export timeout) so a saturated collector cannot block git calls.
+        assert!(
+            STRUCTURED_FLUSH_TIMEOUT.as_millis() > 0,
+            "STRUCTURED_FLUSH_TIMEOUT must be positive"
+        );
+        assert!(
+            STRUCTURED_FLUSH_TIMEOUT.as_secs() < 5,
+            "STRUCTURED_FLUSH_TIMEOUT must be below the 5 s SDK export timeout"
+        );
+    }
+
+    /// `force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT)` on an active guard with an
+    /// unreachable OTLP endpoint must return within the structured-path deadline.
+    /// This mirrors the passthrough-path black-hole test in telemetry.rs and proves
+    /// the structured path cannot stall for minutes when the collector is saturated.
+    #[tokio::test]
+    async fn structured_path_bounded_flush_returns_within_deadline_on_black_hole_endpoint() {
+        use std::sync::Mutex;
+        static ENV_MUTEX: Mutex<()> = Mutex::new(());
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            std::env::set_var("GIT_PRISM_OTLP_ENDPOINT", "http://192.0.2.1:4318");
+        }
+        let mut guard = crate::telemetry::init_quiet();
+        assert!(
+            guard.is_active(),
+            "guard must be active to exercise the structured-path bounded flush"
+        );
+        let start = std::time::Instant::now();
+        guard.force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT);
+        let elapsed = start.elapsed();
+        // SAFETY: cleanup
+        unsafe {
+            std::env::remove_var("GIT_PRISM_OTLP_ENDPOINT");
+        }
+        drop(guard);
+        // Must return well before the 5 s SDK export timeout.
+        assert!(
+            elapsed.as_secs() < 5,
+            "structured-path bounded flush must not stall for the full SDK export timeout; \
+             took {elapsed:?}"
         );
     }
 

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -37,9 +37,32 @@ const PASSTHROUGH_FLUSH_TIMEOUT: Duration = Duration::from_millis(300);
 /// call indefinitely (the #360 multi-minute stall scenario).
 pub(crate) const STRUCTURED_FLUSH_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Returns `true` when the caller has requested an immediate passthrough,
+/// skipping all shim processing and telemetry.
+///
+/// Checked in `main.rs` **before** `telemetry::init_quiet()` so opted-out
+/// calls have zero added latency and emit no telemetry at all.  Also checked
+/// at the top of `run_shim` for callers that already hold a guard.
+///
+/// Truthy values: `"1"`, `"true"` (case-insensitive).
+/// Falsy / absent: empty string, `"0"`, `"false"`, or unset.
+pub(crate) fn passthrough_opt_out_requested(env: &dyn EnvSource) -> bool {
+    for key in &["GIT_PRISM_PASSTHROUGH", "GIT_PRISM_DISABLE"] {
+        if let Some(val) = env.get(key) {
+            let lower = val.to_ascii_lowercase();
+            if lower == "1" || lower == "true" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Main entry point for shim mode.
 ///
 /// Decision tree:
+/// 0. `GIT_PRISM_PASSTHROUGH` / `GIT_PRISM_DISABLE` is truthy → immediate exec
+///    (opt-out; no metrics recorded, no telemetry flush needed).
 /// 1. `GIT_PRISM_INSIDE_SHIM` is set → passthrough (loop-break sentinel).
 /// 2. `detect_calling_agent` returns `None` → passthrough (non-agent caller).
 /// 3. `classify(argv)` returns `Passthrough` → passthrough (unsupported subcommand).
@@ -47,20 +70,21 @@ pub(crate) const STRUCTURED_FLUSH_TIMEOUT: Duration = Duration::from_millis(500)
 ///
 /// # Metrics invariant
 ///
-/// Every path through this function calls `record_shim_invocation` **exactly
-/// once**.  `record_shim_classification` is called at most once, only on the
-/// structured-dispatch path (step 4) — never on passthrough or loop-break
-/// paths.  This invariant ensures dashboards that aggregate
-/// `shim_invocations_total` get an accurate per-call count.
+/// Steps 1–3 call `record_shim_invocation` **exactly once**.  Step 0
+/// (opt-out) short-circuits before any metric recording so opted-out calls
+/// do not appear in dashboards.  `record_shim_classification` is called at
+/// most once, only on the structured-dispatch path (step 4).  This invariant
+/// ensures dashboards that aggregate `shim_invocations_total` get an accurate
+/// per-call count for non-opted-out invocations.
 ///
 /// # Telemetry flush on passthrough
 ///
 /// On passthrough paths `exec.passthrough()` calls `execvp`, which replaces
 /// the process image and never returns.  `Drop` glue and the flush in
-/// `main.rs` are unreachable on those paths.  `telemetry_guard.force_flush()`
+/// `main.rs` are unreachable on those paths.  `telemetry_guard.force_flush_bounded()`
 /// is called on every passthrough branch **before** `exec.passthrough()` so
-/// the buffered metric reaches the OTLP endpoint.  A second flush / `Drop`
-/// is a documented no-op (`TelemetryGuard::force_flush` is idempotent).
+/// the buffered metric reaches the OTLP endpoint.  The step-0 opt-out path
+/// skips the flush entirely (no telemetry was initialized).
 pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(
     argv: &[&str],
     env: &E,
@@ -68,6 +92,12 @@ pub(crate) fn run_shim<E: EnvSource, G: RealGitExec>(
     telemetry_guard: &mut TelemetryGuard,
 ) -> ExitCode {
     let metrics = crate::metrics::get();
+
+    // 0. Per-invocation passthrough opt-out: exec the real binary immediately,
+    //    skipping telemetry and classification entirely.
+    if passthrough_opt_out_requested(env) {
+        return exec.passthrough(argv);
+    }
 
     // 1. Loop-break sentinel: a nested git call from within the shim.
     if env.get("GIT_PRISM_INSIDE_SHIM").is_some() {
@@ -200,6 +230,135 @@ mod tests {
     }
 
     // ---- decision path tests ----
+
+    // ---- passthrough_opt_out_requested unit tests ----
+
+    #[test]
+    fn opt_out_recognizes_passthrough_equals_one() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_PASSTHROUGH", "1")]));
+        assert!(passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_recognizes_passthrough_equals_true_case_insensitive() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_PASSTHROUGH", "TRUE")]));
+        assert!(passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_recognizes_disable_alias() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_DISABLE", "1")]));
+        assert!(passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_inactive_when_var_is_zero() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_PASSTHROUGH", "0")]));
+        assert!(!passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_inactive_when_var_is_false() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_PASSTHROUGH", "false")]));
+        assert!(!passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_inactive_when_var_is_empty() {
+        let env = MapEnv(HashMap::from([("GIT_PRISM_PASSTHROUGH", "")]));
+        assert!(!passthrough_opt_out_requested(&env));
+    }
+
+    #[test]
+    fn opt_out_inactive_when_var_is_unset() {
+        let env = MapEnv(HashMap::new());
+        assert!(!passthrough_opt_out_requested(&env));
+    }
+
+    /// With `GIT_PRISM_PASSTHROUGH=1`, the shim must exec the real binary
+    /// immediately (before any classification or telemetry).
+    #[test]
+    fn it_passes_through_immediately_when_passthrough_env_var_is_set() {
+        let env = MapEnv(HashMap::from([
+            ("CLAUDECODE", "1"),
+            ("GIT_PRISM_PASSTHROUGH", "1"),
+        ]));
+        let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
+
+        // Even though this is a classified command (diff), the opt-out must
+        // cause an immediate passthrough before any classification runs.
+        let code = run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec, &mut guard);
+
+        assert!(
+            exec.called.get(),
+            "expected immediate passthrough when GIT_PRISM_PASSTHROUGH=1"
+        );
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+
+    /// `GIT_PRISM_DISABLE` is an alias for `GIT_PRISM_PASSTHROUGH`.
+    #[test]
+    fn it_passes_through_immediately_when_disable_alias_is_set() {
+        let env = MapEnv(HashMap::from([
+            ("CLAUDECODE", "1"),
+            ("GIT_PRISM_DISABLE", "1"),
+        ]));
+        let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
+
+        run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec, &mut guard);
+
+        assert!(
+            exec.called.get(),
+            "expected immediate passthrough when GIT_PRISM_DISABLE=1"
+        );
+    }
+
+    /// With opt-out unset, a classified agent command must NOT passthrough immediately.
+    #[test]
+    fn it_does_not_passthrough_immediately_when_opt_out_var_is_unset() {
+        use std::process::Command;
+        use tempfile::TempDir;
+
+        // Build a minimal two-commit repo so the handler has something to work with.
+        let dir = TempDir::new().unwrap();
+        let repo_path = dir.path().to_path_buf();
+        let run = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(&repo_path)
+                .output()
+                .unwrap()
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "t@t.com"]);
+        run(&["config", "user.name", "T"]);
+        std::fs::write(repo_path.join("a.txt"), "hello\n").unwrap();
+        run(&["add", "a.txt"]);
+        run(&["commit", "-m", "first"]);
+        std::fs::write(repo_path.join("b.txt"), "world\n").unwrap();
+        run(&["add", "b.txt"]);
+        run(&["commit", "-m", "second"]);
+
+        let repo_str: &'static str =
+            Box::leak(repo_path.to_string_lossy().into_owned().into_boxed_str());
+
+        // No opt-out var — normal agent dispatch should run the handler.
+        let env = MapEnv(HashMap::from([
+            ("CLAUDECODE", "1"),
+            ("GIT_PRISM_REPO", repo_str),
+        ]));
+        let exec = SpyExec::new(ExitCode::SUCCESS);
+        let mut guard = crate::telemetry::TelemetryGuard::noop();
+
+        run_shim(&["git", "diff", "HEAD~1..HEAD"], &env, &exec, &mut guard);
+
+        assert!(
+            !exec.called.get(),
+            "without opt-out, a classified agent command must dispatch to the handler, not passthrough"
+        );
+    }
 
     #[test]
     fn it_passes_through_when_inside_shim_sentinel_is_set() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -52,28 +52,6 @@ impl TelemetryGuard {
         self.tracer_provider.is_some()
     }
 
-    /// Force-flush pending telemetry to the exporter immediately.
-    ///
-    /// The `PeriodicReader` used by the metrics provider only fires on its
-    /// configured interval (default 60 s). A short-lived process — such as the
-    /// shim — exits before the reader ticks, so `Drop` alone never delivers
-    /// metrics. Calling `force_flush` before process exit ensures buffered
-    /// measurements reach the OTLP endpoint.
-    ///
-    /// Safe to call on a no-op guard: it is a documented zero-cost no-op.
-    pub fn force_flush(&mut self) {
-        if let Some(mp) = &self.meter_provider
-            && let Err(e) = mp.force_flush()
-        {
-            eprintln!("git-prism: failed to force-flush metrics: {e}");
-        }
-        if let Some(tp) = &self.tracer_provider
-            && let Err(e) = tp.force_flush()
-        {
-            eprintln!("git-prism: failed to force-flush traces: {e}");
-        }
-    }
-
     /// Best-effort flush with a wall-clock deadline.
     ///
     /// Runs `force_flush` on a background thread and waits at most `timeout`
@@ -686,8 +664,8 @@ mod tests {
             tracer_provider: None,
             meter_provider: None,
         };
-        // force_flush on a no-op guard must be a no-op with zero overhead.
-        guard.force_flush();
+        // force_flush_bounded on a no-op guard must be a zero-cost no-op.
+        guard.force_flush_bounded(Duration::from_millis(500));
     }
 
     #[tokio::test]
@@ -703,8 +681,8 @@ mod tests {
             guard.is_active(),
             "guard must be active for this test to exercise flush"
         );
-        // force_flush on an active guard must not panic even when no exporter is reachable.
-        guard.force_flush();
+        // force_flush_bounded on an active guard must not panic even when no exporter is reachable.
+        guard.force_flush_bounded(Duration::from_millis(500));
         // SAFETY: cleanup
         unsafe {
             std::env::remove_var(ENV_OTLP_ENDPOINT);
@@ -712,7 +690,7 @@ mod tests {
         drop(guard);
     }
 
-    /// Double-flush must be idempotent: `force_flush` borrows the providers
+    /// Double-flush must be idempotent: `force_flush_bounded` borrows the providers
     /// (`&mut self`) rather than taking them, so a second call — and a
     /// subsequent `Drop` — must still succeed without panic or double-free.
     /// This is the real shim sequence: flush before exec, then Drop on exit.
@@ -729,14 +707,14 @@ mod tests {
             guard.is_active(),
             "guard must be active for this test to exercise repeated flush"
         );
-        guard.force_flush();
+        guard.force_flush_bounded(Duration::from_millis(500));
         // Second flush must remain a no-panic no-op: providers are still owned.
-        guard.force_flush();
+        guard.force_flush_bounded(Duration::from_millis(500));
         // Guard must still be active after repeated flushes — flush does not
         // consume the providers the way Drop does.
         assert!(
             guard.is_active(),
-            "force_flush must not consume the providers; guard stays active"
+            "force_flush_bounded must not consume the providers; guard stays active"
         );
         // SAFETY: cleanup
         unsafe {
@@ -751,11 +729,11 @@ mod tests {
     #[test]
     fn it_tolerates_double_force_flush_on_noop_guard() {
         let mut guard = TelemetryGuard::noop();
-        guard.force_flush();
-        guard.force_flush();
+        guard.force_flush_bounded(Duration::from_millis(500));
+        guard.force_flush_bounded(Duration::from_millis(500));
         assert!(
             !guard.is_active(),
-            "a no-op guard must stay inactive across repeated force_flush calls"
+            "a no-op guard must stay inactive across repeated force_flush_bounded calls"
         );
         drop(guard);
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -767,9 +767,9 @@ mod tests {
         }
         drop(guard);
         assert!(
-            elapsed < EXPORT_TIMEOUT,
-            "bounded flush must abandon a stalled exporter well before the {EXPORT_TIMEOUT:?} \
-             export timeout; took {elapsed:?}"
+            elapsed < Duration::from_secs(1),
+            "bounded flush must abandon a stalled exporter well before the 1s budget \
+             (200ms cap × 5 margin); took {elapsed:?}"
         );
     }
 
@@ -784,17 +784,12 @@ mod tests {
     /// return exit_code;                                    // guard dropped HERE
     /// ```
     ///
-    /// The #361 fix bounds `force_flush_bounded`, but the very next thing that
-    /// happens is the guard going out of scope, which runs `Drop::drop` →
-    /// `tp.shutdown()` + `mp.shutdown()`. Those shutdown calls are UNBOUNDED and
-    /// each block up to `EXPORT_TIMEOUT` (5 s) when the collector is a black
-    /// hole. So the bounded flush saves nothing: the agent's `git diff` still
-    /// stalls for multiple seconds on process teardown — the exact #360 symptom
-    /// #361 set out to eliminate.
-    ///
-    /// This test asserts the total teardown (flush + drop) returns within a
-    /// budget well under a single `EXPORT_TIMEOUT`. It FAILS today because
-    /// `Drop` is unbounded.
+    /// The #361 fix bounds `force_flush_bounded`, so the agent's teardown no
+    /// longer stalls for multiple seconds even when the collector is unreachable.
+    /// This test verifies that the *entire* sequence — bounded flush followed by
+    /// the guard's `Drop` (which runs `tp.shutdown()` + `mp.shutdown()`) — stays
+    /// bounded against a black-hole endpoint. This regression guard prevents #360
+    /// from recurring via either the force_flush path or the guard-drop path.
     #[tokio::test]
     async fn qa_structured_path_total_teardown_is_bounded_on_black_hole_endpoint() {
         use crate::shim::STRUCTURED_FLUSH_TIMEOUT;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -9,6 +9,10 @@ use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt
 
 const DEFAULT_SERVICE_NAME: &str = "git-prism";
 const EXPORT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Drop-path shutdown deadline. A down OTLP collector must not stall process
+/// teardown (and therefore the agent's `git` call) on `tp.shutdown()` /
+/// `mp.shutdown()`, which are individually unbounded (up to EXPORT_TIMEOUT each).
+const DROP_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Environment variable names for telemetry configuration.
 const ENV_OTLP_ENDPOINT: &str = "GIT_PRISM_OTLP_ENDPOINT";
@@ -91,21 +95,35 @@ impl TelemetryGuard {
     }
 }
 
-/// The design spec targets a 5s flush on shutdown. The SDK's `.shutdown()` handles
-/// its own timing internally, so we rely on its defaults here rather than passing
-/// an explicit timeout.
+/// Bounded Drop-path shutdown: spawns a thread to run `tp.shutdown()` and
+/// `mp.shutdown()`, then waits at most `DROP_SHUTDOWN_TIMEOUT` (500 ms).
+/// If the collector is unreachable and the shutdown thread stalls, the wait
+/// is abandoned and the thread is reaped when the process exits. This mirrors
+/// the `force_flush_bounded` pattern and prevents a dead OTLP collector from
+/// stalling the agent's `git` invocation on process teardown.
 impl Drop for TelemetryGuard {
     fn drop(&mut self) {
-        if let Some(tp) = self.tracer_provider.take()
-            && let Err(e) = tp.shutdown()
-        {
-            eprintln!("git-prism: failed to flush traces on shutdown: {e}");
+        let tp = self.tracer_provider.take();
+        let mp = self.meter_provider.take();
+        if tp.is_none() && mp.is_none() {
+            return;
         }
-        if let Some(mp) = self.meter_provider.take()
-            && let Err(e) = mp.shutdown()
-        {
-            eprintln!("git-prism: failed to flush metrics on shutdown: {e}");
-        }
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            if let Some(tp) = tp
+                && let Err(e) = tp.shutdown()
+            {
+                eprintln!("git-prism: failed to flush traces on shutdown: {e}");
+            }
+            if let Some(mp) = mp
+                && let Err(e) = mp.shutdown()
+            {
+                eprintln!("git-prism: failed to flush metrics on shutdown: {e}");
+            }
+            let _ = tx.send(());
+        });
+        // Bound the wait; abandon a stalled shutdown (process teardown reaps the thread).
+        let _ = rx.recv_timeout(DROP_SHUTDOWN_TIMEOUT);
     }
 }
 
@@ -773,23 +791,22 @@ mod tests {
         );
     }
 
-    /// QA #361: the WHOLE structured-path teardown — bounded flush AND the
-    /// guard's `Drop` — must stay bounded against an unreachable collector.
+    /// Smoke test: the flush+drop *sequence* completes without panic under the
+    /// test runtime.
     ///
-    /// `main.rs` runs exactly this sequence on the structured `git diff` path:
+    /// **Important limitation:** this test does NOT exercise real OTel provider
+    /// shutdown. The production providers (`SdkTracerProvider`, `SdkMeterProvider`)
+    /// are constructed under `#[cfg(not(test))]`-gated code paths; in test builds
+    /// they degrade to no-ops, so `Drop` returns instantly regardless of whether
+    /// the OTLP endpoint is reachable. The assertion here (`< 2 s`) passes even
+    /// at a buggy HEAD where the real binary stalls for ~10.5 s — it provides
+    /// false confidence about the bounded-shutdown property.
     ///
-    /// ```text
-    /// let exit_code = run_shim(...);                       // returns ExitCode
-    /// guard.force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT); // 500 ms cap
-    /// return exit_code;                                    // guard dropped HERE
-    /// ```
-    ///
-    /// The #361 fix bounds `force_flush_bounded`, so the agent's teardown no
-    /// longer stalls for multiple seconds even when the collector is unreachable.
-    /// This test verifies that the *entire* sequence — bounded flush followed by
-    /// the guard's `Drop` (which runs `tp.shutdown()` + `mp.shutdown()`) — stays
-    /// bounded against a black-hole endpoint. This regression guard prevents #360
-    /// from recurring via either the force_flush path or the guard-drop path.
+    /// The load-bearing guard for the real binary is the end-to-end pentest in
+    /// `tests/shim_structured_teardown_pentest.rs`, which drives the built binary
+    /// against an unroutable TEST-NET-1 endpoint and asserts the whole invocation
+    /// returns under 4 s. That test is the one that fails when the Drop-path
+    /// shutdown is unbounded.
     #[tokio::test]
     async fn qa_structured_path_total_teardown_is_bounded_on_black_hole_endpoint() {
         use crate::shim::STRUCTURED_FLUSH_TIMEOUT;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -773,6 +773,66 @@ mod tests {
         );
     }
 
+    /// QA #361: the WHOLE structured-path teardown — bounded flush AND the
+    /// guard's `Drop` — must stay bounded against an unreachable collector.
+    ///
+    /// `main.rs` runs exactly this sequence on the structured `git diff` path:
+    ///
+    /// ```text
+    /// let exit_code = run_shim(...);                       // returns ExitCode
+    /// guard.force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT); // 500 ms cap
+    /// return exit_code;                                    // guard dropped HERE
+    /// ```
+    ///
+    /// The #361 fix bounds `force_flush_bounded`, but the very next thing that
+    /// happens is the guard going out of scope, which runs `Drop::drop` →
+    /// `tp.shutdown()` + `mp.shutdown()`. Those shutdown calls are UNBOUNDED and
+    /// each block up to `EXPORT_TIMEOUT` (5 s) when the collector is a black
+    /// hole. So the bounded flush saves nothing: the agent's `git diff` still
+    /// stalls for multiple seconds on process teardown — the exact #360 symptom
+    /// #361 set out to eliminate.
+    ///
+    /// This test asserts the total teardown (flush + drop) returns within a
+    /// budget well under a single `EXPORT_TIMEOUT`. It FAILS today because
+    /// `Drop` is unbounded.
+    #[tokio::test]
+    async fn qa_structured_path_total_teardown_is_bounded_on_black_hole_endpoint() {
+        use crate::shim::STRUCTURED_FLUSH_TIMEOUT;
+        let _lock = ENV_MUTEX.lock().unwrap();
+        // SAFETY: ENV_MUTEX is held — no concurrent env mutation.
+        unsafe {
+            clear_telemetry_env();
+            // Unroutable TEST-NET-1 (RFC 5737): connections hang, exercising the
+            // export-timeout path rather than a fast local connection refusal.
+            std::env::set_var(ENV_OTLP_ENDPOINT, "http://192.0.2.1:4318");
+        }
+        let mut guard = init();
+        assert!(
+            guard.is_active(),
+            "guard must be active to exercise the structured-path teardown"
+        );
+        // SAFETY: cleanup before timing so a slow remove_var doesn't pollute the measurement.
+        unsafe {
+            std::env::remove_var(ENV_OTLP_ENDPOINT);
+        }
+
+        let start = std::time::Instant::now();
+        // Exact main.rs structured-path sequence:
+        guard.force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT); // 500 ms cap
+        drop(guard); // <-- main.rs `return exit_code` drops the guard here
+        let elapsed = start.elapsed();
+
+        // The whole teardown must stay well under a single 5 s EXPORT_TIMEOUT.
+        // A generous 2 s budget (4x the 500 ms flush cap) still fails loudly if
+        // Drop reintroduces the unbounded multi-second stall.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "structured-path teardown (bounded flush + guard Drop) must stay bounded; \
+             a black-hole collector must not stall the agent's git diff on teardown. \
+             took {elapsed:?} (Drop::shutdown is unbounded — #361 stall reintroduced)"
+        );
+    }
+
     /// Regression test for PR #210 blocker B1.
     ///
     /// Before the fix: when `Registry::default().with(otel_layer).try_init()`

--- a/tests/shim_bounded_drop_dataloss_pentest.rs
+++ b/tests/shim_bounded_drop_dataloss_pentest.rs
@@ -1,0 +1,131 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #361, gate 3, run 3): the NEW bounded `TelemetryGuard::drop`
+//! (commit 27bc943, DROP_SHUTDOWN_TIMEOUT=500ms) must not introduce telemetry
+//! DATA LOSS in the healthy common case.
+//!
+//! The run-2 fix bounded the Drop-path shutdown so an UNREACHABLE collector can't
+//! stall the agent's `git diff`. The adversarial question for run 3 is the dual:
+//! when the collector is HEALTHY and reachable, does the 500ms Drop budget still
+//! deliver the structured-path telemetry, or does the abandon-on-timeout logic now
+//! silently drop the export against a real backend?
+//!
+//! This drives the BUILT BINARY through the structured `git diff` path with
+//! `GIT_PRISM_OTLP_ENDPOINT` pointed at a LIVE local capture server that answers
+//! immediately. A correct bounded teardown still flushes to a fast collector, so
+//! an OTLP export must arrive well within the test window. If nothing arrives, the
+//! bounded Drop is dropping telemetry in the common case — a regression.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::os::unix::fs::symlink;
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// One-shot HTTP capture server that answers immediately (healthy collector).
+/// Returns the base URL and a receiver that yields `true` on the first request body.
+fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base = format!("http://{}", addr);
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(500)))
+                .ok();
+            let mut buf = [0u8; 4096];
+            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            if got {
+                let _ = tx.send(true);
+            }
+        }
+    });
+
+    (base, rx)
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// HEALTHY-COLLECTOR DATA-LOSS GUARD: the structured `git diff` path must still
+/// deliver an OTLP export to a fast, reachable collector under the bounded
+/// teardown. The export must arrive AND the whole invocation must stay bounded.
+#[test]
+fn structured_diff_still_exports_to_a_healthy_collector_under_bounded_teardown() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "t@t.com"]);
+    git(&repo, &["config", "user.name", "T"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("a.txt"), "alpha\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "first"]);
+    std::fs::write(repo.join("a.txt"), "alpha\nbeta\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "second"]);
+
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", shim_dir.display(), real_path);
+
+    let (endpoint, rx) = spawn_capture_server();
+
+    let start = Instant::now();
+    let out = Command::new(&shim_git)
+        .env("AI_AGENT", "1")
+        .env("GIT_PRISM_REPO", &repo)
+        .env("GIT_PRISM_OTLP_ENDPOINT", &endpoint)
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["diff", "HEAD~1..HEAD"])
+        .output()
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(
+        !out.stdout.is_empty(),
+        "expected structured JSON on stdout; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The bounded teardown must still deliver the export to a healthy collector.
+    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+    assert!(
+        received,
+        "bounded Drop (500ms) lost telemetry against a HEALTHY collector: no OTLP \
+         export arrived. The #361 Drop bound must not drop data in the common case."
+    );
+
+    // Sanity: against a fast collector the whole thing is quick.
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "structured diff against a healthy collector should be fast; took {elapsed:?}"
+    );
+}

--- a/tests/shim_passthrough_optout_pentest.rs
+++ b/tests/shim_passthrough_optout_pentest.rs
@@ -1,0 +1,192 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #362, gate 3): the `GIT_PRISM_PASSTHROUGH` /
+//! `GIT_PRISM_DISABLE` opt-out must:
+//!
+//!  1. RECURSION SAFETY — when the shim is FIRST on PATH, the immediate exec
+//!     must resolve the REAL git (skipping the shim symlink) so the opt-out
+//!     does not infinite-loop into itself.
+//!  2. NO-TELEMETRY GUARANTEE — an opted-out invocation must NOT initialize
+//!     OTel or emit any OTLP export, even when `GIT_PRISM_OTLP_ENDPOINT` is set.
+//!
+//! These drive the built binary end-to-end through argv[0]="git" shim mode.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::os::unix::fs::{PermissionsExt, symlink};
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+/// Spawn a one-shot HTTP capture server. Returns the bound `base` URL and a
+/// receiver that yields `true` once ANY HTTP request body is received.
+fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base = format!("http://{}", addr);
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(500)))
+                .ok();
+            let mut buf = [0u8; 4096];
+            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            if got {
+                let _ = tx.send(true);
+            }
+        }
+    });
+
+    (base, rx)
+}
+
+/// Create a fake real `git` that prints a unique marker and exits 0. Lets us
+/// prove the REAL git ran (not the shim) and that output is byte-identical.
+fn make_marker_git(dir: &std::path::Path, marker: &str) {
+    let git = dir.join("git");
+    std::fs::write(&git, format!("#!/bin/sh\nprintf '{marker}'\nexit 0\n")).unwrap();
+    let mut perms = std::fs::metadata(&git).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&git, perms).unwrap();
+}
+
+/// RECURSION SAFETY: shim symlink FIRST on PATH, real git SECOND. With
+/// `GIT_PRISM_PASSTHROUGH=1` the shim must exec the REAL git (skipping its own
+/// symlink) and terminate, NOT re-enter itself forever. We bound the child with
+/// a wall-clock timeout: an infinite recursion would never exit.
+#[test]
+fn it_execs_real_git_without_recursing_when_passthrough_set_and_shim_is_first_on_path() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    let real_dir = tmp.path().join("realbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    std::fs::create_dir_all(&real_dir).unwrap();
+
+    // Shim symlink installed AS `git`, FIRST on PATH.
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    // Real git SECOND on PATH, prints a marker so we can prove it ran.
+    let marker = "REAL_GIT_RAN_362";
+    make_marker_git(&real_dir, marker);
+
+    let path = format!("{}:{}", shim_dir.display(), real_dir.display());
+
+    // Opt-out set. Even though AI_AGENT is set (agent detected) and `diff` is a
+    // classified command, the opt-out must short-circuit to an immediate exec of
+    // the REAL git, with no recursion.
+    let out = Command::new(&shim_git)
+        .env("GIT_PRISM_PASSTHROUGH", "1")
+        .env("AI_AGENT", "1")
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["diff", "HEAD~1..HEAD"])
+        .output()
+        .expect("child must terminate; an infinite shim recursion would hang");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "opted-out passthrough should exit 0"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(marker),
+        "opt-out must exec the REAL git (marker {marker:?}); got stdout={stdout:?} \
+         stderr={:?}. If the marker is absent the shim either recursed or ran its \
+         own structured handler instead of the real git.",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The structured JSON handler would emit a '{' — real git's marker must be
+    // the ONLY output, proving no structured processing leaked through.
+    assert!(
+        !stdout.trim_start().starts_with('{'),
+        "opted-out output must be the real git's, not structured JSON; got {stdout:?}"
+    );
+}
+
+/// NO-TELEMETRY GUARANTEE: with the OTLP endpoint configured AND opt-out set,
+/// the shim must NOT initialize OTel or emit any export. We point the endpoint
+/// at a live capture server and assert NOTHING arrives within a generous window.
+#[test]
+fn it_emits_no_otlp_export_when_passthrough_opt_out_is_set() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    let real_dir = tmp.path().join("realbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    std::fs::create_dir_all(&real_dir).unwrap();
+
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+    make_marker_git(&real_dir, "X");
+
+    let path = format!("{}:{}", shim_dir.display(), real_dir.display());
+    let (endpoint, rx) = spawn_capture_server();
+
+    let status = Command::new(&shim_git)
+        .env("GIT_PRISM_PASSTHROUGH", "1")
+        .env("AI_AGENT", "1")
+        .env("GIT_PRISM_OTLP_ENDPOINT", &endpoint)
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["diff", "HEAD~1..HEAD"])
+        .status()
+        .unwrap();
+    assert_eq!(status.code(), Some(0));
+
+    // A correct opt-out never initializes telemetry, so NO export should arrive.
+    // If one arrives within 2 s, telemetry leaked on the opted-out path.
+    let leaked = rx.recv_timeout(Duration::from_secs(2)).unwrap_or(false);
+    assert!(
+        !leaked,
+        "opted-out invocation emitted an OTLP export; telemetry must be skipped \
+         entirely when GIT_PRISM_PASSTHROUGH is set (init must run AFTER the \
+         opt-out check, and it does — but this guards against regression)"
+    );
+}
+
+/// The `GIT_PRISM_DISABLE` alias must behave identically to
+/// `GIT_PRISM_PASSTHROUGH` for the immediate-exec recursion-safe path.
+#[test]
+fn it_execs_real_git_without_recursing_for_disable_alias() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    let real_dir = tmp.path().join("realbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    std::fs::create_dir_all(&real_dir).unwrap();
+
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+    let marker = "REAL_GIT_DISABLE_362";
+    make_marker_git(&real_dir, marker);
+
+    let path = format!("{}:{}", shim_dir.display(), real_dir.display());
+
+    let out = Command::new(&shim_git)
+        .env("GIT_PRISM_DISABLE", "1")
+        .env("AI_AGENT", "1")
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["diff", "HEAD~1..HEAD"])
+        .output()
+        .expect("child must terminate; an infinite shim recursion would hang");
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains(marker),
+        "GIT_PRISM_DISABLE alias must exec the real git just like GIT_PRISM_PASSTHROUGH"
+    );
+}

--- a/tests/shim_structured_teardown_pentest.rs
+++ b/tests/shim_structured_teardown_pentest.rs
@@ -1,0 +1,119 @@
+#![cfg(unix)]
+
+//! Adversarial QA (issue #361, gate 3): the structured-output path's TOTAL
+//! teardown — bounded flush PLUS the `TelemetryGuard::drop` shutdown — must stay
+//! bounded against an unreachable OTLP collector.
+//!
+//! Issue #361's stated goal is to kill the #360 multi-minute stall: an agent's
+//! `git diff` must not block when the OTLP collector is saturated or unreachable.
+//! The fix replaced the unbounded `force_flush()` with
+//! `force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT)` (500 ms) in `main.rs`.
+//!
+//! HOWEVER, `main.rs` runs:
+//!
+//! ```text
+//! let exit_code = run_shim(...);                       // structured JSON printed
+//! guard.force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT); // 500 ms cap  ✅ bounded
+//! return exit_code;                                    // guard DROPPED here
+//! ```
+//!
+//! `TelemetryGuard::drop` calls `tp.shutdown()` then `mp.shutdown()`. Those
+//! shutdowns are UNBOUNDED — each blocks up to `EXPORT_TIMEOUT` (5 s) trying to
+//! reach the dead collector. So the agent's `git diff` still stalls ~10 s
+//! (500 ms flush + ~5 s tracer shutdown + ~5 s meter shutdown) on every call
+//! when the collector is down — the exact #360 symptom the issue set out to fix,
+//! merely relocated from `force_flush` to `Drop`.
+//!
+//! This test drives the BUILT BINARY end-to-end through the structured `git diff`
+//! path with `GIT_PRISM_OTLP_ENDPOINT` pointed at an unroutable TEST-NET-1
+//! address (RFC 5737, 192.0.2.1 — connections hang rather than refuse fast) and
+//! asserts the whole invocation returns within a generous bound. It FAILS today
+//! because the guard's `Drop::shutdown` reintroduces the multi-second stall.
+
+use std::os::unix::fs::symlink;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The structured `git diff` path with a black-hole OTLP endpoint must complete
+/// well before two `EXPORT_TIMEOUT`s (10 s) elapse. A correct, fully-bounded
+/// teardown returns in well under 4 s; the unbounded `Drop::shutdown` makes the
+/// real binary take ~10.5 s.
+#[test]
+fn structured_diff_with_unreachable_otlp_collector_returns_within_bound() {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let tmp = TempDir::new().unwrap();
+    let shim_dir = tmp.path().join("shimbin");
+    std::fs::create_dir_all(&shim_dir).unwrap();
+    let shim_git = shim_dir.join("git");
+    symlink(bin, &shim_git).unwrap();
+
+    // Real two-commit fixture so the structured diff handler actually produces
+    // JSON (proving we exercised the structured path, not a passthrough).
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "t@t.com"]);
+    git(&repo, &["config", "user.name", "T"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("a.txt"), "alpha\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "first"]);
+    std::fs::write(repo.join("a.txt"), "alpha\nbeta\n").unwrap();
+    git(&repo, &["add", "a.txt"]);
+    git(&repo, &["commit", "-m", "second"]);
+
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{}", shim_dir.display(), real_path);
+
+    // AI_AGENT → agent detected; `git diff HEAD~1..HEAD` is classified →
+    // structured dispatch → run_shim returns → main.rs force_flush_bounded → Drop.
+    let start = Instant::now();
+    let out = Command::new(&shim_git)
+        .env("AI_AGENT", "1")
+        .env("GIT_PRISM_REPO", &repo)
+        // Unroutable TEST-NET-1: connections hang (export-timeout path), the
+        // exact saturated/unreachable collector scenario from #360.
+        .env("GIT_PRISM_OTLP_ENDPOINT", "http://192.0.2.1:4318")
+        .env_remove("GIT_PRISM_INSIDE_SHIM")
+        .env_remove("CI")
+        .env("PATH", &path)
+        .args(["diff", "HEAD~1..HEAD"])
+        .output()
+        .unwrap();
+    let elapsed = start.elapsed();
+
+    // Sanity: we really hit the structured path (non-empty JSON on stdout).
+    assert!(
+        !out.stdout.is_empty(),
+        "expected structured JSON on stdout (structured path), got empty; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The whole invocation must stay bounded. A correct teardown (bounded flush
+    // + bounded shutdown) returns in << 4 s. The unbounded `Drop::shutdown`
+    // currently makes this take ~10.5 s (500 ms flush + 5 s + 5 s shutdowns).
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "structured `git diff` with an unreachable OTLP collector must not stall \
+         the agent: total teardown (bounded flush + guard Drop shutdown) took \
+         {elapsed:?}. The #361 fix bounded force_flush but TelemetryGuard::drop \
+         still calls unbounded tp.shutdown()+mp.shutdown() (EXPORT_TIMEOUT=5s each), \
+         reintroducing the #360 multi-second stall."
+    );
+}


### PR DESCRIPTION
## Summary

Two fixes from the #360 perf investigation, both in the shim/telemetry path:

- **Closes #361** — bound the structured-output path's telemetry teardown. The shim's structured path (`git diff`/`log`/`show`/`blame` → JSON manifest) flushed telemetry with an **unbounded** `force_flush()`, so a saturated or unreachable OTLP collector could stall a `git diff` for minutes (#360 symptom 2). The flush is now `force_flush_bounded(STRUCTURED_FLUSH_TIMEOUT)` (500 ms), the unbounded `TelemetryGuard::force_flush()` method is gone, **and** the `TelemetryGuard::drop` shutdown — which `main.rs` runs immediately after the flush on `return` — is now bounded too (`DROP_SHUTDOWN_TIMEOUT` 500 ms). The second half mattered: bounding only the explicit flush merely relocated the stall into the guard's `Drop`, where `tp.shutdown()` + `mp.shutdown()` each block up to 5 s on a dead collector. Caught by adversarial QA driving the **built binary** end-to-end (a `#[cfg(test)]` unit test can't reproduce it — the real provider wiring is `#[cfg(not(test))]`-gated).

- **Closes #362** — per-invocation opt-out. Set `GIT_PRISM_PASSTHROUGH=1` (or the alias `GIT_PRISM_DISABLE=1`) and the shim execs the real `git`/`gh` **immediately** — before `telemetry::init_quiet()`, before classification — with near-zero added latency and no recording. This replaces the all-or-nothing `PATH` hack for agent workflows that shell `git` heavily in throwaway tmp repos.

## What changed

- `src/main.rs` — opt-out checked before telemetry init on the shim branch; structured-path flush now bounded.
- `src/shim/mod.rs` — `passthrough_opt_out_requested()` (truthy = `1`/`true`, case-insensitive); `STRUCTURED_FLUSH_TIMEOUT` (500 ms); opt-out short-circuit at step 0 of `run_shim`.
- `src/telemetry.rs` — removed unbounded `force_flush()`; bounded `Drop` shutdown via the same spawn + `recv_timeout` pattern as `force_flush_bounded`.
- `README.md` — "Per-invocation opt-out" section + env-var table rows.
- `tests/shim_passthrough_optout_pentest.rs` — opt-out e2e: recursion-safe, no telemetry, `DISABLE` alias.
- `tests/shim_structured_teardown_pentest.rs` — drives the built binary through the structured path against an unroutable TEST-NET-1 OTLP endpoint and asserts the whole invocation returns under 4 s (was ~10.5 s before the Drop bound).

## Testing

- Full suite green (`cargo test`), including both new e2e pentests.
- `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- Opt-out verified for `1`/`true`/`TRUE`/`GIT_PRISM_DISABLE`; inactive for `0`/`false`/empty/unset/`2`/`yes`/`on`/whitespace.
- Structured `git diff` against a black-hole collector: ~10.5 s → 3.16 s.

## Out of scope

- #363 (serve daemon lifecycle) — separate PR.
- Pre-existing `current_dir().expect()` panics in the CLI subcommand handlers — filed as #364.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
