### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] — 2026-06-06
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "git-prism"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-prism"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2024"
 description = "Agent-optimized git data MCP server — structured change manifests and full file snapshots for LLM agents"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.10.0

Minor release — the shim's `gh pr diff` behavior changed (passthrough). Version bump (`0.9.4` → `0.10.0`) + CHANGELOG `[Unreleased]` → `[0.10.0]`. No executable code change in this PR.

### Changed
- **The shim no longer intercepts `gh pr diff <N>`** — it passes straight through to the real `gh`, returning the unified diff (was: a JSON change-manifest, which broke reviewers and diff-parsing tooling). Structured PR review remains via the MCP tools (`review_change`, `get_change_manifest`). (#367)

### Fixed
- **The change manifest labels common non-grammar file types instead of `unknown`** — `.sh`→`shell`, `.yml`→`yaml`, `.j2`→`jinja`, `.md`→`markdown`, etc., so `languages_affected` reflects a PR's real composition. Grammar-less files still report `functions_changed: null`. (#368)

After merge: tag `v0.10.0` (triggers cargo-dist → GitHub Release + Homebrew), then `cargo publish` to crates.io.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
