### PR TITLE
fix(cli): return a clean error instead of panicking when cwd is unavailable (#364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `manifest` / `history` / `snapshot` / `context` CLI subcommands no longer panic when the current directory is unavailable.** They resolved the default repo path with `std::env::current_dir().expect(...)`, which panicked with a backtrace if the cwd was deleted or inaccessible (a real case for the shim running in agent-driven throwaway tmp repos). They now return a clean `anyhow` error instead. (#364)
 - **The shim's structured-output path (`git diff` / `log` / `show` / `blame`) no longer stalls on an unreachable OpenTelemetry collector.** The structured path flushed telemetry with an unbounded `force_flush()`, and `main` then dropped the `TelemetryGuard`, whose `Drop` ran unbounded `shutdown()` calls — so a single `git diff` could block for minutes (≈10 s per call was reproduced against a black-hole endpoint: 5 s tracer shutdown + 5 s meter shutdown). Both the explicit flush and the `Drop`-path shutdown are now time-bounded (500 ms each), mirroring the already-bounded passthrough path; a saturated or unreachable collector can no longer stall an intercepted git command. Telemetry still delivers normally when the collector is responsive (proven by an end-to-end data-loss guard against a live capture server). (#361)
 
 ## [0.9.3] — 2026-06-03

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod treesitter;
 
 use std::path::PathBuf;
 
+use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 
 use git::refs::{RefRange, parse_range, validate_commit_range};
@@ -158,6 +159,16 @@ enum ShimCommands {
     Uninstall,
     /// Report whether the shim is installed and show the shim directory
     Status,
+}
+
+fn resolve_cli_repo_path(
+    repo: Option<String>,
+    cwd: impl Fn() -> std::io::Result<PathBuf>,
+) -> anyhow::Result<PathBuf> {
+    match repo {
+        Some(r) => Ok(PathBuf::from(r)),
+        None => cwd().context("cannot determine current working directory"),
+    }
 }
 
 /// Dispatch a `git-prism hooks <subcommand>` invocation. Returns the exit
@@ -332,9 +343,7 @@ async fn run() -> anyhow::Result<()> {
             include_function_analysis,
             max_response_tokens,
         } => {
-            let repo_path = repo.map(PathBuf::from).unwrap_or_else(|| {
-                std::env::current_dir().expect("cannot determine current directory")
-            });
+            let repo_path = resolve_cli_repo_path(repo, std::env::current_dir)?;
             let options = ManifestOptions {
                 include_patterns: vec![],
                 exclude_patterns: vec![],
@@ -360,9 +369,7 @@ async fn run() -> anyhow::Result<()> {
             repo,
             page_size,
         } => {
-            let repo_path = repo.map(PathBuf::from).unwrap_or_else(|| {
-                std::env::current_dir().expect("cannot determine current directory")
-            });
+            let repo_path = resolve_cli_repo_path(repo, std::env::current_dir)?;
             let ref_range = parse_range(&range);
             validate_commit_range(&ref_range, "history")?;
             let (base_ref, head_ref) = match ref_range {
@@ -385,9 +392,7 @@ async fn run() -> anyhow::Result<()> {
             repo,
             include_diff_hunks,
         } => {
-            let repo_path = repo.map(PathBuf::from).unwrap_or_else(|| {
-                std::env::current_dir().expect("cannot determine current directory")
-            });
+            let repo_path = resolve_cli_repo_path(repo, std::env::current_dir)?;
             let ref_range = parse_range(&range);
             validate_commit_range(&ref_range, "snapshot")?;
             let (base_ref, head_ref) = match ref_range {
@@ -412,9 +417,7 @@ async fn run() -> anyhow::Result<()> {
             function_names,
             max_response_tokens,
         } => {
-            let repo_path = repo.map(PathBuf::from).unwrap_or_else(|| {
-                std::env::current_dir().expect("cannot determine current directory")
-            });
+            let repo_path = resolve_cli_repo_path(repo, std::env::current_dir)?;
             let ref_range = parse_range(&range);
             validate_commit_range(&ref_range, "context")?;
             let (base_ref, head_ref) = match ref_range {
@@ -488,4 +491,34 @@ async fn run() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_cli_repo_path_uses_explicit_repo_without_calling_cwd() {
+        let result = resolve_cli_repo_path(Some("/some/path".into()), || unreachable!());
+        assert_eq!(result.unwrap(), PathBuf::from("/some/path"));
+    }
+
+    #[test]
+    fn resolve_cli_repo_path_falls_back_to_cwd_when_repo_is_none() {
+        let result = resolve_cli_repo_path(None, || Ok(PathBuf::from("/cwd")));
+        assert_eq!(result.unwrap(), PathBuf::from("/cwd"));
+    }
+
+    #[test]
+    fn resolve_cli_repo_path_returns_clean_error_when_cwd_is_unavailable() {
+        let result = resolve_cli_repo_path(None, || {
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "boom"))
+        });
+        let err = result.unwrap_err();
+        let formatted = format!("{err:#}");
+        assert!(
+            formatted.contains("cannot determine current working directory"),
+            "expected error context in: {formatted}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,19 +498,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_cli_repo_path_uses_explicit_repo_without_calling_cwd() {
+    fn it_uses_explicit_repo_without_calling_cwd() {
         let result = resolve_cli_repo_path(Some("/some/path".into()), || unreachable!());
         assert_eq!(result.unwrap(), PathBuf::from("/some/path"));
     }
 
     #[test]
-    fn resolve_cli_repo_path_falls_back_to_cwd_when_repo_is_none() {
+    fn it_falls_back_to_cwd_when_repo_is_none() {
         let result = resolve_cli_repo_path(None, || Ok(PathBuf::from("/cwd")));
         assert_eq!(result.unwrap(), PathBuf::from("/cwd"));
     }
 
     #[test]
-    fn resolve_cli_repo_path_returns_clean_error_when_cwd_is_unavailable() {
+    fn it_returns_clean_error_when_cwd_is_unavailable() {
         let result = resolve_cli_repo_path(None, || {
             Err(std::io::Error::new(std::io::ErrorKind::NotFound, "boom"))
         });
@@ -520,5 +520,15 @@ mod tests {
             formatted.contains("cannot determine current working directory"),
             "expected error context in: {formatted}"
         );
+    }
+
+    #[test]
+    fn it_treats_empty_repo_string_as_an_explicit_path() {
+        // `--repo ""` parses to Some(String::new()); the helper returns it as an
+        // explicit empty path (gix resolves "" to cwd downstream) rather than
+        // falling back via cwd. Pin this so a future is_empty() fallback is a
+        // deliberate choice, not an accident.
+        let result = resolve_cli_repo_path(Some(String::new()), || unreachable!());
+        assert_eq!(result.unwrap(), std::path::PathBuf::from(""));
     }
 }

--- a/tests/cli_repo_path_cwd_pentest.rs
+++ b/tests/cli_repo_path_cwd_pentest.rs
@@ -1,0 +1,92 @@
+#![cfg(unix)]
+
+//! Adversarial / regression pentest for issue #364: the
+//! manifest/history/snapshot/context CLI handlers no longer panic when the
+//! process working directory has been deleted. They drive the REAL binary
+//! through a deleted-cwd sh wrapper (deterministic: rmdir before exec).
+
+use std::process::Command;
+
+fn run_from_deleted_cwd(args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_git-prism");
+    let mut cmd = String::from("d=$(mktemp -d) && cd \"$d\" && rmdir \"$d\" && exec");
+    cmd.push_str(" '");
+    cmd.push_str(&bin.replace('\'', "'\\''"));
+    cmd.push('\'');
+    for a in args {
+        cmd.push_str(" '");
+        cmd.push_str(&a.replace('\'', "'\\''"));
+        cmd.push('\'');
+    }
+    Command::new("sh")
+        .arg("-c")
+        .arg(&cmd)
+        .env("RUST_BACKTRACE", "1")
+        .output()
+        .expect("failed to spawn sh wrapper")
+}
+
+fn combined(out: &std::process::Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn assert_clean_cwd_error(args: &[&str]) {
+    let out = run_from_deleted_cwd(args);
+    let text = combined(&out);
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "expected non-zero exit on deleted cwd; output: {text}"
+    );
+    assert!(
+        !text.contains("panicked") && !text.contains("stack backtrace"),
+        "expected NO panic/backtrace (regression to .expect()); output: {text}"
+    );
+    assert!(
+        text.contains("cannot determine current working directory"),
+        "expected clean context message; output: {text}"
+    );
+}
+
+#[test]
+fn manifest_with_deleted_cwd_errors_cleanly_without_panic() {
+    assert_clean_cwd_error(&["manifest", "main..HEAD"]);
+}
+
+#[test]
+fn history_with_deleted_cwd_errors_cleanly_without_panic() {
+    assert_clean_cwd_error(&["history", "main..HEAD"]);
+}
+
+#[test]
+fn snapshot_with_deleted_cwd_errors_cleanly_without_panic() {
+    assert_clean_cwd_error(&["snapshot", "main..HEAD"]);
+}
+
+#[test]
+fn context_with_deleted_cwd_errors_cleanly_without_panic() {
+    assert_clean_cwd_error(&["context", "main..HEAD"]);
+}
+
+#[test]
+fn explicit_repo_does_not_consult_cwd_even_when_cwd_is_deleted() {
+    let out = run_from_deleted_cwd(&["manifest", "main..HEAD", "--repo", "/nonexistent/repo/path"]);
+    let text = combined(&out);
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "a bogus repo path should still fail; output: {text}"
+    );
+    assert!(
+        !text.contains("cannot determine current working directory"),
+        "explicit --repo must short-circuit cwd resolution; output: {text}"
+    );
+    assert!(
+        !text.contains("panicked") && !text.contains("stack backtrace"),
+        "explicit --repo on a bogus path must not panic; output: {text}"
+    );
+}


### PR DESCRIPTION
## Summary

**Closes #364.** The `manifest` / `history` / `snapshot` / `context` CLI subcommand handlers resolved the default repo path with `std::env::current_dir().expect("cannot determine current directory")` — an unhandled **panic** (with backtrace) when the current directory is deleted or inaccessible. That's a real case for the shim running inside agent-driven throwaway tmp repos that can be removed out from under a call.

`main()` already returns `anyhow::Result<()>`, so the fix is to propagate, not panic:

- New helper `resolve_cli_repo_path(repo: Option<String>, cwd: impl Fn() -> std::io::Result<PathBuf>) -> anyhow::Result<PathBuf>` — `Some(r)` returns the explicit path (without consulting cwd); `None` calls `cwd().context("cannot determine current working directory")`. The injected `cwd` closure makes the error path unit-testable without removing the real working directory.
- All four handlers now use `resolve_cli_repo_path(repo, std::env::current_dir)?`.

The other `current_dir()` site (`run_hooks_command`) already used `.map_err(...)?` and was never a panic — left as-is (no `--repo` option, different shape).

## Behavior change

`git-prism manifest|history|snapshot|context` run from a deleted cwd now exit **1** with `error: cannot determine current working directory: ...` instead of a Rust panic + backtrace.

## Testing

- 4 unit tests on the helper: explicit-repo short-circuits cwd (`|| unreachable!()` resolver), `None` falls back to cwd, `None` + failing cwd → clean `anyhow` error with the context message, and `Some("")` is an explicit empty path (not a cwd fallback).
- `tests/cli_repo_path_cwd_pentest.rs` (`#![cfg(unix)]`) — end-to-end guard driving the **real binary** from a `rmdir`'d cwd, asserting all four handlers exit 1 with a clean error and **zero** panic/backtrace lines (even under `RUST_BACKTRACE=1`).
- Full suite green (1104 tests); `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean. Adversarial QA (gate 3, genuine run against the built binary) + church (rust/test/secret) — clean.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
