### PR TITLE
feat(serve): self-terminate orphaned MCP daemons on parent death (#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Per-invocation shim opt-out via `GIT_PRISM_PASSTHROUGH` / `GIT_PRISM_DISABLE`.** Setting either env var to a truthy value (`1` or case-insensitive `true`) makes the shim `exec` the real `git` / `gh` immediately — before `telemetry::init_quiet()` and before command classification — with near-zero added latency and no recording. This replaces the all-or-nothing `PATH` hack for agent workflows that shell `git` heavily in throwaway tmp repos, where per-call cold-start and telemetry overhead is unwanted and recording ephemeral repos is undesirable anyway. The opt-out exec is recursion-safe (it resolves and runs the real binary, not the shim symlink, even when the shim is first on `PATH`). (#362)
+- **`git-prism serve` now self-terminates when its launching session dies.** The MCP `serve` daemon polls its parent pid every 5 seconds and exits when it detects it has been reparented to init/launchd (`ppid == 1`) — the signal that the Claude Code session that spawned it exited without closing stdin. This prevents the orphaned-daemon accumulation observed in shim-heavy setups (multiple `serve` processes lingering for hours to days). The README now documents the shim-vs-MCP distinction and notes that shim-only users can drop the `serve` registration entirely (`claude mcp remove git-prism`). (#363)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "gix",
  "glob",
  "insta",
+ "libc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.31", features = ["http-proto"] }
 sha2 = "0.11"
 rand = { version = "0.9", default-features = false, features = ["thread_rng"] }
+libc = "0.2"
 
 [build-dependencies]
 cc = "1"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,46 @@ claude mcp add git-prism -- git-prism serve
 That's it. The server uses stdio transport and is available in all Claude Code
 sessions.
 
+### Shim vs. MCP server — which do you need?
+
+git-prism has two independent interception paths. They do different things and
+can be used together or separately:
+
+| | PATH shim (`git-prism shim install`) | MCP server (`git-prism serve`) |
+|---|---|---|
+| **What it intercepts** | `git` and `gh` CLI calls made by the agent | Direct calls to git-prism MCP tools (`get_change_manifest`, `get_function_context`, etc.) |
+| **How it runs** | One-shot process per intercepted command; exits immediately | Long-running stdio server; one process per Claude Code session |
+| **Needs MCP registration?** | No | Yes (`claude mcp add`) |
+
+**If you only use the PATH shim** (agents call `git`/`gh` directly and you
+haven't registered git-prism as an MCP server), you don't need the MCP
+registration at all — and you can remove it to avoid the orphaned-process
+accumulation described below.
+
+**If you use the MCP tools** (`get_change_manifest`, etc.) in your agent
+prompts, you need the MCP server registration.
+
+**Most users want both:** the shim redirects raw `git diff`/`git log` calls,
+and the MCP tools give structured data when the agent calls them explicitly.
+
+### Orphaned serve processes
+
+`git-prism serve` is launched by the MCP client and its lifecycle is owned by
+that client. In practice, Claude Code sessions sometimes exit without closing
+the server's stdin, leaving an orphaned process running indefinitely. Observed
+accumulation: 5+ processes, uptimes from ~2 hours to >1 day.
+
+git-prism defends against this: the serve process polls its parent pid every
+5 seconds and exits when it detects it has been reparented to init/launchd
+(`ppid == 1`), which is the OS signal that the launching session has died.
+
+If you are **shim-only** (no MCP tool calls in your prompts), removing the MCP
+registration entirely is the simplest fix:
+
+```bash
+claude mcp remove git-prism
+```
+
 ## Redirect hook (removed in v0.9.0)
 
 Earlier versions bundled a Claude Code `PreToolUse` redirect hook, installed via

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sessions.
 
 ### Shim vs. MCP server — which do you need?
 
-git-prism has two independent interception paths. They do different things and
+git-prism works through two independent mechanisms. They do different things and
 can be used together or separately:
 
 | | PATH shim (`git-prism shim install`) | MCP server (`git-prism serve`) |
@@ -68,8 +68,8 @@ can be used together or separately:
 
 **If you only use the PATH shim** (agents call `git`/`gh` directly and you
 haven't registered git-prism as an MCP server), you don't need the MCP
-registration at all — and you can remove it to avoid the orphaned-process
-accumulation described below.
+registration at all -- and you can remove it to avoid the orphaned `serve`
+processes described below.
 
 **If you use the MCP tools** (`get_change_manifest`, etc.) in your agent
 prompts, you need the MCP server registration.
@@ -86,7 +86,7 @@ accumulation: 5+ processes, uptimes from ~2 hours to >1 day.
 
 git-prism defends against this: the serve process polls its parent pid every
 5 seconds and exits when it detects it has been reparented to init/launchd
-(`ppid == 1`), which is the OS signal that the launching session has died.
+(`ppid == 1`) -- the OS signal that the launching session has died.
 
 If you are **shim-only** (no MCP tool calls in your prompts), removing the MCP
 registration entirely is the simplest fix:

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,43 @@ use crate::tools::{
     build_manifest, build_review_change, build_snapshots, build_worktree_manifest,
 };
 
+/// How often the orphan watchdog polls the parent pid.
+const ORPHAN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Returns `true` when the process has been reparented to init/launchd (ppid == 1),
+/// which means the Claude Code session that launched `git-prism serve` has exited
+/// without closing stdin. Exiting on this condition prevents indefinite orphan daemons.
+///
+/// The argument is injected for testability — callers pass `libc::getppid() as u32`
+/// in production and a fixed value in unit tests.
+pub fn should_exit_orphaned(ppid: u32) -> bool {
+    ppid == 1
+}
+
+/// Spawn a background task that polls the parent pid every [`ORPHAN_POLL_INTERVAL`]
+/// and hard-exits the process when [`should_exit_orphaned`] returns `true`.
+///
+/// This is a fire-and-forget guard: `tokio::select!` in `run_server` races the
+/// serve future against a never-resolving placeholder, while this task hard-exits
+/// on orphan. The hard-exit is intentional — a reparented process has no meaningful
+/// cleanup to do (telemetry flush is best-effort; the OTLP collector is gone too).
+fn spawn_orphan_watchdog() {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(ORPHAN_POLL_INTERVAL).await;
+            // SAFETY: getppid() is always safe to call; it never fails.
+            let ppid = unsafe { libc::getppid() } as u32;
+            if should_exit_orphaned(ppid) {
+                eprintln!(
+                    "git-prism: parent process exited (ppid == 1); \
+                     exiting orphaned serve process"
+                );
+                std::process::exit(0);
+            }
+        }
+    });
+}
+
 /// Convert a `ChangeScope` variant to a static metric label string.
 fn change_scope_label(scope: ChangeScope) -> &'static str {
     match scope {
@@ -882,6 +919,11 @@ pub async fn run_server() -> anyhow::Result<()> {
         );
     }
     crate::metrics::get().record_session_started();
+    // Spawn the orphan watchdog before starting the serve loop. It runs
+    // concurrently and hard-exits the process if the parent pid becomes 1
+    // (reparented to init/launchd), which happens when the Claude Code session
+    // that launched `git-prism serve` dies without closing stdin.
+    spawn_orphan_watchdog();
     let server = GitPrismServer::new();
     let transport = tokio::io::join(tokio::io::stdin(), tokio::io::stdout());
     server.serve(transport).await?.waiting().await?;
@@ -1079,6 +1121,32 @@ mod tests {
         assert!(
             server_info.capabilities.prompts.is_none(),
             "prompts capability must not be advertised — this server does not implement prompts"
+        );
+    }
+
+    #[test]
+    fn it_exits_when_reparented_to_init() {
+        assert!(
+            should_exit_orphaned(1),
+            "ppid == 1 means the process was reparented to init/launchd \
+             (the Claude Code session died); serve must exit"
+        );
+    }
+
+    #[test]
+    fn it_does_not_exit_when_parent_is_alive() {
+        assert!(
+            !should_exit_orphaned(2),
+            "ppid == 2 means a live parent; serve must not exit"
+        );
+    }
+
+    #[test]
+    fn it_does_not_exit_for_typical_shell_parent_pid() {
+        // Realistic shell pids are in the thousands; must not trigger exit.
+        assert!(
+            !should_exit_orphaned(12345),
+            "ppid == 12345 is a normal shell pid; serve must not exit"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use crate::tools::{
 };
 
 /// How often the orphan watchdog polls the parent pid.
+#[cfg(unix)]
 const ORPHAN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Returns `true` when the process has been reparented to init/launchd (ppid == 1),
@@ -22,7 +23,8 @@ const ORPHAN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs
 ///
 /// The argument is injected for testability — callers pass `libc::getppid() as u32`
 /// in production and a fixed value in unit tests.
-pub fn should_exit_orphaned(ppid: u32) -> bool {
+#[cfg(unix)]
+pub(crate) fn should_exit_orphaned(ppid: u32) -> bool {
     ppid == 1
 }
 
@@ -35,6 +37,7 @@ pub fn should_exit_orphaned(ppid: u32) -> bool {
 /// serve future entirely. The hard-exit is intentional — a reparented process has
 /// no meaningful cleanup to do (telemetry flush is best-effort; the OTLP collector
 /// is likely gone too).
+#[cfg(unix)]
 fn spawn_orphan_watchdog() {
     tokio::spawn(async move {
         loop {
@@ -58,6 +61,12 @@ fn spawn_orphan_watchdog() {
         }
     });
 }
+
+/// On non-Unix targets there is no `getppid()` / init-reparenting signal, so the
+/// orphan watchdog is a no-op. The MCP client owns server lifetime there and the
+/// stdin-EOF path still handles graceful shutdown.
+#[cfg(not(unix))]
+fn spawn_orphan_watchdog() {}
 
 /// Convert a `ChangeScope` variant to a static metric label string.
 fn change_scope_label(scope: ChangeScope) -> &'static str {
@@ -1133,6 +1142,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_returns_true_when_ppid_is_init() {
         assert!(
@@ -1142,6 +1152,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_returns_false_when_ppid_is_two() {
         assert!(
@@ -1150,6 +1161,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_returns_false_for_typical_shell_pid() {
         // Realistic shell pids are in the thousands; must not trigger exit.
@@ -1159,6 +1171,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn it_returns_false_when_ppid_is_zero() {
         // `getppid() == 0` can occur in a Linux PID namespace whose parent lives

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,16 +29,24 @@ pub fn should_exit_orphaned(ppid: u32) -> bool {
 /// Spawn a background task that polls the parent pid every [`ORPHAN_POLL_INTERVAL`]
 /// and hard-exits the process when [`should_exit_orphaned`] returns `true`.
 ///
-/// This is a fire-and-forget guard: `tokio::select!` in `run_server` races the
-/// serve future against a never-resolving placeholder, while this task hard-exits
-/// on orphan. The hard-exit is intentional — a reparented process has no meaningful
-/// cleanup to do (telemetry flush is best-effort; the OTLP collector is gone too).
+/// This is a fire-and-forget guard: `run_server` spawns it and then awaits the
+/// serve loop normally; the watchdog runs concurrently on the tokio runtime and
+/// calls `std::process::exit(0)` directly when it detects an orphan, bypassing the
+/// serve future entirely. The hard-exit is intentional — a reparented process has
+/// no meaningful cleanup to do (telemetry flush is best-effort; the OTLP collector
+/// is likely gone too).
 fn spawn_orphan_watchdog() {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(ORPHAN_POLL_INTERVAL).await;
-            // SAFETY: getppid() is always safe to call; it never fails.
-            let ppid = unsafe { libc::getppid() } as u32;
+            // SAFETY: `getppid` is a POSIX system call with no preconditions —
+            // it takes no arguments, dereferences no pointers, and touches no
+            // shared state, so there is nothing the caller can violate. It is
+            // also infallible (it cannot return an error).
+            let raw_ppid: libc::pid_t = unsafe { libc::getppid() };
+            // `pid_t` is signed but a real ppid is always >= 1; the cast is a
+            // plain widening reinterpretation used only for the `== 1` compare.
+            let ppid = raw_ppid as u32;
             if should_exit_orphaned(ppid) {
                 eprintln!(
                     "git-prism: parent process exited (ppid == 1); \
@@ -1125,7 +1133,7 @@ mod tests {
     }
 
     #[test]
-    fn it_exits_when_reparented_to_init() {
+    fn it_returns_true_when_ppid_is_init() {
         assert!(
             should_exit_orphaned(1),
             "ppid == 1 means the process was reparented to init/launchd \
@@ -1134,7 +1142,7 @@ mod tests {
     }
 
     #[test]
-    fn it_does_not_exit_when_parent_is_alive() {
+    fn it_returns_false_when_ppid_is_two() {
         assert!(
             !should_exit_orphaned(2),
             "ppid == 2 means a live parent; serve must not exit"
@@ -1142,11 +1150,23 @@ mod tests {
     }
 
     #[test]
-    fn it_does_not_exit_for_typical_shell_parent_pid() {
+    fn it_returns_false_for_typical_shell_pid() {
         // Realistic shell pids are in the thousands; must not trigger exit.
         assert!(
             !should_exit_orphaned(12345),
             "ppid == 12345 is a normal shell pid; serve must not exit"
+        );
+    }
+
+    #[test]
+    fn it_returns_false_when_ppid_is_zero() {
+        // `getppid() == 0` can occur in a Linux PID namespace whose parent lives
+        // outside the namespace. The current predicate does NOT treat this as
+        // orphaned, so the watchdog won't fire for that case. Pinning current
+        // behavior; whether to broaden to `ppid <= 1` is tracked in #366.
+        assert!(
+            !should_exit_orphaned(0),
+            "ppid == 0 (PID-namespace reparenting) is currently not treated as orphaned (see #366)"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,8 +49,9 @@ fn spawn_orphan_watchdog() {
             let ppid = raw_ppid as u32;
             if should_exit_orphaned(ppid) {
                 eprintln!(
-                    "git-prism: parent process exited (ppid == 1); \
-                     exiting orphaned serve process"
+                    "git-prism: serve pid {} reparented to init (ppid == 1); \
+                     parent Claude Code session exited — shutting down orphaned daemon",
+                    std::process::id()
                 );
                 std::process::exit(0);
             }


### PR DESCRIPTION
## Summary

**Closes #363** (part of #360 — `serve` daemons accumulate one-per-session).

The MCP `serve` daemon had no self-termination path: when the Claude Code session that launched it exited without closing stdin, the process lingered indefinitely. In shim-heavy setups this accumulated multiple orphaned `git-prism serve` processes (observed: 5+, uptimes from ~2 hours to >1 day), each still loading the OTLP collector.

`serve` now spawns a watchdog that polls its parent pid every 5 s and exits when it has been reparented to init/launchd (`ppid == 1`) — the signal that the launching session died. The README also documents the shim-vs-MCP distinction and notes that shim-only users can drop the `serve` registration entirely (`claude mcp remove git-prism`).

## What changed

- `src/server.rs` — `should_exit_orphaned(ppid)` (pure, injected pid for hermetic testing), `spawn_orphan_watchdog()` (tokio task: poll `libc::getppid()` every `ORPHAN_POLL_INTERVAL`, `std::process::exit(0)` on orphan with a pid-tagged stderr line), wired into `run_server`. Unit tests for the predicate including the `ppid == 0` boundary.
- `Cargo.toml` — `libc = "0.2"` (already in the build graph transitively; now declared) for `getppid()`.
- `README.md` — "Shim vs. MCP server — which do you need?" section + escape hatch.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design notes

- The hard `process::exit(0)` from the watchdog intentionally skips the telemetry-flush-on-drop: a reparented process's launching session is gone and its collector is likely gone too; lingering to flush is worse than dropping a few spans.
- The predicate keys on `ppid == 1` (init/launchd reparenting), which covers the reported macOS accumulation. The Linux PID-namespace edge where `getppid() == 0` is **out of scope** here — pinned by a test (`it_returns_false_when_ppid_is_zero`) and tracked for a decision in #366.

## Testing

- Full suite green (`cargo test`); `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- Adversarial QA (gate 3) passed at the final HEAD; the watchdog predicate has true/false-polarity triangulation (ppid 1 → exit; 0/2/12345 → stay).

## Out of scope (filed separately)

- `getppid() == 0` PID-namespace handling — #366.
- The MCP client's own server reaping (upstream Claude Code).

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
