### PR TITLE
test(shim): dedup capture-server helper + harden recv_timeout false-pass (#369)

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -72,7 +72,13 @@ impl TelemetryGuard {
         if self.meter_provider.is_none() && self.tracer_provider.is_none() {
             return;
         }
-        // Clone the Arc-backed provider handles so they can be moved into the thread.
+        // Clone the Arc-backed provider handles so they can be moved into the flush thread.
+        // WHY clone rather than take(): `force_flush_bounded` is intentionally non-destructive.
+        // `Drop::drop` is the shutdown gate — it calls `.take()` and runs `tp.shutdown()` /
+        // `mp.shutdown()` to perform the final teardown. If we used `.take()` here, the guard
+        // would hold `None` after the first flush and `Drop` would have nothing to shut down,
+        // silently skipping the final export on process exit. A future reader must not
+        // "simplify" this to `take()`.
         let mp = self.meter_provider.clone();
         let tp = self.tracer_provider.clone();
         let (tx, rx) = std::sync::mpsc::channel::<()>();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,7 @@
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::time::Duration;
 
 /// Spawn a one-shot HTTP capture server that answers immediately (healthy collector).
@@ -49,4 +50,18 @@ pub fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
     });
 
     (base, rx)
+}
+
+/// Receive the capture server's telemetry signal, distinguishing "no telemetry
+/// within the deadline" (`Timeout` → `false`, the legitimate expected case) from
+/// "the capture-server thread died" (`Disconnected` → panic, a harness failure
+/// that must not masquerade as a passing test).
+pub fn recv_telemetry(rx: &Receiver<bool>, timeout: Duration) -> bool {
+    match rx.recv_timeout(timeout) {
+        Ok(v) => v,
+        Err(RecvTimeoutError::Timeout) => false,
+        Err(RecvTimeoutError::Disconnected) => {
+            panic!("capture-server thread disconnected — harness failure, not a telemetry signal")
+        }
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,52 @@
+//! Shared test helpers for shim telemetry end-to-end tests.
+//!
+//! This module is NOT compiled as its own test binary — `tests/common/mod.rs`
+//! is a plain module that each integration test opts into with `mod common;`.
+
+#![allow(dead_code)]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Spawn a one-shot HTTP capture server that answers immediately (healthy collector).
+///
+/// Returns the bound base URL and a receiver that yields `true` once ANY HTTP
+/// request body is received.
+///
+/// # Harness failure detection
+///
+/// The receiver distinguishes three outcomes:
+///
+/// - `Ok(true)` — a request body arrived (telemetry was emitted)
+/// - `Err(RecvTimeoutError::Timeout)` — no request within the timeout window
+///   (legitimate "no telemetry" result in opt-out / passthrough tests)
+/// - `Err(RecvTimeoutError::Disconnected)` — the capture-server thread died
+///   (channel sender was dropped without sending); this is a harness failure,
+///   NOT a telemetry signal. Callers must treat `Disconnected` as a test
+///   failure rather than silently reading it as "no telemetry received".
+pub fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base = format!("http://{}", addr);
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(500)))
+                .ok();
+            let mut buf = [0u8; 4096];
+            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            if got {
+                let _ = tx.send(true);
+            }
+        }
+    });
+
+    (base, rx)
+}

--- a/tests/shim_bounded_drop_dataloss_pentest.rs
+++ b/tests/shim_bounded_drop_dataloss_pentest.rs
@@ -16,41 +16,14 @@
 //! an OTLP export must arrive well within the test window. If nothing arrives, the
 //! bounded Drop is dropping telemetry in the common case — a regression.
 
-use std::io::{Read, Write};
-use std::net::TcpListener;
+mod common;
+
 use std::os::unix::fs::symlink;
 use std::process::Command;
-use std::sync::mpsc;
+use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
-
-/// One-shot HTTP capture server that answers immediately (healthy collector).
-/// Returns the base URL and a receiver that yields `true` on the first request body.
-fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let base = format!("http://{}", addr);
-    let (tx, rx) = mpsc::channel();
-
-    std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            let Ok(mut stream) = stream else { continue };
-            stream
-                .set_read_timeout(Some(Duration::from_millis(500)))
-                .ok();
-            let mut buf = [0u8; 4096];
-            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
-            let _ = stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-            if got {
-                let _ = tx.send(true);
-            }
-        }
-    });
-
-    (base, rx)
-}
 
 fn git(repo: &std::path::Path, args: &[&str]) {
     let out = Command::new("git")
@@ -94,7 +67,7 @@ fn structured_diff_still_exports_to_a_healthy_collector_under_bounded_teardown()
     let real_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{}", shim_dir.display(), real_path);
 
-    let (endpoint, rx) = spawn_capture_server();
+    let (endpoint, rx) = common::spawn_capture_server();
 
     let start = Instant::now();
     let out = Command::new(&shim_git)
@@ -116,7 +89,18 @@ fn structured_diff_still_exports_to_a_healthy_collector_under_bounded_teardown()
     );
 
     // The bounded teardown must still deliver the export to a healthy collector.
-    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+    //
+    // RecvTimeoutError::Timeout  → no export arrived within the window (test fails below)
+    // RecvTimeoutError::Disconnected → capture-server thread died; this is a harness
+    //   failure, NOT a "no telemetry" signal — panic loudly so the failure is not
+    //   silently misread as a data-loss regression in the bounded teardown.
+    let received = match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(val) => val,
+        Err(RecvTimeoutError::Timeout) => false,
+        Err(RecvTimeoutError::Disconnected) => {
+            panic!("capture-server thread disconnected — harness failure, not a telemetry signal")
+        }
+    };
     assert!(
         received,
         "bounded Drop (500ms) lost telemetry against a HEALTHY collector: no OTLP \

--- a/tests/shim_bounded_drop_dataloss_pentest.rs
+++ b/tests/shim_bounded_drop_dataloss_pentest.rs
@@ -20,7 +20,6 @@ mod common;
 
 use std::os::unix::fs::symlink;
 use std::process::Command;
-use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -89,18 +88,7 @@ fn structured_diff_still_exports_to_a_healthy_collector_under_bounded_teardown()
     );
 
     // The bounded teardown must still deliver the export to a healthy collector.
-    //
-    // RecvTimeoutError::Timeout  → no export arrived within the window (test fails below)
-    // RecvTimeoutError::Disconnected → capture-server thread died; this is a harness
-    //   failure, NOT a "no telemetry" signal — panic loudly so the failure is not
-    //   silently misread as a data-loss regression in the bounded teardown.
-    let received = match rx.recv_timeout(Duration::from_secs(5)) {
-        Ok(val) => val,
-        Err(RecvTimeoutError::Timeout) => false,
-        Err(RecvTimeoutError::Disconnected) => {
-            panic!("capture-server thread disconnected — harness failure, not a telemetry signal")
-        }
-    };
+    let received = common::recv_telemetry(&rx, Duration::from_secs(5));
     assert!(
         received,
         "bounded Drop (500ms) lost telemetry against a HEALTHY collector: no OTLP \

--- a/tests/shim_passthrough_optout_pentest.rs
+++ b/tests/shim_passthrough_optout_pentest.rs
@@ -13,9 +13,8 @@
 
 mod common;
 
-use std::os::unix::fs::{PermissionsExt, symlink};
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::process::Command;
-use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 
 use tempfile::TempDir;
@@ -120,18 +119,7 @@ fn it_emits_no_otlp_export_when_passthrough_opt_out_is_set() {
 
     // A correct opt-out never initializes telemetry, so NO export should arrive.
     // If one arrives within 2 s, telemetry leaked on the opted-out path.
-    //
-    // RecvTimeoutError::Timeout  → no telemetry within the window (expected)
-    // RecvTimeoutError::Disconnected → capture-server thread died; this is a
-    //   harness failure, NOT a "no telemetry" signal — panic loudly so the
-    //   failure isn't silently misread as a passing opt-out test.
-    let leaked = match rx.recv_timeout(Duration::from_secs(2)) {
-        Ok(val) => val,
-        Err(RecvTimeoutError::Timeout) => false,
-        Err(RecvTimeoutError::Disconnected) => {
-            panic!("capture-server thread disconnected — harness failure, not a telemetry signal")
-        }
-    };
+    let leaked = common::recv_telemetry(&rx, Duration::from_secs(2));
     assert!(
         !leaked,
         "opted-out invocation emitted an OTLP export; telemetry must be skipped \

--- a/tests/shim_passthrough_optout_pentest.rs
+++ b/tests/shim_passthrough_optout_pentest.rs
@@ -11,41 +11,14 @@
 //!
 //! These drive the built binary end-to-end through argv[0]="git" shim mode.
 
-use std::io::{Read, Write};
-use std::net::TcpListener;
+mod common;
+
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::process::Command;
-use std::sync::mpsc;
+use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 
 use tempfile::TempDir;
-
-/// Spawn a one-shot HTTP capture server. Returns the bound `base` URL and a
-/// receiver that yields `true` once ANY HTTP request body is received.
-fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let base = format!("http://{}", addr);
-    let (tx, rx) = mpsc::channel();
-
-    std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            let Ok(mut stream) = stream else { continue };
-            stream
-                .set_read_timeout(Some(Duration::from_millis(500)))
-                .ok();
-            let mut buf = [0u8; 4096];
-            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
-            let _ = stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-            if got {
-                let _ = tx.send(true);
-            }
-        }
-    });
-
-    (base, rx)
-}
 
 /// Create a fake real `git` that prints a unique marker and exits 0. Lets us
 /// prove the REAL git ran (not the shim) and that output is byte-identical.
@@ -131,7 +104,7 @@ fn it_emits_no_otlp_export_when_passthrough_opt_out_is_set() {
     make_marker_git(&real_dir, "X");
 
     let path = format!("{}:{}", shim_dir.display(), real_dir.display());
-    let (endpoint, rx) = spawn_capture_server();
+    let (endpoint, rx) = common::spawn_capture_server();
 
     let status = Command::new(&shim_git)
         .env("GIT_PRISM_PASSTHROUGH", "1")
@@ -147,7 +120,18 @@ fn it_emits_no_otlp_export_when_passthrough_opt_out_is_set() {
 
     // A correct opt-out never initializes telemetry, so NO export should arrive.
     // If one arrives within 2 s, telemetry leaked on the opted-out path.
-    let leaked = rx.recv_timeout(Duration::from_secs(2)).unwrap_or(false);
+    //
+    // RecvTimeoutError::Timeout  → no telemetry within the window (expected)
+    // RecvTimeoutError::Disconnected → capture-server thread died; this is a
+    //   harness failure, NOT a "no telemetry" signal — panic loudly so the
+    //   failure isn't silently misread as a passing opt-out test.
+    let leaked = match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(val) => val,
+        Err(RecvTimeoutError::Timeout) => false,
+        Err(RecvTimeoutError::Disconnected) => {
+            panic!("capture-server thread disconnected — harness failure, not a telemetry signal")
+        }
+    };
     assert!(
         !leaked,
         "opted-out invocation emitted an OTLP export; telemetry must be skipped \

--- a/tests/shim_passthrough_optout_pentest.rs
+++ b/tests/shim_passthrough_optout_pentest.rs
@@ -13,7 +13,7 @@
 
 mod common;
 
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::process::Command;
 use std::time::Duration;
 

--- a/tests/shim_passthrough_telemetry_pentest.rs
+++ b/tests/shim_passthrough_telemetry_pentest.rs
@@ -25,42 +25,13 @@
 //! the OTLP metrics export arrives. It currently FAILS because no flush happens
 //! before the process is replaced.
 
-use std::io::{Read, Write};
-use std::net::TcpListener;
-use std::os::unix::fs::{PermissionsExt, symlink};
+mod common;
+
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::process::Command;
-use std::sync::mpsc;
 use std::time::Duration;
 
 use tempfile::TempDir;
-
-/// Spawn a one-shot HTTP capture server. Returns the bound `base` URL (no
-/// trailing path) and a receiver that yields `true` once ANY HTTP request body
-/// (an OTLP export) is received.
-fn spawn_capture_server() -> (String, mpsc::Receiver<bool>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let base = format!("http://{}", addr);
-    let (tx, rx) = mpsc::channel();
-
-    std::thread::spawn(move || {
-        for stream in listener.incoming() {
-            let Ok(mut stream) = stream else { continue };
-            stream
-                .set_read_timeout(Some(Duration::from_millis(500)))
-                .ok();
-            let mut buf = [0u8; 4096];
-            let got = matches!(stream.read(&mut buf), Ok(n) if n > 0);
-            let _ = stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-            if got {
-                let _ = tx.send(true);
-            }
-        }
-    });
-
-    (base, rx)
-}
 
 /// Create a fast fake `git` so the passthrough succeeds in milliseconds.
 fn make_fake_git(dir: &std::path::Path) {
@@ -89,7 +60,7 @@ fn it_flushes_shim_invocation_metric_on_passthrough_before_process_replacement()
 
     let path = format!("{}:{}", shim_dir.display(), real_dir.display());
 
-    let (endpoint, rx) = spawn_capture_server();
+    let (endpoint, rx) = common::spawn_capture_server();
 
     // GIT_PRISM_INSIDE_SHIM=1 forces the passthrough (loop-break) path, which
     // records shim_invocations_total{outcome="loop_break"} and then replaces the
@@ -107,7 +78,7 @@ fn it_flushes_shim_invocation_metric_on_passthrough_before_process_replacement()
     // A correct implementation force-flushes before replacing the process, so a
     // real export arrives in well under 5 s. If nothing arrives, the metric was
     // dropped when the process image was replaced — the bug.
-    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+    let received = common::recv_telemetry(&rx, Duration::from_secs(5));
 
     assert!(
         received,
@@ -166,7 +137,7 @@ fn it_flushes_shim_metric_on_structured_path_control() {
     let real_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{}", shim_dir.display(), real_path);
 
-    let (endpoint, rx) = spawn_capture_server();
+    let (endpoint, rx) = common::spawn_capture_server();
 
     // AI_AGENT → agent detected; `git show <sha>` is a classified command →
     // structured dispatch → run_shim returns → main.rs force_flushes.
@@ -186,7 +157,7 @@ fn it_flushes_shim_metric_on_structured_path_control() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let received = rx.recv_timeout(Duration::from_secs(5)).unwrap_or(false);
+    let received = common::recv_telemetry(&rx, Duration::from_secs(5));
     assert!(
         received,
         "control: structured path must export via force_flush; if this fails, \

--- a/tests/shim_passthrough_telemetry_pentest.rs
+++ b/tests/shim_passthrough_telemetry_pentest.rs
@@ -27,7 +27,7 @@
 
 mod common;
 
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::process::Command;
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary

**Closes #369.** Test-hygiene follow-ups from the PR #365 review. No production logic change — the only `src/` edit is a clarifying comment.

- **Dedup the OTLP capture-server helper.** `spawn_capture_server` was byte-for-byte duplicated across the telemetry e2e tests. Extracted into `tests/common/mod.rs` (the standard subdir shared-module pattern — not compiled as its own test binary). A review pass found a **third** copy (`shim_passthrough_telemetry_pentest.rs`) beyond the two named in the issue; all three now route through `common::spawn_capture_server`.
- **Fix the `recv_timeout` false-pass.** The receive used `recv_timeout(..).unwrap_or(false)`, which collapsed *both* error arms to `false` — so a **panicked capture-server thread** (`Disconnected`) read as "no telemetry received" and silently **passed** the opt-out test. Centralized into `common::recv_telemetry(&Receiver<bool>, Duration) -> bool`: `Timeout → false` (the legitimate "no telemetry" case), `Disconnected → panic!` (a harness failure that must fail loudly). Defining it once means the invariant can't be re-copied wrong.
- **Document clone-not-take.** A WHY comment in `src/telemetry.rs::force_flush_bounded` explains that the provider handles are *cloned* (not `take()`n) on purpose: `Drop` is the shutdown gate and must retain them, so a future `take()` "simplification" would silently skip the final export on exit.

## Testing

- All three telemetry e2e tests (`shim_passthrough_telemetry_pentest`, `shim_bounded_drop_dataloss_pentest`, `shim_passthrough_optout_pentest`) pass through the shared helpers, non-vacuously (real OTLP export through the built shim binary against a live capture server). Run 3× — no flakiness from the centralized `Disconnected → panic` (the capture thread's `incoming()` loop never drops its sender on a healthy run).
- Full suite green; `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean. Adversarial QA (gate 3, genuine run) + church (rust/test) — clean.
- Exactly one `spawn_capture_server` and one `recv_timeout` site remain (both in `tests/common/mod.rs`).

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
