### PR TITLE
chore: release v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.4] — 2026-06-05
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "git-prism"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-prism"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "Agent-optimized git data MCP server — structured change manifests and full file snapshots for LLM agents"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.9.4

Bundles the #360 performance investigation fixes plus follow-ups. Version bump (`0.9.3` → `0.9.4`) + CHANGELOG `[Unreleased]` → `[0.9.4]`. No executable code change in this PR.

### Added
- **`GIT_PRISM_PASSTHROUGH` / `GIT_PRISM_DISABLE`** per-invocation shim opt-out — execs the real git/gh before telemetry/classification, near-zero overhead, no recording. (#362)
- **`serve` self-terminates** when its launching session dies (reparented to init, `ppid == 1`), ending orphaned-daemon accumulation. (#363)
- **`serve` lifecycle logging** to stderr (started / watchdog-active / clean-shutdown). (#371)

### Fixed
- **Structured-path telemetry teardown is bounded** — `git diff`/`log`/`show`/`blame` no longer stall for minutes on an unreachable OTLP collector (flush and `Drop` shutdown both 500ms-bounded). (#361)
- **CLI no longer panics** when the cwd is deleted/inaccessible — `manifest`/`history`/`snapshot`/`context` return a clean error. (#364)

### Internal (no changelog entry)
- #366 documented the orphan predicate (`ppid == 1`, not `<= 1`); #369 deduped the test capture-server helper and hardened a recv false-pass.

After merge: tag `v0.9.4` (triggers cargo-dist → GitHub Release + Homebrew), then `cargo publish` to crates.io.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
